### PR TITLE
Add db column to submissions and namespace routes by db

### DIFF
--- a/app/controllers/accessions_controller.rb
+++ b/app/controllers/accessions_controller.rb
@@ -1,6 +1,6 @@
 class AccessionsController < ApplicationController
   def index
-    submission = current_user.submissions.find(params[:submission_id])
+    submission = current_user.submissions.where(db: params[:db]).find(params[:submission_id])
 
     pagy, @accessions = pagy(submission.accessions.order(:id))
 

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -1,5 +1,5 @@
 class StatusesController < ApplicationController
   def show
-    @request = current_user.submission_requests.find(params[:submission_request_id])
+    @request = current_user.submission_requests.where(db: params[:db]).find(params[:submission_request_id])
   end
 end

--- a/app/controllers/submission_requests_controller.rb
+++ b/app/controllers/submission_requests_controller.rb
@@ -1,16 +1,16 @@
 class SubmissionRequestsController < ApplicationController
   def index
-    pagy, @requests = pagy(current_user.submission_requests.order(id: :desc))
+    pagy, @requests = pagy(current_user.submission_requests.where(db: params[:db]).order(id: :desc))
 
     response.headers.merge! pagy.headers_hash
   end
 
   def show
-    @request = current_user.submission_requests.find(params[:id])
+    @request = current_user.submission_requests.where(db: params[:db]).find(params[:id])
   end
 
   def create
-    @request = current_user.submission_requests.create!(request_params)
+    @request = current_user.submission_requests.create!(**request_params, db: params[:db])
 
     raise ActiveRecord::RecordInvalid unless @request.waiting_validation?
 

--- a/app/controllers/submission_updates_controller.rb
+++ b/app/controllers/submission_updates_controller.rb
@@ -1,11 +1,11 @@
 class SubmissionUpdatesController < ApplicationController
   def show
-    @update = current_user.submission_updates.find(params[:id])
+    @update = current_user.submission_updates.where(db: params[:db]).find(params[:id])
   end
 
   def create
-    submission = current_user.submissions.find(params[:submission_id])
-    @update    = submission.updates.create!(update_params)
+    submission = current_user.submissions.where(db: params[:db]).find(params[:submission_id])
+    @update    = submission.updates.create!(**update_params, db: params[:db])
 
     raise ActiveRecord::RecordInvalid unless @update.waiting_validation?
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,12 +1,12 @@
 class SubmissionsController < ApplicationController
   def index
-    pagy, @submissions = pagy(current_user.submissions.order(id: :desc))
+    pagy, @submissions = pagy(current_user.submissions.where(db: params[:db]).order(id: :desc))
 
     response.headers.merge! pagy.headers_hash
   end
 
   def show
