### PR TITLE
Use ISO8601-like datetime format

### DIFF
--- a/web/app/helpers/format-datetime.ts
+++ b/web/app/helpers/format-datetime.ts
@@ -5,5 +5,16 @@ export default function formatDatetime(date?: Date | string) {
     date = new Date(date);
   }
 
-  return `${date.toLocaleDateString('ja-JP')} ${date.toLocaleTimeString('ja-JP')}`;
+  const year = padZero(date.getFullYear());
+  const month = padZero(date.getMonth() + 1);
+  const _date = padZero(date.getDate());
+  const hours = padZero(date.getHours());
+  const minutes = padZero(date.getMinutes());
+  const seconds = padZero(date.getSeconds());
+
+  return `${year}-${month}-${_date} ${hours}:${minutes}:${seconds}`;
+}
+
+function padZero(n: number) {
+  return n.toString().padStart(2, '0');
 }

--- a/web/tests/integration/helpers/format-datetime-test.ts
+++ b/web/tests/integration/helpers/format-datetime-test.ts
@@ -1,0 +1,30 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ddbj-repository/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | format-datetime', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('date instance', async function (assert) {
+    this.set('date', new Date(2024, 0, 2, 3, 4, 56));
+
+    await render(hbs`{{format-datetime this.date}}`);
+
+    assert.dom().hasText('2024-01-02 03:04:56');
+  });
+
+  test('string', async function (assert) {
+    this.set('date', new Date(2024, 0, 2, 3, 4, 56).toISOString());
+
+    await render(hbs`{{format-datetime this.date}}`);
+
+    assert.dom().hasText('2024-01-02 03:04:56');
+  });
+
+  test('undefined', async function (assert) {
+    await render(hbs`{{format-datetime undefined}}`);
+
+    assert.dom().hasNoText();
+  });
+});


### PR DESCRIPTION
Separating a date with a slash is confusing because it has different meanings in different countries.

- [ISO 8601 - Wikipedia](https://en.wikipedia.org/wiki/ISO_8601)
- [Testing Helpers - Testing - Ember Guides](https://guides.emberjs.com/v5.5.0/testing/testing-helpers/)