### PR TITLE
Add force option to regenerate flatfiles

### DIFF
--- a/app/controllers/admin/regenerate_flatfiles_controller.rb
+++ b/app/controllers/admin/regenerate_flatfiles_controller.rb
@@ -16,12 +16,10 @@ module Admin
       date        = Date.parse(params[:date])
       submissions = Submission.where.associated(:ddbj_record_attachment)
 
-      Accession.update_all locus_date: date
-
       progress = RegenerateFlatfilesProgress.create!(total: submissions.count)
 
       ActiveJob.perform_all_later submissions.map {|submission|
-        RegenerateSubmissionFlatfilesJob.new(submission, current_user, progress)
+        RegenerateSubmissionFlatfilesJob.new(submission, current_user, progress, date)
       }
 
       render json: {}, status: :accepted

--- a/app/controllers/admin/regenerate_flatfiles_controller.rb
+++ b/app/controllers/admin/regenerate_flatfiles_controller.rb
@@ -14,12 +14,13 @@ module Admin
 
     def create
       date        = Date.parse(params[:date])
+      force       = ActiveModel::Type::Boolean.new.cast(params[:force]) || false
       submissions = Submission.where.associated(:ddbj_record_attachment)
 
       progress = RegenerateFlatfilesProgress.create!(total: submissions.count)
 
       ActiveJob.perform_all_later submissions.map {|submission|
-        RegenerateSubmissionFlatfilesJob.new(submission, current_user, progress, date)
+        RegenerateSubmissionFlatfilesJob.new(submission, current_user, progress, date, force:)
       }
 
       render json: {}, status: :accepted

--- a/app/jobs/regenerate_submission_flatfiles_job.rb
+++ b/app/jobs/regenerate_submission_flatfiles_job.rb
@@ -1,11 +1,59 @@
 class RegenerateSubmissionFlatfilesJob < ApplicationJob
   include SubmissionOutputWriter
 
-  def perform(submission, user, progress)
-    record                 = submission.ddbj_record.open { DDBJRecord.parse(it) }
-    accessions_by_entry_id = submission.accessions.index_by(&:entry_id)
+  def perform(submission, user, progress, date)
+    record = submission.ddbj_record.open { DDBJRecord.parse(it) }
 