-    @submission = current_user.submissions.includes(
+    @submission = current_user.submissions.where(db: params[:db]).includes(
       :updates
     ).order(
       'submission_updates.id DESC'
@@ -14,7 +14,7 @@ class SubmissionsController < ApplicationController
   end
 
   def create
-    request = current_user.submission_requests.valid_only.joins(
+    request = current_user.submission_requests.where(db: params[:db]).valid_only.joins(
       :validation
     ).where(
       validations: {
@@ -32,7 +32,7 @@ class SubmissionsController < ApplicationController
   end
 
   def update
-    update = current_user.submission_updates.valid_only.joins(
+    update = current_user.submission_updates.where(db: params[:db]).valid_only.joins(
       :validation
     ).where(
       validations: {

--- a/app/jobs/apply_submission_request_job.rb
+++ b/app/jobs/apply_submission_request_job.rb
@@ -37,7 +37,7 @@ class ApplySubmissionRequestJob < ApplicationJob
         [
           Sequence.allocate!(:jpo_na, na_count),
           Sequence.allocate!(:jpo_aa, aa_count),
-          request.create_submission!
+          request.create_submission!(db: request.db)
         ]
       }
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,4 +1,10 @@
 class Submission < ApplicationRecord
+  enum :db, {
+    st26:       'st26',
+    bioproject: 'bioproject',
+    biosample:  'biosample'
+  }, suffix: true, validate: true
+
   has_one :request, dependent: :destroy, class_name: 'SubmissionRequest'
 
   has_many :updates,    dependent: :destroy, class_name: 'SubmissionUpdate'

--- a/app/models/submission_request.rb
+++ b/app/models/submission_request.rb
@@ -1,6 +1,12 @@
 class SubmissionRequest < ApplicationRecord
   include ValidationSubject
 
+  enum :db, {
+    st26:       'st26',
+    bioproject: 'bioproject',
+    biosample:  'biosample'
+  }, suffix: true, validate: true
+
   belongs_to :user
   belongs_to :submission, optional: true, inverse_of: :request
 

--- a/app/models/submission_update.rb
+++ b/app/models/submission_update.rb
@@ -1,6 +1,12 @@
 class SubmissionUpdate < ApplicationRecord
   include ValidationSubject
 
+  enum :db, {
+    st26:       'st26',
+    bioproject: 'bioproject',
+    biosample:  'biosample'
+  }, suffix: true, validate: true
+
   belongs_to :submission, inverse_of: :updates
 
   has_one_attached :ddbj_record

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,18 +11,20 @@ Rails.application.routes.draw do
 
     resource :me, only: %i[show]
 
-    resources :submission_requests, only: %i[index show create] do
-      resource :status,     only: :show
-      resource :submission, only: :create
-    end
+    scope ':db', constraints: {db: Regexp.union(Submission.dbs.keys)} do
+      resources :submission_requests, only: %i[index show create] do
+        resource :status,     only: :show
+        resource :submission, only: :create
+      end
 
-    resources :submission_updates, only: %i[show] do
-      resource :submission, only: :update
-    end
+      resources :submission_updates, only: %i[show] do
+        resource :submission, only: :update
+      end
 
-    resources :submissions, only: %i[index show] do
-      resources :accessions, only: %i[index]
-      resources :updates,    only: %i[create], controller: 'submission_updates'
+      resources :submissions, only: %i[index show] do
+        resources :accessions, only: %i[index]
+        resources :updates,    only: %i[create], controller: 'submission_updates'
+      end
     end
 
     resources :accessions, only: %i[show], param: :number, constraints: {number: %r{[^/]+}}

--- a/db/migrate/20260428071540_add_db_to_submissions.rb
+++ b/db/migrate/20260428071540_add_db_to_submissions.rb
@@ -1,0 +1,17 @@
+class AddDbToSubmissions < ActiveRecord::Migration[8.1]
+  def up
+    %i[submission_requests submissions submission_updates].each do |table|
+      add_column table, :db, :string
+      execute "UPDATE #{table} SET db = 'st26'"
+      change_column_null table, :db, false
+      add_index table, :db
+    end
+  end
+
+  def down
+    %i[submission_requests submissions submission_updates].each do |table|
+      remove_index  table, :db
+      remove_column table, :db
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_15_055821) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_28_071540) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -81,28 +81,34 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_055821) do
 
   create_table "submission_requests", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.string "db", null: false
     t.string "error_message"
     t.integer "status", default: 0, null: false
     t.bigint "submission_id"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.index ["db"], name: "index_submission_requests_on_db"
     t.index ["submission_id"], name: "index_submission_requests_on_submission_id"
     t.index ["user_id"], name: "index_submission_requests_on_user_id"
   end
 
   create_table "submission_updates", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.string "db", null: false
     t.string "diff"
     t.string "error_message"
     t.integer "status", default: 0, null: false
     t.bigint "submission_id", null: false
     t.datetime "updated_at", null: false
+    t.index ["db"], name: "index_submission_updates_on_db"
     t.index ["submission_id"], name: "index_submission_updates_on_submission_id"
   end
 
   create_table "submissions", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.string "db", null: false
     t.datetime "updated_at", null: false
+    t.index ["db"], name: "index_submissions_on_db"
   end
 
   create_table "users", force: :cascade do |t|

--- a/schema/openapi.d.ts
+++ b/schema/openapi.d.ts
@@ -84,11 +84,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/submission_requests": {
+    "/{db}/submission_requests": {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
+            path: {
+                /** @description Database that the submission belongs to. */
+                db: components["parameters"]["Db"];
+            };
             cookie?: never;
         };
         /** @description Get a list of submission requests. */
@@ -96,7 +99,10 @@ export interface paths {
             parameters: {
                 query?: never;
                 header?: never;
-                path?: never;
+                path: {
+                    /** @description Database that the submission belongs to. */
+                    db: components["parameters"]["Db"];
+                };
                 cookie?: never;
             };
             requestBody?: never;
@@ -119,7 +125,10 @@ export interface paths {
             parameters: {
                 query?: never;
                 header?: never;
-                path?: never;
+                path: {
+                    /** @description Database that the submission belongs to. */
+                    db: components["parameters"]["Db"];
+                };
                 cookie?: never;
             };
             requestBody: {
@@ -152,11 +161,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/submission_requests/{id}": {
+    "/{db}/submission_requests/{id}": {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
+            path: {
+                /** @description Database that the submission belongs to. */
+                db: components["parameters"]["Db"];
+            };
             cookie?: never;
         };
         /** @description Get a submission request. */
@@ -165,6 +177,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
+                    /** @description Database that the submission belongs to. */
+                    db: components["parameters"]["Db"];
                     id: number;
                 };
                 cookie?: never;
@@ -192,11 +206,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/submission_requests/{id}/status": {
+    "/{db}/submission_requests/{id}/status": {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
+            path: {
+                /** @description Database that the submission belongs to. */
+                db: components["parameters"]["Db"];
+            };
             cookie?: never;
         };
         /** @description Get the status of a submission request. Lightweight endpoint for polling. */
@@ -205,6 +222,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
+                    /** @description Database that the submission belongs to. */
+                    db: components["parameters"]["Db"];
                     id: number;
                 };
                 cookie?: never;
@@ -232,11 +251,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/submission_requests/{id}/submission": {
+    "/{db}/submission_requests/{id}/submission": {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
+            path: {
+                /** @description Database that the submission belongs to. */
+                db: components["parameters"]["Db"];
+            };
             cookie?: never;
         };
         get?: never;
@@ -247,6 +269,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
+                    /** @description Database that the submission belongs to. */
+                    db: components["parameters"]["Db"];
                     id: number;
                 };
                 cookie?: never;
@@ -271,11 +295,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/submission_updates/{id}": {
+    "/{db}/submission_updates/{id}": {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
+            path: {
+                /** @description Database that the submission belongs to. */
+                db: components["parameters"]["Db"];
+            };
             cookie?: never;
         };
         /** @description Get a submission update. */
@@ -284,6 +311,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
+                    /** @description Database that the submission belongs to. */
+                    db: components["parameters"]["Db"];
                     id: number;
                 };
                 cookie?: never;
@@ -311,11 +340,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/submission_updates/{id}/submission": {
+    "/{db}/submission_updates/{id}/submission": {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
+            path: {
+                /** @description Database that the submission belongs to. */
+                db: components["parameters"]["Db"];
+            };
             cookie?: never;
         };
         get?: never;
@@ -330,6 +362,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
+                    /** @description Database that the submission belongs to. */
+                    db: components["parameters"]["Db"];
                     id: number;
                 };
                 cookie?: never;
@@ -350,11 +384,14 @@ export interface paths {
         };
         trace?: never;
     };
-    "/submissions": {
+    "/{db}/submissions": {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
+            path: {
+                /** @description Database that the submission belongs to. */
+                db: components["parameters"]["Db"];
+            };
             cookie?: never;
         };
         /** @description Get a list of submissions. */
@@ -362,7 +399,10 @@ export interface paths {
             parameters: {
                 query?: never;
                 header?: never;
-                path?: never;
+                path: {
+                    /** @description Database that the submission belongs to. */
+                    db: components["parameters"]["Db"];
+                };
                 cookie?: never;
             };
             requestBody?: never;
@@ -387,11 +427,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/submissions/{id}": {
+    "/{db}/submissions/{id}": {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
+            path: {
+                /** @description Database that the submission belongs to. */
+                db: components["parameters"]["Db"];
+            };
             cookie?: never;
         };
         /** @description Get a submission. */
@@ -400,6 +443,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
+                    /** @description Database that the submission belongs to. */
+                    db: components["parameters"]["Db"];
                     id: number;
                 };
                 cookie?: never;
@@ -427,11 +472,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/submissions/{id}/accessions": {
+    "/{db}/submissions/{id}/accessions": {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
+            path: {
+                /** @description Database that the submission belongs to. */
+                db: components["parameters"]["Db"];
+            };
             cookie?: never;
         };
         /** @description Get a paginated list of accessions for a submission. */
@@ -442,6 +490,8 @@ export interface paths {
                 };
                 header?: never;
                 path: {
+                    /** @description Database that the submission belongs to. */
+                    db: components["parameters"]["Db"];
                     id: number;
                 };
                 cookie?: never;
@@ -470,11 +520,61 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/submissions/{id}/updates": {
+    "/accessions/{number}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
+            cookie?: never;
+        };
+        /** @description Get an accession by number, including its submission and flatfile URLs. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    number: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Returns the accession with its submission. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            number: string;
+                            entry_id: string;
+                            version: number;
+                            /** Format: date */
+                            locus_date: string;
+                            submission: components["schemas"]["Submission"];
+                        };
+                    };
+                };
+                401: components["responses"]["Unauthorized"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/{db}/submissions/{id}/updates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Database that the submission belongs to. */
+                db: components["parameters"]["Db"];
+            };
             cookie?: never;
         };
         get?: never;
