### PR TITLE
Fix the healthcheck condition

### DIFF
--- a/ansible/healthcheck
+++ b/ansible/healthcheck
@@ -31,7 +31,9 @@ Error:
 end
 
 failed_services = out.lines.map {|line| JSON.parse(line) }.select {|service|
-  service['State'] == 'exited' && (service['ExitCode'] != 0 || service['ExitCode'] != 143)
+  state, exit_code = service.values_at('State', 'ExitCode')
+
+  state == 'exited' && !(exit_code == 0 || exit_code == 143)
 }
 
 exit 0 if failed_services.empty?


### PR DESCRIPTION
Oops, that was opposite.
On a successfully terminated exit code is 0 or 143, otherwise is not 0 and not 143.

See also:
- https://github.com/ddbj/submission-mss/commit/372e41f133947d6125d2b637b7b8fbced0aee8fe
- https://github.com/ddbj/submission-mss/commit/e8aea4f5202c1c5fd9d1dbe71f5efb78f1293686
- https://github.com/ddbj/submission-mss/commit/5cb3cc902eb34c16e6c2c393c5914f4d3937481f