### PR TITLE
Move dev docker services to compose.dev.yaml

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,6 +1,3 @@
 api: SOLID_QUEUE_IN_PUMA=true bin/rails server --port 3000
 web: cd web && pnpm start --port 4200
-validator: docker run --rm --name repository-validator --publish 3001:3000 --volume ./validator/logs:/usr/src/ddbj_validator/logs --volume ./validator/conf/pub:/usr/src/ddbj_validator/conf/pub --volume ./validator/conf/coll_dump:/usr/src/ddbj_validator/conf/coll_dump --env DDBJ_VALIDATOR_APP_VIRTUOSO_ENDPOINT_MASTER=http://repository-virtuoso:8890/sparql --env DDBJ_VALIDATOR_APP_NAMED_GRAPHE_URI_TAXONOMY=http://ddbj.nig.ac.jp/ontologies/taxonomy-private --network repository ghcr.io/ddbj/ddbj_validator:main
-virtuoso: docker run --rm --name repository-virtuoso --volume ./validator/virtuoso/database:/database --network repository openlink/virtuoso-opensource-7:7.2.6-r1-g0a3336c
-seaweedfs: docker run --rm --name repository-seaweedfs --publish 8333:8333 --volume repository_seaweedfs:/data --volume ./docker/seaweedfs/entrypoint.sh:/entrypoint.sh --volume ./docker/seaweedfs/s3.development.json:/etc/seaweedfs/s3.json --entrypoint /entrypoint.sh chrislusf/seaweedfs
-keycloak: docker run --rm --name repository-keycloak --publish 8080:8080 --env KC_BOOTSTRAP_ADMIN_USERNAME=keycloak --env KC_BOOTSTRAP_ADMIN_PASSWORD=keycloak --volume repository_keycloak:/opt/keycloak/data keycloak/keycloak:26.3.1 start-dev
+services: docker compose -f compose.dev.yaml up

--- a/bin/setup
+++ b/bin/setup
@@ -30,8 +30,6 @@ FileUtils.chdir APP_ROOT do
   system! "corepack enable pnpm && cd web && corepack install"
   system! "pnpm install --dir web"
 
-  system! "docker network inspect repository > /dev/null 2>&1 || docker network create repository"
-
   unless ARGV.include?("--skip-server")
     puts "\n== Starting development server =="
     STDOUT.flush # flush the output before exec(2) so that it displays

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,0 +1,50 @@
+name: repository
+
+services:
+  validator:
+    image: ghcr.io/ddbj/ddbj_validator:main
+    container_name: repository-validator
+    ports:
+      - 3001:3000
+    volumes:
+      - ./validator/logs:/usr/src/ddbj_validator/logs
+      - ./validator/conf/pub:/usr/src/ddbj_validator/conf/pub
+      - ./validator/conf/coll_dump:/usr/src/ddbj_validator/conf/coll_dump
+    environment:
+      DDBJ_VALIDATOR_APP_VIRTUOSO_ENDPOINT_MASTER: http://repository-virtuoso:8890/sparql
+      DDBJ_VALIDATOR_APP_NAMED_GRAPHE_URI_TAXONOMY: http://ddbj.nig.ac.jp/ontologies/taxonomy-private
+    depends_on:
+      - virtuoso
+
+  virtuoso:
+    image: openlink/virtuoso-opensource-7:7.2.6-r1-g0a3336c
+    container_name: repository-virtuoso
+    volumes:
+      - ./validator/virtuoso/database:/database
+
+  seaweedfs:
+    image: chrislusf/seaweedfs
+    container_name: repository-seaweedfs
+    ports:
+      - 8333:8333
+    volumes:
+      - seaweedfs:/data
+      - ./docker/seaweedfs/entrypoint.sh:/entrypoint.sh
+      - ./docker/seaweedfs/s3.development.json:/etc/seaweedfs/s3.json
+    entrypoint: /entrypoint.sh
+
+  keycloak:
+    image: keycloak/keycloak:26.3.1
+    container_name: repository-keycloak
+    ports:
+      - 8080:8080
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: keycloak
+      KC_BOOTSTRAP_ADMIN_PASSWORD: keycloak
+    volumes:
+      - keycloak:/opt/keycloak/data
+    command: start-dev
+
+volumes:
+  seaweedfs:
+  keycloak:


### PR DESCRIPTION
## Summary

- Replace the four docker-run lines in `Procfile.dev` with a single `services: docker compose -f compose.dev.yaml up` entry.
- Compose project name is `repository`, so the existing named volumes (`repository_seaweedfs`, `repository_keycloak`) are reused as-is — no data migration needed.
- Each service keeps its `container_name`, so the validator can still reach virtuoso at `repository-virtuoso:8890` via Docker's DNS.
- Drop the `docker network create repository` step from `bin/setup`; compose manages its own default network.

## Test plan

- [x] `docker compose -f compose.dev.yaml config --quiet` (clean)
- [ ] `bin/dev` brings up api + web + all four containers; smoke-test by uploading a record through the validator
- [ ] After a clean checkout, `bin/setup` runs without the `docker network` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)