@@ -485,6 +585,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
+                    /** @description Database that the submission belongs to. */
+                    db: components["parameters"]["Db"];
                     id: number;
                 };
                 cookie?: never;
@@ -617,7 +719,7 @@ export interface components {
         /** @enum {string} */
         SubmissionOperationStatus: "waiting_validation" | "validating" | "validation_failed" | "ready_to_apply" | "waiting_application" | "applying" | "applied" | "application_failed" | "no_change";
         Error: {
-            message: string;
+            error: string;
         };
     };
     responses: {
@@ -667,7 +769,10 @@ export interface components {
             };
         };
     };
-    parameters: never;
+    parameters: {
+        /** @description Database that the submission belongs to. */
+        Db: "st26" | "bioproject" | "biosample";
+    };
     requestBodies: never;
     headers: never;
     pathItems: never;

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -69,7 +69,10 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
-  /submission_requests:
+  /{db}/submission_requests:
+    parameters:
+      - $ref: '#/components/parameters/Db'
+
     get:
       description: Get a list of submission requests.
 
@@ -133,7 +136,10 @@ paths:
         '422':
           $ref: '#/components/responses/UnprocessableContent'
 
-  /submission_requests/{id}:
+  /{db}/submission_requests/{id}:
+    parameters:
+      - $ref: '#/components/parameters/Db'
+
     get:
       description: Get a submission request.
 
@@ -163,7 +169,10 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /submission_requests/{id}/status:
+  /{db}/submission_requests/{id}/status:
+    parameters:
+      - $ref: '#/components/parameters/Db'
+
     get:
       description: Get the status of a submission request. Lightweight endpoint for polling.
 
@@ -193,7 +202,10 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /submission_requests/{id}/submission:
+  /{db}/submission_requests/{id}/submission:
+    parameters:
+      - $ref: '#/components/parameters/Db'
+
     post:
       description: Apply a submission request.
 
@@ -221,7 +233,10 @@ paths:
         '422':
           $ref: '#/components/responses/UnprocessableContent'
 
