### PR TITLE
Move applicant_name fallback to flatfile template

### DIFF
--- a/app/models/flatfile.rb
+++ b/app/models/flatfile.rb
@@ -1,4 +1,6 @@
 module Flatfile
+  APPLICANT_NAME_FALLBACK = 'Applicants [Refer to the patent publication]'.freeze
+
   def self.render(record, entries)
     Root.new(record, entries).render
   end

--- a/app/models/flatfile/template.erb
+++ b/app/models/flatfile/template.erb
@@ -21,9 +21,7 @@ REFERENCE   1  (residues <%= entry.location_span.join(' to ') %>)
   AUTHORS
   TITLE     <%= entry.invention_title %>
   JOURNAL   Patent: <%= format_seqid(entry.seqid, format: :journal) %> <%= format_date(record.submission.publication_date) %>;
-            <%- if name = record.submission.applicant_name -%>
-            <%=   name %>
-            <%- end -%>
+            <%= record.submission.applicant_name || APPLICANT_NAME_FALLBACK %>
 COMMENT     OS   <%= entry.organism %>
             PN   <%= format_seqid(entry.seqid) %>
             PD   <%= format_date(record.submission.publication_date) %>

--- a/lib/tasks/backfill_applicant_name.thor
+++ b/lib/tasks/backfill_applicant_name.thor
@@ -9,7 +9,7 @@ class BackfillApplicantNameTasks < Thor
 
   def self.exit_on_failure? = true
 
-  desc 'execute', 'Fill empty applicant_name with placeholder on existing DDBJ Records'
+  desc 'execute', 'Revert placeholder applicant_name back to nil on existing DDBJ Records'
   method_option :dry_run, type: :boolean, default: false, aliases: '-n', desc: 'Report targets without writing'
   def execute
     scope = Submission.where.associated(:ddbj_record_attachment).includes(:request)
@@ -40,10 +40,10 @@ class BackfillApplicantNameTasks < Thor
     attachment = record.ddbj_record
     parsed     = JSON.parse(attachment.download, symbolize_names: true)
 
-    return false if parsed.dig(:submission, :applicant_name).present?
+    return false unless parsed.dig(:submission, :applicant_name) == FALLBACK
     return true  if dry_run
 
-    parsed[:submission][:applicant_name] = FALLBACK
+    parsed[:submission][:applicant_name] = nil
 
     record.update!(ddbj_record: {
       io:           StringIO.new(JSON.generate(parsed)),

--- a/test/models/flatfile_test.rb
+++ b/test/models/flatfile_test.rb
@@ -26,6 +26,38 @@ class FlatfileTest < ActiveSupport::TestCase
     )
   end
 
+  test 'renders fallback applicant in JOURNAL and omits PA/PT/PI when nil' do
+    record = file_fixture('ddbj_record/example.json').open { DDBJRecord.parse(it) }
+
+    submission = record.submission.with(
+      publication_date: '2026-06-01',
+      applicant_name:   nil,
+      invention_title:  nil,
+      inventor_name:    nil
+    )
+
+    entries = record.sequences.entries.map.with_index(1) {|entry, i|
+      entry.with(
+        accession:    "AB00000#{i}",
+        locus:        "AB00000#{i}",
+        version:      1,
+        last_updated: '2026-06-01'
+      )
+    }
+
+    record = record.with(
+      submission: submission,
+      sequences:  record.sequences.with(entries:)
+    )
+
+    output = Flatfile.render(record, record.sequences.entries).read
+
+    assert_includes output, "  JOURNAL   Patent: JP 2026123456-A 1 01-JUN-2026;\n            Applicants [Refer to the patent publication]\n"
+    refute_match(/^ {12}PA /, output)
+    refute_match(/^ {12}PT /, output)
+    refute_match(/^ {12}PI /, output)
+  end
+
   test 'renders flatfile from Data objects' do
     record = build_record
     output = Flatfile.render(record, record.sequences.entries).read


### PR DESCRIPTION
## Summary
- JOURNAL line always renders `applicant_name` or the placeholder; PA/COMMENT lines now skip when `applicant_name` is nil, matching PT/PI.
- Reverse the `backfill_applicant_name` thor task so stored placeholders can be set back to `nil`.
- Add a flatfile test that covers the nil case.

## Migration
1. Merge & release submission-bulk-st26 PR (https://github.com/ddbj/submission-bulk-st26/pull/new/fix/applicant-name-fallback) so new submissions no longer embed the placeholder.
2. Merge this PR.
3. Run `bin/thor backfill_applicant_name:execute -n` on staging/production to verify, then re-run without `-n` to strip the stored placeholder.

## Test plan
- [x] `bin/rails test`
- [ ] Regenerate a flatfile for an existing patent submission and confirm PA is omitted while JOURNAL retains the fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)