### PR TITLE
Remove /api/auth/login_by_access_token endoint

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -21,10 +21,6 @@ Rails.application.routes.draw do
       post :regenerate
     end
 
-    resource :auth, only: %i() do
-      post :login_by_access_token
-    end
-
     resource :me, only: %i(show)
 
     resources :validations, only: %i() do

--- a/api/spec/requests/auth_spec.rb
+++ b/api/spec/requests/auth_spec.rb
@@ -29,74 +29,44 @@ RSpec.describe 'authentication', type: :request do
   end
 
   describe 'login' do
-    describe 'login by authorization code flow' do
-      before do
-        allow_any_instance_of(AuthsController).to receive(:generate_state) { 'STATE' }
-        allow_any_instance_of(AuthsController).to receive(:generate_code_verifier) { 'CODE_VERIFIER' }
-        allow_any_instance_of(AuthsController).to receive(:calculate_code_challenge).with('CODE_VERIFIER') { 'CODE_CHALLENGE' }
+    before do
+      allow_any_instance_of(AuthsController).to receive(:generate_state) { 'STATE' }
+      allow_any_instance_of(AuthsController).to receive(:generate_code_verifier) { 'CODE_VERIFIER' }
+      allow_any_instance_of(AuthsController).to receive(:calculate_code_challenge).with('CODE_VERIFIER') { 'CODE_CHALLENGE' }
 
-        allow(access_token).to receive(:userinfo!) { userinfo(account_type_number: 1) }
-        allow(oidc_client).to receive(:access_token!) { access_token }
-      end
-
-      example do
-        get '/auth/login'
-
-        expect(response).to redirect_to('http://example.com/auth/authorization')
-
-        expect(oidc_client).to have_received(:authorization_uri).with(
-          scope:                 %i(openid),
-          state:                 'STATE',
-          code_challenge:        'CODE_CHALLENGE',
-          code_challenge_method: 'S256'
-        )
-
-        get '/auth/callback', params: {
-          state: 'STATE',
-          code:  'CODE'
-        }
-
-        expect(response).to have_http_status(:ok)
-
-        user = User.find_by!(uid: 'alice')
-
-        expect(user).to have_attributes(
-          api_key:     'API_KEY',
-          ddbj_member: false
-        )
-
-        expect(response.body).to include("Your API key is: #{user.api_key}")
-
-        expect(oidc_client).to have_received(:authorization_code=).with('CODE')
-        expect(oidc_client).to have_received(:access_token!).with(code_verifier: 'CODE_VERIFIER')
-      end
+      allow(access_token).to receive(:userinfo!) { userinfo(account_type_number: 1) }
+      allow(oidc_client).to receive(:access_token!) { access_token }
     end
 
-    describe 'login by access token' do
-      before do
-        allow(OpenIDConnect::AccessToken).to receive(:new) { access_token }
-        allow(access_token).to receive(:userinfo!) { userinfo(account_type_number: 3) }
-      end
+    example do
+      get '/auth/login'
 
-      example do
-        post '/api/auth/login_by_access_token', **{
-          params:  'ACCESS_TOKEN',
-          headers: {'Content-Type': 'applicaiton/jwt'}
-        }
+      expect(response).to redirect_to('http://example.com/auth/authorization')
 
-        expect(response).to have_http_status(:ok)
+      expect(oidc_client).to have_received(:authorization_uri).with(
+        scope:                 %i(openid),
+        state:                 'STATE',
+        code_challenge:        'CODE_CHALLENGE',
+        code_challenge_method: 'S256'
+      )
 
-        expect(response.parsed_body.deep_symbolize_keys).to eq(
-          api_key: 'API_KEY'
-        )
+      get '/auth/callback', params: {
+        state: 'STATE',
+        code:  'CODE'
+      }
 
-        user = User.find_by!(uid: 'alice')
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Your API key is: API_KEY')
 
-        expect(user).to have_attributes(
-          api_key:     'API_KEY',
-          ddbj_member: true
-        )
-      end
+      user = User.find_by!(uid: 'alice')
+
+      expect(user).to have_attributes(
+        api_key:     'API_KEY',
+        ddbj_member: false
+      )
+
+      expect(oidc_client).to have_received(:authorization_code=).with('CODE')
+      expect(oidc_client).to have_received(:access_token!).with(code_verifier: 'CODE_VERIFIER')
     end
   end
 end


### PR DESCRIPTION
This was an internal API used by the CLI; it is no longer needed as the CLI has moved to API key-based authentication.