-    entries = record.sequences.entries.map {|entry|
+    if changed?(submission, record)
+      submission.accessions.update_all locus_date: date
+
+      entries             = build_entries(record, submission.accessions.reload)
+      record_with_entries = record.with(sequences: record.sequences.with(entries:))
+
+      generate_outputs record_with_entries, entries, **{
+        filename:     submission.ddbj_record.filename,
+        content_type: submission.ddbj_record.content_type
+      } do |updates|
+        submission.update! updates
+      end
+
+      AccessionHistory.insert_all! submission.accessions.ids.map {|id|
+        {
+          accession_id: id,
+          user_id:      user.id,
+          action:       'regenerate'
+        }
+      }
+    end
+
+    progress.increment! :processed
+  end
+
+  private
+
+  def changed?(submission, record)
+    entries             = build_entries(record, submission.accessions)
+    record_with_entries = record.with(sequences: record.sequences.with(entries:))
+
+    result = false
+
+    generate_outputs record_with_entries, entries, **{
+      filename:     submission.ddbj_record.filename,
+      content_type: submission.ddbj_record.content_type
+    } do |updates|
+      result =
+        attachment_changed?(submission.ddbj_record, updates[:ddbj_record]) ||
+        attachment_changed?(submission.flatfile_na, updates[:flatfile_na]) ||
+        attachment_changed?(submission.flatfile_aa, updates[:flatfile_aa])
+    end
+
+    result
+  end
+
+  def build_entries(record, accessions)
+    accessions_by_entry_id = accessions.index_by(&:entry_id)
+
+    record.sequences.entries.map {|entry|
       acc = accessions_by_entry_id.fetch(entry.id)
 
       entry.with(
@@ -15,24 +63,15 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
         last_updated: acc.locus_date.to_s
       )
     }
+  end
 
-    record = record.with(sequences: record.sequences.with(entries:))
-
-    generate_outputs record, entries, **{
-      filename:     submission.ddbj_record.filename,
-      content_type: submission.ddbj_record.content_type
-    } do |updates|
-      submission.update! updates
+  def attachment_changed?(attachment, payload)
+    if payload.nil?
+      attachment.attached?
+    elsif attachment.attached?
+      Digest::MD5.file(payload[:io].path).base64digest != attachment.blob.checksum
+    else
+      true
     end
-
-    AccessionHistory.insert_all! submission.accessions.ids.map {|id|
-      {
-        accession_id: id,
-        user_id:      user.id,
-        action:       'regenerate'
-      }
-    }
-
-    progress.increment! :processed
   end
 end

--- a/app/jobs/regenerate_submission_flatfiles_job.rb
+++ b/app/jobs/regenerate_submission_flatfiles_job.rb
@@ -1,10 +1,10 @@
 class RegenerateSubmissionFlatfilesJob < ApplicationJob
   include SubmissionOutputWriter
 
-  def perform(submission, user, progress, date)
+  def perform(submission, user, progress, date, force: false)
     record = submission.ddbj_record.open { DDBJRecord.parse(it) }
 
-    if changed?(submission, record)
+    if force || changed?(submission, record)
       submission.accessions.update_all locus_date: date
 
       entries             = build_entries(record, submission.accessions.reload)

--- a/test/integration/admin/regenerate_flatfiles_test.rb
+++ b/test/integration/admin/regenerate_flatfiles_test.rb
@@ -68,7 +68,26 @@ class AdminRegenerateFlatfilesTest < ActionDispatch::IntegrationTest
 
     enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs.find { it['job_class'] == 'RegenerateSubmissionFlatfilesJob' }
 
-    assert_equal Date.new(2026, 7, 1).to_s, enqueued['arguments'].last['value']
+    assert_equal Date.new(2026, 7, 1).to_s, enqueued['arguments'][3]['value']
+    assert_equal false,                     enqueued['arguments'].last['force']
+  end
+
+  test 'create forwards force flag to the job' do
+    submission = submissions(:one)
+
+    submission.ddbj_record.attach(
+      io:           file_fixture('ddbj_record/example.json').open,
+      filename:     'example.json',
+      content_type: 'application/json'
+    )
+
+    post admin_regenerate_flatfiles_path, params: {date: '2026-07-01', force: true}, as: :json
+
+    assert_response :accepted
+
+    enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs.find { it['job_class'] == 'RegenerateSubmissionFlatfilesJob' }
+
+    assert_equal true, enqueued['arguments'].last['force']
   end
 
   test 'create returns 403 for non-admin users' do

--- a/test/integration/admin/regenerate_flatfiles_test.rb
+++ b/test/integration/admin/regenerate_flatfiles_test.rb
@@ -62,13 +62,13 @@ class AdminRegenerateFlatfilesTest < ActionDispatch::IntegrationTest
 
     assert_response :accepted
 
-    submission.accessions.each do
-      assert_equal Date.new(2026, 7, 1), it.reload.locus_date
-    end
-
     progress = RegenerateFlatfilesProgress.order(created_at: :desc).first
 
     assert_equal 1, progress.total
+
+    enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs.find { it['job_class'] == 'RegenerateSubmissionFlatfilesJob' }
+
+    assert_equal Date.new(2026, 7, 1).to_s, enqueued['arguments'].last['value']
   end
 
   test 'create returns 403 for non-admin users' do

--- a/test/jobs/apply_submission_request_job_test.rb
+++ b/test/jobs/apply_submission_request_job_test.rb
@@ -12,7 +12,7 @@ class ApplySubmissionRequestJobTest < ActiveSupport::TestCase
 
     request.save!
 
-    ApplySubmissionRequestJob.perform_now(request)
+    ApplySubmissionRequestJob.perform_now request
 
     submission = request.reload.submission
 

--- a/test/jobs/apply_submission_update_job_test.rb
+++ b/test/jobs/apply_submission_update_job_test.rb
@@ -12,7 +12,7 @@ class ApplySubmissionUpdateJobTest < ActiveSupport::TestCase
 
     request.save!
 
-    ApplySubmissionRequestJob.perform_now(request)
+    ApplySubmissionRequestJob.perform_now request
 
     @submission = request.reload.submission
   end
@@ -27,7 +27,7 @@ class ApplySubmissionUpdateJobTest < ActiveSupport::TestCase
     update.ddbj_record.attach io: StringIO.new(JSON.generate(json)), filename: 'example.json', content_type: 'application/json'
     update.save!
 
-    ApplySubmissionUpdateJob.perform_now(update)
+    ApplySubmissionUpdateJob.perform_now update
 
     @submission.reload
 
@@ -51,7 +51,7 @@ class ApplySubmissionUpdateJobTest < ActiveSupport::TestCase
     update.ddbj_record.attach io: StringIO.new(JSON.generate(json)), filename: 'example.json', content_type: 'application/json'
     update.save!
 
-    ApplySubmissionUpdateJob.perform_now(update)
+    ApplySubmissionUpdateJob.perform_now update
 
     @submission.reload
 

--- a/test/jobs/regenerate_submission_flatfiles_job_test.rb
+++ b/test/jobs/regenerate_submission_flatfiles_job_test.rb
@@ -2,36 +2,68 @@ require 'test_helper'
 
 class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
   setup do
-    @submission = submissions(:one)
-    @admin      = users(:alice).tap { it.update!(admin: true) }
+    request = SubmissionRequest.new(user: users(:alice))
 
-    @submission.ddbj_record.attach(
+    request.ddbj_record.attach(
       io:           file_fixture('ddbj_record/example.json').open,
       filename:     'example.json',
       content_type: 'application/json'
     )
 
-    @submission.accessions.update_all locus_date: Date.new(2026, 7, 1)
+    request.save!
+
+    ApplySubmissionRequestJob.perform_now request
+
+    @submission = request.reload.submission
+    @admin      = users(:alice).tap { it.update!(admin: true) }
   end
 
-  test 'regenerates flatfiles with new locus date' do
+  test 'does nothing when flatfiles would be identical' do
+    original_locus_dates = @submission.accessions.pluck(:id, :locus_date).to_h
+    original_na_blob_id  = @submission.flatfile_na.blob.id
+
     progress = RegenerateFlatfilesProgress.create!(total: 1)
 
-    RegenerateSubmissionFlatfilesJob.perform_now(@submission, @admin, progress)
+    assert_no_difference 'AccessionHistory.count' do
+      RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, progress, Date.new(2099, 1, 1)
+    end
+
+    @submission.reload
+
+    assert_equal original_na_blob_id, @submission.flatfile_na.blob.id
+
+    @submission.accessions.each do |acc|
+      assert_equal original_locus_dates[acc.id], acc.locus_date
+    end
+
+    assert_equal 1, progress.reload.processed
+  end
+
+  test 'regenerates flatfiles with new locus date when content changed' do
+    @submission.flatfile_na.purge
+    @submission.flatfile_aa.purge if @submission.flatfile_aa.attached?
+
+    progress = RegenerateFlatfilesProgress.create!(total: 1)
+
+    RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, progress, Date.new(2026, 7, 1)
 
     @submission.reload
 
     assert @submission.flatfile_na.attached?
+    assert_match /01-JUL-2026/, @submission.flatfile_na.download
 
-    flatfile = @submission.flatfile_na.download
-
-    assert_match /01-JUL-2026/, flatfile
+    @submission.accessions.each do |acc|
+      assert_equal Date.new(2026, 7, 1), acc.locus_date
+    end
   end
 
-  test 'records accession history' do
+  test 'records accession history when content changed' do
+    @submission.flatfile_na.purge
+    @submission.flatfile_aa.purge if @submission.flatfile_aa.attached?
+
     progress = RegenerateFlatfilesProgress.create!(total: 1)
 
-    RegenerateSubmissionFlatfilesJob.perform_now(@submission, @admin, progress)
+    RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, progress, Date.new(2026, 7, 1)
 
     histories = AccessionHistory.where(accession: @submission.accessions, action: 'regenerate')
 
@@ -42,10 +74,8 @@ class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
   test 'increments progress' do
     progress = RegenerateFlatfilesProgress.create!(total: 1)
 
-    RegenerateSubmissionFlatfilesJob.perform_now(@submission, @admin, progress)
+    RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, progress, Date.new(2026, 7, 1)
 
-    progress.reload
-
-    assert_equal 1, progress.processed
+    assert_equal 1, progress.reload.processed
   end
 end

--- a/test/jobs/regenerate_submission_flatfiles_job_test.rb
+++ b/test/jobs/regenerate_submission_flatfiles_job_test.rb
@@ -18,6 +18,18 @@ class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
     @admin      = users(:alice).tap { it.update!(admin: true) }
   end
 
+  test 'force: true regenerates even when flatfiles would be identical' do
+    progress = RegenerateFlatfilesProgress.create!(total: 1)
+
+    assert_difference 'AccessionHistory.where(action: "regenerate").count', @submission.accessions.count do
+      RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, progress, Date.new(2026, 7, 1), force: true
+    end
+
+    @submission.accessions.each do |acc|
+      assert_equal Date.new(2026, 7, 1), acc.reload.locus_date
+    end
+  end
+
   test 'does nothing when flatfiles would be identical' do
     original_locus_dates = @submission.accessions.pluck(:id, :locus_date).to_h
     original_na_blob_id  = @submission.flatfile_na.blob.id

--- a/web/app/templates/admin/regenerate-flatfiles.gts
+++ b/web/app/templates/admin/regenerate-flatfiles.gts
@@ -21,6 +21,7 @@ class RegenerateFlatfilesForm extends Component<{ Args: { model: Model } }> {
   @service declare router: RouterService;
 
   @tracked date = '';
+  @tracked force = false;
 
   get loading() {
     return this.args.model.status.loading;
@@ -56,13 +57,18 @@ class RegenerateFlatfilesForm extends Component<{ Args: { model: Model } }> {
     this.date = (e.target as HTMLInputElement).value;
   }
 
+  @action
+  setForce(e: Event) {
+    this.force = (e.target as HTMLInputElement).checked;
+  }
+
   submitTask = task(async (e: Event) => {
     e.preventDefault();
 
     await this.requestManager.request({
       url: '/admin/regenerate_flatfiles',
       method: 'POST',
-      data: { date: this.date },
+      data: { date: this.date, force: this.force },
     });
 
     this.router.refresh();
@@ -84,6 +90,22 @@ class RegenerateFlatfilesForm extends Component<{ Args: { model: Model } }> {
                   disabled={{this.loading}}
                   {{on "input" this.setDate}}
                 />
+              {{/let}}
+            </div>
+
+            <div class="form-check mb-3">
+              {{#let (uniqueId) as |id|}}
+                <input
+                  type="checkbox"
+                  checked={{this.force}}
+                  id={{id}}
+                  class="form-check-input"
+                  disabled={{this.loading}}
+                  {{on "change" this.setForce}}
+                />
+                <label for={{id}} class="form-check-label">
+                  Force update all submissions (even if content is unchanged)
+                </label>
               {{/let}}
             </div>
 

--- a/web/public/mockServiceWorker.js
+++ b/web/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.13.2'
+const PACKAGE_VERSION = '2.13.4'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/web/tests/acceptance/admin/regenerate-flatfiles-test.gts
+++ b/web/tests/acceptance/admin/regenerate-flatfiles-test.gts
@@ -83,9 +83,10 @@ module('Acceptance | admin | regenerate flatfiles', function (hooks) {
       }),
 
       mswHttp.post(adminURL, async ({ request }) => {
-        const body = (await request.json()) as { date: string };
+        const body = (await request.json()) as { date: string; force: boolean };
 
         assert.strictEqual(body.date, '2026-07-01');
+        assert.false(body.force);
 
         postCalled = true;
 
@@ -101,5 +102,27 @@ module('Acceptance | admin | regenerate flatfiles', function (hooks) {
     await waitUntil(() => document.querySelector('.alert-success') !== null);
 
     assert.dom('.alert-success').includesText('3 submissions regenerated');
+  });
+
+  test('submit with force checkbox POSTs force=true', async (assert) => {
+    worker.use(
+      mswHttp.get(adminURL, () => {
+        return HttpResponse.json({ loading: false, total: null, processed: null });
+      }),
+
+      mswHttp.post(adminURL, async ({ request }) => {
+        const body = (await request.json()) as { date: string; force: boolean };
+
+        assert.true(body.force);
+
+        return new HttpResponse('{}', { status: 202, headers: { 'Content-Type': 'application/json' } });
+      }),
+    );
+
+    await visit('/admin/regenerate-flatfiles');
+
+    await fillIn('input[type="date"]', '2026-07-01');
+    await click('input[type="checkbox"]');
+    await click('button[type="submit"]');
   });
 });


### PR DESCRIPTION
## Summary

- Added a `force` flag to the regenerate flatfiles flow (controller → job → UI)
- When `force: true`, every submission is regenerated and its accessions' `locus_date` is updated regardless of whether the output actually changed
- When `force: false` (default), the prior skip-when-unchanged behavior is preserved
- UI gains a checkbox: "Force update all submissions (even if content is unchanged)"

## Test plan

- [x] `bin/rails test test/jobs/regenerate_submission_flatfiles_job_test.rb test/integration/admin/regenerate_flatfiles_test.rb`
- [x] `cd web && pnpm test` (acceptance tests for admin/regenerate-flatfiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)