-  /submission_updates/{id}:
+  /{db}/submission_updates/{id}:
+    parameters:
+      - $ref: '#/components/parameters/Db'
+
     get:
       description: Get a submission update.
 
@@ -251,7 +266,10 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /submission_updates/{id}/submission:
+  /{db}/submission_updates/{id}/submission:
+    parameters:
+      - $ref: '#/components/parameters/Db'
+
     patch:
       description: Apply a submission update.
 
@@ -279,7 +297,10 @@ paths:
         '422':
           $ref: '#/components/responses/UnprocessableContent'
 
-  /submissions:
+  /{db}/submissions:
+    parameters:
+      - $ref: '#/components/parameters/Db'
+
     get:
       description: Get a list of submissions.
 
@@ -301,7 +322,10 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
-  /submissions/{id}:
+  /{db}/submissions/{id}:
+    parameters:
+      - $ref: '#/components/parameters/Db'
+
     get:
       description: Get a submission.
 
@@ -331,7 +355,10 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /submissions/{id}/accessions:
+  /{db}/submissions/{id}/accessions:
+    parameters:
+      - $ref: '#/components/parameters/Db'
+
     get:
       description: Get a paginated list of accessions for a submission.
 
@@ -424,7 +451,10 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /submissions/{id}/updates:
+  /{db}/submissions/{id}/updates:
+    parameters:
+      - $ref: '#/components/parameters/Db'
+
     post:
       description: Create a submission update.
 
@@ -889,3 +919,18 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+
+  parameters:
+    Db:
+      name: db
+      in: path
+      required: true
+      description: Database that the submission belongs to.
+
+      schema:
+        type: string
+
+        enum:
+          - st26
+          - bioproject
+          - biosample

--- a/test/fixtures/accessions.yml
+++ b/test/fixtures/accessions.yml
@@ -1,11 +1,11 @@
 one:
-  submission: one
+  submission: st26
   number:     ACC_000001
   entry_id:   "SEQ|JP|2026123456|A|1"
   locus_date: 2026-01-15
 
 two:
-  submission: one
+  submission: st26
   number:     ACC_000002
   entry_id:   "SEQ|JP|2026123456|A|2"
   locus_date: 2026-01-15

--- a/test/fixtures/submission_requests.yml
+++ b/test/fixtures/submission_requests.yml
@@ -1,3 +1,14 @@
-one:
+st26:
   user: alice
-  submission: one
+  submission: st26
+  db: st26
+
+bioproject:
+  user: alice
+  submission: bioproject
+  db: bioproject
+
+biosample:
+  user: alice
+  submission: biosample
+  db: biosample

--- a/test/fixtures/submission_updates.yml
+++ b/test/fixtures/submission_updates.yml
@@ -1,2 +1,3 @@
-one:
-  submission: one
+st26:
+  submission: st26
+  db: st26

--- a/test/fixtures/submissions.yml
+++ b/test/fixtures/submissions.yml
@@ -1,1 +1,8 @@
-one: {}
+st26:
+  db: st26
+
+bioproject:
+  db: bioproject
+
+biosample:
+  db: biosample

--- a/test/fixtures/validations.yml
+++ b/test/fixtures/validations.yml
@@ -1,5 +1,5 @@
-valid_one:
+valid_st26:
   subject_type: SubmissionRequest
-  subject_id: <%= ActiveRecord::FixtureSet.identify(:one) %>
+  subject_id: <%= ActiveRecord::FixtureSet.identify(:st26) %>
   progress: finished
   finished_at: 2024-01-03

--- a/test/integration/accessions_test.rb
+++ b/test/integration/accessions_test.rb
@@ -8,10 +8,10 @@ class AccessionsTest < ActionDispatch::IntegrationTest
   end
 
   test 'show' do
-    submission = submissions(:one)
+    submission = submissions(:st26)
 
     attach_submission_files submission
-    attach_ddbj_record submission_updates(:one)
+    attach_ddbj_record submission_updates(:st26)
 
     accession = submission.accessions.first
 
@@ -38,7 +38,7 @@ class AccessionsTest < ActionDispatch::IntegrationTest
     default_headers['Authorization'] = "Bearer #{users(:carol).api_key}"
 
     with_exceptions_app do
-      get accession_path(submissions(:one).accessions.first.number)
+      get accession_path(submissions(:st26).accessions.first.number)
     end
 
     assert_conform_schema 404

--- a/test/integration/admin/regenerate_flatfiles_test.rb
+++ b/test/integration/admin/regenerate_flatfiles_test.rb
@@ -48,7 +48,7 @@ class AdminRegenerateFlatfilesTest < ActionDispatch::IntegrationTest
   end
 
   test 'create enqueues jobs for submissions with ddbj_record' do
