### PR TITLE
Redesign login screen

### DIFF
--- a/web/app/templates/index.gts
+++ b/web/app/templates/index.gts
@@ -47,9 +47,20 @@ export default class extends Component {
         </div>
       </div>
     {{else}}
-      <form action={{authURL}} method="POST">
-        <button type="submit" class="btn btn-primary btn-lg">Login</button>
-      </form>
+      <div class="row justify-content-center py-5">
+        <div class="col-12 col-sm-10 col-md-8 col-lg-6">
+          <div class="card shadow-sm">
+            <div class="card-body p-4 p-md-5 text-center">
+              <h1 class="h3 mb-2">DDBJ Repository</h1>
+              <p class="text-body-secondary mb-4">Sign in with your DDBJ Account to continue.</p>
+
+              <form action={{authURL}} method="POST">
+                <button type="submit" class="btn btn-primary btn-lg">Login with DDBJ Account</button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
     {{/if}}
   </template>
 }


### PR DESCRIPTION
## Summary

- Wrap the unauthenticated landing in a Bootstrap card so it reads as a real sign-in page rather than a bare button.
- Show the app name and a short prompt above the action.
- Rename the button to "Login with DDBJ Account" (the auth system is DDBJ Account, not D-way).

## Test plan

- [x] `pnpm lint` (clean)
- [x] `pnpm test` (13 runs)
- [ ] Eyeball at the various breakpoints (sm/md/lg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)