-    submission = submissions(:one)
+    submission = submissions(:st26)
 
     submission.ddbj_record.attach(
       io:           file_fixture('ddbj_record/example.json').open,
@@ -73,7 +73,7 @@ class AdminRegenerateFlatfilesTest < ActionDispatch::IntegrationTest
   end
 
   test 'create forwards force flag to the job' do
-    submission = submissions(:one)
+    submission = submissions(:st26)
 
     submission.ddbj_record.attach(
       io:           file_fixture('ddbj_record/example.json').open,

--- a/test/integration/submission_requests/submissions_test.rb
+++ b/test/integration/submission_requests/submissions_test.rb
@@ -8,7 +8,7 @@ class SubmissionRequestsSubmissionsTest < ActionDispatch::IntegrationTest
   end
 
   test 'create' do
-    request = submission_requests(:one)
+    request = submission_requests(:st26)
 
     attach_ddbj_record request
     request.update! status: :ready_to_apply
@@ -20,7 +20,7 @@ class SubmissionRequestsSubmissionsTest < ActionDispatch::IntegrationTest
     )
 
     perform_enqueued_jobs do
-      post submission_request_submission_path(request)
+      post submission_request_submission_path(db: 'st26', submission_request_id: request.id)
     end
 
     assert_conform_schema 204

--- a/test/integration/submission_requests_test.rb
+++ b/test/integration/submission_requests_test.rb
@@ -8,19 +8,19 @@ class SubmissionRequestsTest < ActionDispatch::IntegrationTest
   end
 
   test 'index' do
-    get submission_requests_path
+    get submission_requests_path(db: 'st26')
 
     assert_conform_schema 200
   end
 
   test 'show' do
-    request = submission_requests(:one)
+    request = submission_requests(:st26)
 
     attach_ddbj_record request
     attach_submission_files request.submission
-    attach_ddbj_record submission_updates(:one)
+    attach_ddbj_record submission_updates(:st26)
 
-    get submission_request_path(request)
+    get submission_request_path(db: 'st26', id: request.id)
 
     assert_conform_schema 200
   end
@@ -33,7 +33,7 @@ class SubmissionRequestsTest < ActionDispatch::IntegrationTest
     )
 
     perform_enqueued_jobs do
-      post submission_requests_path, params: {
+      post submission_requests_path(db: 'st26'), params: {
         submission_request: {
           ddbj_record: blob.signed_id
         }
@@ -48,5 +48,47 @@ class SubmissionRequestsTest < ActionDispatch::IntegrationTest
     assert_equal 'valid',    body.dig('validation', 'validity')
     assert_equal [],         body.dig('validation', 'details')
     assert_nil               body['submission']
+  end
+
+  test 'index is scoped by db' do
+    attach_ddbj_record submission_requests(:bioproject)
+
+    get submission_requests_path(db: 'bioproject')
+
+    assert_conform_schema 200
+
+    ids = response.parsed_body.pluck('id')
+
+    assert_includes     ids, submission_requests(:bioproject).id
+    assert_not_includes ids, submission_requests(:st26).id
+  end
+
+  test 'show returns 404 across dbs' do
+    attach_ddbj_record submission_requests(:st26)
+
+    with_exceptions_app do
+      get submission_request_path(db: 'bioproject', id: submission_requests(:st26).id)
+    end
+
+    assert_conform_schema 404
+  end
+
+  test 'create persists the db from the route' do
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io:           file_fixture('ddbj_record/example.json').open,
+      filename:     'example.json',
+      content_type: 'application/json'
+    )
+
+    perform_enqueued_jobs do
+      post submission_requests_path(db: 'biosample'), params: {
+        submission_request: {
+          ddbj_record: blob.signed_id
+        }
+      }, as: :json
+    end
+
+    assert_conform_schema 202
+    assert_equal 'biosample', SubmissionRequest.find(response.parsed_body['id']).db
   end
 end

--- a/test/integration/submission_updates/submissions_test.rb
+++ b/test/integration/submission_updates/submissions_test.rb
@@ -8,7 +8,7 @@ class SubmissionUpdatesSubmissionsTest < ActionDispatch::IntegrationTest
   end
 
   test 'create' do
-    update = submission_updates(:one)
+    update = submission_updates(:st26)
 
     attach_ddbj_record update
     update.update! status: :ready_to_apply
@@ -20,7 +20,7 @@ class SubmissionUpdatesSubmissionsTest < ActionDispatch::IntegrationTest
     )
 
     perform_enqueued_jobs do
-      patch submission_update_submission_path(update)
+      patch submission_update_submission_path(db: 'st26', submission_update_id: update.id)
     end
 
     assert_conform_schema 204

--- a/test/integration/submission_updates_test.rb
+++ b/test/integration/submission_updates_test.rb
@@ -8,12 +8,12 @@ class SubmissionUpdatesTest < ActionDispatch::IntegrationTest
   end
 
   test 'show' do
-    update = submission_updates(:one)
+    update = submission_updates(:st26)
 
     attach_ddbj_record update
     attach_submission_files update.submission
 
-    get submission_update_path(update)
+    get submission_update_path(db: 'st26', id: update.id)
 
     assert_conform_schema 200
   end

--- a/test/integration/submissions/updates_test.rb
+++ b/test/integration/submissions/updates_test.rb
@@ -6,10 +6,10 @@ class SubmissionsUpdatesTest < ActionDispatch::IntegrationTest
 
     default_headers['Authorization'] = "Bearer #{@user.api_key}"
 
-    @submission = submissions(:one)
+    @submission = submissions(:st26)
 
     attach_submission_files @submission
-    attach_ddbj_record submission_updates(:one)
+    attach_ddbj_record submission_updates(:st26)
   end
 
   test 'create' do
@@ -19,7 +19,7 @@ class SubmissionsUpdatesTest < ActionDispatch::IntegrationTest
       content_type: 'application/json'
     )
 
-    post submission_updates_path(@submission), params: {
+    post submission_updates_path(db: 'st26', submission_id: @submission.id), params: {
       submission_update: {
         ddbj_record: blob.signed_id
       }

--- a/test/integration/submissions_test.rb
+++ b/test/integration/submissions_test.rb
@@ -6,14 +6,14 @@ class SubmissionsTest < ActionDispatch::IntegrationTest
 
     default_headers['Authorization'] = "Bearer #{@user.api_key}"
 
-    @submission = submissions(:one)
+    @submission = submissions(:st26)
 
     attach_submission_files @submission
-    attach_ddbj_record submission_updates(:one)
+    attach_ddbj_record submission_updates(:st26)
   end
 
   test 'index' do
-    get submissions_path
+    get submissions_path(db: 'st26')
 
     assert_conform_schema 200
 
@@ -21,7 +21,7 @@ class SubmissionsTest < ActionDispatch::IntegrationTest
   end
 
   test 'show' do
-    get submission_path(@submission)
+    get submission_path(db: 'st26', id: @submission.id)
 
     assert_conform_schema 200
     assert_equal @submission.id, response.parsed_body['id']

--- a/test/jobs/apply_submission_request_job_test.rb
+++ b/test/jobs/apply_submission_request_job_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ApplySubmissionRequestJobTest < ActiveSupport::TestCase
   test 'generates NA flatfile for genomic DNA entries' do
-    request = SubmissionRequest.new(user: users(:alice))
+    request = SubmissionRequest.new(user: users(:alice), db: 'st26')
 
     request.ddbj_record.attach(
       io:           file_fixture('ddbj_record/example.json').open,

--- a/test/jobs/apply_submission_update_job_test.rb
+++ b/test/jobs/apply_submission_update_job_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ApplySubmissionUpdateJobTest < ActiveSupport::TestCase
   setup do
-    request = SubmissionRequest.new(user: users(:alice))
+    request = SubmissionRequest.new(user: users(:alice), db: 'st26')
 
     request.ddbj_record.attach(
       io:           file_fixture('ddbj_record/example.json').open,
@@ -23,7 +23,7 @@ class ApplySubmissionUpdateJobTest < ActiveSupport::TestCase
     json = @submission.ddbj_record.open { JSON.parse(it.read) }
     json['sequences']['entries'][0]['definition'] = 'modified definition'
 
-    update = @submission.updates.new
+    update = @submission.updates.new(db: @submission.db)
     update.ddbj_record.attach io: StringIO.new(JSON.generate(json)), filename: 'example.json', content_type: 'application/json'
     update.save!
 
@@ -47,7 +47,7 @@ class ApplySubmissionUpdateJobTest < ActiveSupport::TestCase
     json = @submission.ddbj_record.open { JSON.parse(it.read) }
     json['sequences']['entries'][0]['definition'] = 'modified definition'
 
-    update = @submission.updates.new
+    update = @submission.updates.new(db: @submission.db)
     update.ddbj_record.attach io: StringIO.new(JSON.generate(json)), filename: 'example.json', content_type: 'application/json'
     update.save!
 

--- a/test/jobs/regenerate_submission_flatfiles_job_test.rb
+++ b/test/jobs/regenerate_submission_flatfiles_job_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
   setup do
-    request = SubmissionRequest.new(user: users(:alice))
+    request = SubmissionRequest.new(user: users(:alice), db: 'st26')
 
     request.ddbj_record.attach(
       io:           file_fixture('ddbj_record/example.json').open,

--- a/web/app/routes/request.gts
+++ b/web/app/routes/request.gts
@@ -4,14 +4,15 @@ import { service } from '@ember/service';
 import type { RequestManager } from '@warp-drive/core';
 import type { paths } from 'schema/openapi';
 
-type SubmissionRequest = paths['/submission_requests/{id}']['get']['responses']['200']['content']['application/json'];
+type SubmissionRequest =
+  paths['/{db}/submission_requests/{id}']['get']['responses']['200']['content']['application/json'];
 
 export default class extends Route {
   @service declare requestManager: RequestManager;
 
   async model({ request_id }: { request_id: string }) {
     const { content } = await this.requestManager.request<SubmissionRequest>({
-      url: `/submission_requests/${request_id}`,
+      url: `/st26/submission_requests/${request_id}`,
     });
 
     return content;

--- a/web/app/routes/requests/index.ts
+++ b/web/app/routes/requests/index.ts
@@ -4,7 +4,8 @@ import { service } from '@ember/service';
 import type { RequestManager } from '@warp-drive/core';
 import type { paths } from 'schema/openapi';
 
-type SubmissionRequestSummary = paths['/submission_requests']['get']['responses']['200']['content']['application/json'];
+type SubmissionRequestSummary =
+  paths['/{db}/submission_requests']['get']['responses']['200']['content']['application/json'];
 
 export default class extends Route {
   @service declare requestManager: RequestManager;
@@ -17,7 +18,7 @@ export default class extends Route {
 
   async model({ page }: { page?: number }) {
     const { content, response } = await this.requestManager.request<SubmissionRequestSummary>({
-      url: '/submission_requests',
+      url: '/st26/submission_requests',
       options: { params: { page } },
     });
 

--- a/web/app/routes/submission.ts
+++ b/web/app/routes/submission.ts
@@ -4,14 +4,14 @@ import { service } from '@ember/service';
 import type { RequestManager } from '@warp-drive/core';
 import type { paths } from 'schema/openapi';
 
-type Submission = paths['/submissions/{id}']['get']['responses']['200']['content']['application/json'];
+type Submission = paths['/{db}/submissions/{id}']['get']['responses']['200']['content']['application/json'];
 
 export default class SubmissionRoute extends Route {
   @service declare requestManager: RequestManager;
 
   async model({ submission_id }: { submission_id: string }) {
     const { content } = await this.requestManager.request<Submission>({
-      url: `/submissions/${submission_id}`,
+      url: `/st26/submissions/${submission_id}`,
     });
 
     return content;

--- a/web/app/routes/submission/accessions.ts
+++ b/web/app/routes/submission/accessions.ts
@@ -4,7 +4,7 @@ import { service } from '@ember/service';
 import type { RequestManager } from '@warp-drive/core';
 import type { paths } from 'schema/openapi';
 
-type Accessions = paths['/submissions/{id}/accessions']['get']['responses']['200']['content']['application/json'];
+type Accessions = paths['/{db}/submissions/{id}/accessions']['get']['responses']['200']['content']['application/json'];
 
 export default class extends Route {
   @service declare requestManager: RequestManager;
@@ -19,7 +19,7 @@ export default class extends Route {
     const { submission_id } = this.paramsFor('submission') as { submission_id: string };
 
     const { content, response } = await this.requestManager.request<Accessions>({
-      url: `/submissions/${submission_id}/accessions`,
+      url: `/st26/submissions/${submission_id}/accessions`,
       options: { params: { page } },
     });
 

--- a/web/app/routes/submissions/index.ts
+++ b/web/app/routes/submissions/index.ts
@@ -4,7 +4,7 @@ import { service } from '@ember/service';
 import type { RequestManager } from '@warp-drive/core';
 import type { paths } from 'schema/openapi';
 
-type SubmissionSummary = paths['/submissions']['get']['responses']['200']['content']['application/json'];
+type SubmissionSummary = paths['/{db}/submissions']['get']['responses']['200']['content']['application/json'];
 
 export default class extends Route {
   @service declare requestManager: RequestManager;
@@ -17,7 +17,7 @@ export default class extends Route {
 
   async model({ page }: { page?: number }) {
     const { content, response } = await this.requestManager.request<SubmissionSummary>({
-      url: '/submissions',
+      url: '/st26/submissions',
       options: { params: { page } },
     });
 

--- a/web/app/routes/update.ts
+++ b/web/app/routes/update.ts
@@ -4,14 +4,15 @@ import { service } from '@ember/service';
 import type { RequestManager } from '@warp-drive/core';
 import type { paths } from 'schema/openapi';
 
-type SubmissionUpdate = paths['/submission_updates/{id}']['get']['responses']['200']['content']['application/json'];
+type SubmissionUpdate =
+  paths['/{db}/submission_updates/{id}']['get']['responses']['200']['content']['application/json'];
 
 export default class extends Route {
   @service declare requestManager: RequestManager;
 
   async model({ update_id }: { update_id: string }) {
     const { content } = await this.requestManager.request<SubmissionUpdate>({
-      url: `/submission_updates/${update_id}`,
+      url: `/st26/submission_updates/${update_id}`,
     });
 
     return content;

--- a/web/app/templates/request.gts
+++ b/web/app/templates/request.gts
@@ -30,7 +30,7 @@ export default class extends Component<Signature> {
     const { model } = this.args;
 
     await this.requestManager.request({
-      url: `/submission_requests/${model.id}/submission`,
+      url: `/st26/submission_requests/${model.id}/submission`,
       method: 'POST',
     });
 

--- a/web/app/templates/requests/new.gts
+++ b/web/app/templates/requests/new.gts
@@ -13,7 +13,8 @@ import type RouterService from '@ember/routing/router-service';
 import type { Blob } from '@rails/activestorage';
 import type { paths } from 'schema/openapi';
 
-type CreateRequestResponse = paths['/submission_requests']['post']['responses']['202']['content']['application/json'];
+type CreateRequestResponse =
+  paths['/{db}/submission_requests']['post']['responses']['202']['content']['application/json'];
 
 export default class extends Component {
   @service declare requestManager: RequestManager;
@@ -39,7 +40,7 @@ export default class extends Component {
     });
 
     const { content } = await this.requestManager.request<CreateRequestResponse>({
-      url: '/submission_requests',
+      url: '/st26/submission_requests',
       method: 'POST',
       data: { submission_request: { ddbj_record: blob.signed_id } },
     });

--- a/web/app/templates/submission/updates/new.gts
+++ b/web/app/templates/submission/updates/new.gts
@@ -14,7 +14,7 @@ import type { Blob } from '@rails/activestorage';
 import type { components, paths } from 'schema/openapi';
 
 type CreateUpdateResponse =
-  paths['/submissions/{id}/updates']['post']['responses']['202']['content']['application/json'];
+  paths['/{db}/submissions/{id}/updates']['post']['responses']['202']['content']['application/json'];
 
 interface Signature {
   Args: {
@@ -46,7 +46,7 @@ export default class extends Component<Signature> {
     });
 
     const { content } = await this.requestManager.request<CreateUpdateResponse>({
-      url: `/submissions/${this.args.model.id}/updates`,
+      url: `/st26/submissions/${this.args.model.id}/updates`,
       method: 'POST',
       data: { submission_update: { ddbj_record: blob.signed_id } },
     });

--- a/web/app/templates/update.gts
+++ b/web/app/templates/update.gts
@@ -31,7 +31,7 @@ export default class extends Component<Signature> {
     const { model } = this.args;
 
     await this.requestManager.request({
-      url: `/submission_updates/${model.id}/submission`,
+      url: `/st26/submission_updates/${model.id}/submission`,
       method: 'PATCH',
     });
 

--- a/web/tests/acceptance/submission-request-test.gts
+++ b/web/tests/acceptance/submission-request-test.gts
@@ -20,7 +20,7 @@ module('Acceptance | submission request', function (hooks) {
     // --- List page ---
 
     worker.use(
-      http.get('/submission_requests', ({ response }) => {
+      http.get('/{db}/submission_requests', ({ response }) => {
         return response(200).json([], {
           headers: { 'Total-Pages': '1' },
         });
@@ -58,11 +58,11 @@ module('Acceptance | submission request', function (hooks) {
     };
 
     worker.use(
-      http.post('/submission_requests', ({ response }) => {
+      http.post('/{db}/submission_requests', ({ response }) => {
         return response(202).json(createdRequest);
       }),
 
-      http.get('/submission_requests/{id}', ({ response }) => {
+      http.get('/{db}/submission_requests/{id}', ({ response }) => {
         return response(200).json({
           ...createdRequest,
           status: 'ready_to_apply',
@@ -92,11 +92,11 @@ module('Acceptance | submission request', function (hooks) {
     // --- Apply ---
 
     worker.use(
-      http.post('/submission_requests/{id}/submission', ({ response }) => {
+      http.post('/{db}/submission_requests/{id}/submission', ({ response }) => {
         return response(204).empty();
       }),
 
-      http.get('/submission_requests/{id}', ({ response }) => {
+      http.get('/{db}/submission_requests/{id}', ({ response }) => {
         return response(200).json({
           ...createdRequest,
           status: 'applied',

--- a/web/tests/acceptance/submission-update-test.gts
+++ b/web/tests/acceptance/submission-update-test.gts
@@ -41,7 +41,7 @@ module('Acceptance | submission update', function (hooks) {
     // --- Submission detail page ---
 
     worker.use(
-      http.get('/submissions/{id}', ({ response }) => {
+      http.get('/{db}/submissions/{id}', ({ response }) => {
         return response(200).json(submission);
       }),
     );
@@ -78,11 +78,11 @@ module('Acceptance | submission update', function (hooks) {
     };
 
     worker.use(
-      http.post('/submissions/{id}/updates', ({ response }) => {
+      http.post('/{db}/submissions/{id}/updates', ({ response }) => {
         return response(202).json(createdUpdate);
       }),
 
-      http.get('/submission_updates/{id}', ({ response }) => {
+      http.get('/{db}/submission_updates/{id}', ({ response }) => {
         return response(200).json({
           ...createdUpdate,
           status: 'ready_to_apply',
@@ -114,11 +114,11 @@ module('Acceptance | submission update', function (hooks) {
     // --- Apply ---
 
     worker.use(
-      http.patch('/submission_updates/{id}/submission', ({ response }) => {
+      http.patch('/{db}/submission_updates/{id}/submission', ({ response }) => {
         return response(204).empty();
       }),
 
-      http.get('/submission_updates/{id}', ({ response }) => {
+      http.get('/{db}/submission_updates/{id}', ({ response }) => {
         return response(200).json({
           ...createdUpdate,
           status: 'applied',


### PR DESCRIPTION
## Summary

- Add a `db` enum column (`st26`/`bioproject`/`biosample`) to `submission_requests`, `submissions`, and `submission_updates`. Existing rows are backfilled to `st26`; column is `NOT NULL` with no default so future inserts must specify it explicitly.
- Namespace API routes under `/api/:db/...` (constraints sourced from `Submission.dbs.keys`). A single set of controllers/models serves all three DBs and filters by `params[:db]`.
- Update the Ember frontend to call `/api/st26/...` directly (UI is ST.26-only for now). MSW handlers stay on the templated `/{db}/...` form because openapi-msw matches against schema paths.
- Update OpenAPI schema with `/{db}/...` template paths and a shared `Db` parameter component; regenerate `schema/openapi.d.ts`.
- Add cross-db scoping tests (404 across dbs, db persistence on create) and rename the `:one` fixture to `:st26` to match the other dbs.

The `db` column on `submissions` / `submission_updates` is technically derivable from the parent record but is kept redundantly so cross-db queries (e.g. retrofitting flatfiles) stay JOIN-free. Consistency is enforced at controller/job boundaries by passing `db:` explicitly when creating child records.

## Test plan

- [x] `bin/rails test` (75 runs, 196 assertions)
- [x] `bundle exec rubocop` (clean)
- [x] `bundle exec brakeman` (clean)
- [x] `cd web && pnpm lint` (clean)
- [x] `cd web && pnpm test` (13 runs)
- [ ] Verify against staging: each db prefix returns 200, cross-db lookups 404, frontend ST.26 flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)