### PR TITLE
Migrate landing pages to Tailwind

### DIFF
--- a/web/app/components/nav-card.gts
+++ b/web/app/components/nav-card.gts
@@ -1,0 +1,27 @@
+import { LinkTo } from '@ember/routing';
+
+import type { TOC } from '@ember/component/template-only';
+
+interface Signature {
+  Args: {
+    title: string;
+    description?: string;
+    route: string;
+    model?: string;
+  };
+}
+
+const NavCard = <template>
+  <LinkTo
+    @route={{@route}}
+    @model={{@model}}
+    class="flex h-full flex-col rounded-lg border border-gray-200 bg-white p-6 no-underline shadow-sm transition hover:-translate-y-px hover:border-gray-300 hover:shadow-md"
+  >
+    <h2 class="mb-2 text-lg font-medium text-gray-900">{{@title}}</h2>
+    {{#if @description}}
+      <p class="m-0 text-gray-600">{{@description}}</p>
+    {{/if}}
+  </LinkTo>
+</template> satisfies TOC<Signature>;
+
+export default NavCard;

--- a/web/app/templates/account.gts
+++ b/web/app/templates/account.gts
@@ -42,45 +42,53 @@ export default class Account extends Component {
 
     <Breadcrumb @items={{array (hash label="Home" route="index") (hash label="Account")}} />
 
-    <h1 class="display-6 mb-4">Account</h1>
+    <h1 class="mb-6 text-3xl font-light">Account</h1>
 
-    <div class="card">
-      <div class="card-body">
-        <div class="row mb-3">
-          {{#let (uniqueId) as |id|}}
-            <label for={{id}} class="col-sm-2 col-form-label">Username</label>
+    <div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+      <div class="mb-4 grid items-center gap-2 sm:grid-cols-6">
+        {{#let (uniqueId) as |id|}}
+          <label for={{id}} class="text-sm font-medium text-gray-700 sm:col-span-1">Username</label>
 
-            <div class="col-sm-10">
-              <input
-                type="text"
-                value={{this.currentUser.user.uid}}
-                readonly
-                id={{id}}
-                class="form-control-plaintext"
-              />
-            </div>
-          {{/let}}
-        </div>
+          <input
+            type="text"
+            value={{this.currentUser.user.uid}}
+            readonly
+            id={{id}}
+            class="bg-transparent text-gray-900 sm:col-span-5"
+          />
+        {{/let}}
+      </div>
 
-        <div class="row">
-          {{#let (uniqueId) as |id|}}
-            <label for={{id}} class="col-sm-2 col-form-label">API key</label>
+      <div class="grid items-center gap-2 sm:grid-cols-6">
+        {{#let (uniqueId) as |id|}}
+          <label for={{id}} class="text-sm font-medium text-gray-700 sm:col-span-1">API key</label>
 
-            <div class="col-sm-10">
-              <div class="input-group">
-                <input type="text" value={{this.currentUser.user.apiKey}} readonly id={{id}} class="form-control" />
+          <div class="flex gap-2 sm:col-span-5">
+            <input
+              type="text"
+              value={{this.currentUser.user.apiKey}}
+              readonly
+              id={{id}}
+              class="flex-1 rounded-md border border-gray-300 bg-white px-3 py-2 font-mono text-sm text-gray-900 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+            />
 
-                <button type="button" class="btn btn-outline-secondary" {{on "click" this.copyApiKey}}>
-                  Copy
-                </button>
+            <button
+              type="button"
+              class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+              {{on "click" this.copyApiKey}}
+            >
+              Copy
+            </button>
 
-                <button type="button" class="btn btn-outline-secondary" {{on "click" this.regenerateApiKey}}>
-                  Regenerate
-                </button>
-              </div>
-            </div>
-          {{/let}}
-        </div>
+            <button
+              type="button"
+              class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+              {{on "click" this.regenerateApiKey}}
+            >
+              Regenerate
+            </button>
+          </div>
+        {{/let}}
       </div>
     </div>
   </template>

--- a/web/app/templates/admin/db/index.gts
+++ b/web/app/templates/admin/db/index.gts
@@ -1,7 +1,7 @@
-import { LinkTo } from '@ember/routing';
 import { array, hash } from '@ember/helper';
 
 import Breadcrumb from 'repository/components/breadcrumb';
+import NavCard from 'repository/components/nav-card';
 import dbLabel from 'repository/helpers/db-label';
 
 import type { TOC } from '@ember/component/template-only';
@@ -15,26 +15,21 @@ export default <template>
     }}
   />
 
-  <h1 class="display-6 mb-4">{{dbLabel @model.db}}</h1>
+  <h1 class="mb-6 text-3xl font-light">{{dbLabel @model.db}}</h1>
 
-  <div class="row g-3">
-    <div class="col-md-6">
-      <LinkTo @route="admin.db.requests" @model={{@model.db}} class="card text-decoration-none h-100">
-        <div class="card-body">
-          <h2 class="card-title h5">Requests</h2>
-          <p class="card-text text-body-secondary mb-0">All users' submission requests in this database.</p>
-        </div>
-      </LinkTo>
-    </div>
-
-    <div class="col-md-6">
-      <LinkTo @route="admin.db.submissions" @model={{@model.db}} class="card text-decoration-none h-100">
-        <div class="card-body">
-          <h2 class="card-title h5">Submissions</h2>
-          <p class="card-text text-body-secondary mb-0">All users' applied submissions in this database.</p>
-        </div>
-      </LinkTo>
-    </div>
+  <div class="grid gap-4 md:grid-cols-2">
+    <NavCard
+      @route="admin.db.requests"
+      @model={{@model.db}}
+      @title="Requests"
+      @description="All users' submission requests in this database."
+    />
+    <NavCard
+      @route="admin.db.submissions"
+      @model={{@model.db}}
+      @title="Submissions"
+      @description="All users' applied submissions in this database."
+    />
   </div>
 </template> satisfies TOC<{
   Args: {

--- a/web/app/templates/admin/index.gts
+++ b/web/app/templates/admin/index.gts
@@ -1,63 +1,44 @@
-import { LinkTo } from '@ember/routing';
 import { array, hash } from '@ember/helper';
 
 import Breadcrumb from 'repository/components/breadcrumb';
+import NavCard from 'repository/components/nav-card';
 
 <template>
   <Breadcrumb @items={{array (hash label="Home" route="index") (hash label="Administration")}} />
 
-  <h1 class="display-6 mb-4">Administration</h1>
+  <h1 class="mb-6 text-3xl font-light">Administration</h1>
 
-  <h2 class="h5 mt-4">Databases</h2>
+  <h2 class="mt-4 mb-3 text-base font-medium text-gray-500 uppercase">Databases</h2>
 
-  <div class="row g-3">
-    <div class="col-md-4">
-      <LinkTo @route="admin.db" @model="st26" class="card text-decoration-none h-100">
-        <div class="card-body">
-          <h3 class="card-title h5">ST.26</h3>
-          <p class="card-text text-body-secondary mb-0">Browse all users' requests and submissions.</p>
-        </div>
-      </LinkTo>
-    </div>
-
-    <div class="col-md-4">
-      <LinkTo @route="admin.db" @model="bioproject" class="card text-decoration-none h-100">
-        <div class="card-body">
-          <h3 class="card-title h5">BioProject</h3>
-          <p class="card-text text-body-secondary mb-0">Browse all users' requests and submissions.</p>
-        </div>
-      </LinkTo>
-    </div>
-
-    <div class="col-md-4">
-      <LinkTo @route="admin.db" @model="biosample" class="card text-decoration-none h-100">
-        <div class="card-body">
-          <h3 class="card-title h5">BioSample</h3>
-          <p class="card-text text-body-secondary mb-0">Browse all users' requests and submissions.</p>
-        </div>
-      </LinkTo>
-    </div>
+  <div class="grid gap-4 md:grid-cols-3">
+    <NavCard
+      @route="admin.db"
+      @model="st26"
+      @title="ST.26"
+      @description="Browse all users' requests and submissions."
+    />
+    <NavCard
+      @route="admin.db"
+      @model="bioproject"
+      @title="BioProject"
+      @description="Browse all users' requests and submissions."
+    />
+    <NavCard
+      @route="admin.db"
+      @model="biosample"
+      @title="BioSample"
+      @description="Browse all users' requests and submissions."
+    />
   </div>
 
-  <h2 class="h5 mt-5">Tools</h2>
+  <h2 class="mt-8 mb-3 text-base font-medium text-gray-500 uppercase">Tools</h2>
 
-  <div class="row g-3">
-    <div class="col-md-4">
-      <LinkTo @route="admin.proxy-login" class="card text-decoration-none h-100">
-        <div class="card-body">
-          <h3 class="card-title h5">Proxy Login</h3>
-          <p class="card-text text-body-secondary mb-0">Act on behalf of a D-way user.</p>
-        </div>
-      </LinkTo>
-    </div>
-
-    <div class="col-md-4">
-      <LinkTo @route="admin.regenerate-flatfiles" class="card text-decoration-none h-100">
-        <div class="card-body">
-          <h3 class="card-title h5">Regenerate Flatfiles</h3>
-          <p class="card-text text-body-secondary mb-0">Recreate flatfiles for all submissions.</p>
-        </div>
-      </LinkTo>
-    </div>
+  <div class="grid gap-4 md:grid-cols-3">
+    <NavCard @route="admin.proxy-login" @title="Proxy Login" @description="Act on behalf of a DDBJ Account user." />
+    <NavCard
+      @route="admin.regenerate-flatfiles"
+      @title="Regenerate Flatfiles"
+      @description="Recreate flatfiles for all submissions."
+    />
   </div>
 </template>

--- a/web/app/templates/db/index.gts
+++ b/web/app/templates/db/index.gts
@@ -1,7 +1,7 @@
-import { LinkTo } from '@ember/routing';
 import { array, hash } from '@ember/helper';
 
 import Breadcrumb from 'repository/components/breadcrumb';
+import NavCard from 'repository/components/nav-card';
 import dbLabel from 'repository/helpers/db-label';
 
 import type { TOC } from '@ember/component/template-only';
@@ -9,35 +9,27 @@ import type { TOC } from '@ember/component/template-only';
 export default <template>
   <Breadcrumb @items={{array (hash label="Home" route="index") (hash label=(dbLabel @model.db))}} />
 
-  <h1 class="display-6 mb-4">{{dbLabel @model.db}}</h1>
+  <h1 class="mb-6 text-3xl font-light">{{dbLabel @model.db}}</h1>
 
-  <div class="row g-3">
-    <div class="col-md-4">
-      <LinkTo @route="db.requests.new" @model={{@model.db}} class="card text-decoration-none h-100">
-        <div class="card-body">
-          <h2 class="card-title h5">Submit</h2>
-          <p class="card-text text-body-secondary mb-0">Upload a new DDBJ Record for validation.</p>
-        </div>
-      </LinkTo>
-    </div>
-
-    <div class="col-md-4">
-      <LinkTo @route="db.requests" @model={{@model.db}} class="card text-decoration-none h-100">
-        <div class="card-body">
-          <h2 class="card-title h5">Requests</h2>
-          <p class="card-text text-body-secondary mb-0">Submission requests in progress or awaiting application.</p>
-        </div>
-      </LinkTo>
-    </div>
-
-    <div class="col-md-4">
-      <LinkTo @route="db.submissions" @model={{@model.db}} class="card text-decoration-none h-100">
-        <div class="card-body">
-          <h2 class="card-title h5">Submissions</h2>
-          <p class="card-text text-body-secondary mb-0">Applied submissions and their accessions.</p>
-        </div>
-      </LinkTo>
-    </div>
+  <div class="grid gap-4 md:grid-cols-3">
+    <NavCard
+      @route="db.requests.new"
+      @model={{@model.db}}
+      @title="Submit"
+      @description="Upload a new DDBJ Record for validation."
+    />
+    <NavCard
+      @route="db.requests"
+      @model={{@model.db}}
+      @title="Requests"
+      @description="Submission requests in progress or awaiting application."
+    />
+    <NavCard
+      @route="db.submissions"
+      @model={{@model.db}}
+      @title="Submissions"
+      @description="Applied submissions and their accessions."
+    />
   </div>
 </template> satisfies TOC<{
   Args: {

--- a/web/app/templates/index.gts
+++ b/web/app/templates/index.gts
@@ -1,9 +1,10 @@
 import Component from '@glimmer/component';
-import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import { pageTitle } from 'ember-page-title';
 
 import ENV from 'repository/config/environment';
+
+import NavCard from 'repository/components/nav-card';
 
 import type CurrentUserService from 'repository/services/current-user';
 
@@ -16,35 +17,12 @@ export default class extends Component {
     {{pageTitle "DDBJ Repository"}}
 
     {{#if this.currentUser.isLoggedIn}}
-      <h1 class="display-6 mb-4">DDBJ Repository</h1>
+      <h1 class="mb-6 text-3xl font-light">DDBJ Repository</h1>
 
-      <div class="row g-3">
-        <div class="col-md-4">
-          <LinkTo @route="db" @model="st26" class="card text-decoration-none h-100">
-            <div class="card-body">
-              <h2 class="card-title h5">ST.26</h2>
-              <p class="card-text text-body-secondary mb-0">Patent sequence listings (ST.26 XML).</p>
-            </div>
-          </LinkTo>
-        </div>
-
-        <div class="col-md-4">
-          <LinkTo @route="db" @model="bioproject" class="card text-decoration-none h-100">
-            <div class="card-body">
-              <h2 class="card-title h5">BioProject</h2>
-              <p class="card-text text-body-secondary mb-0">Biological project metadata.</p>
-            </div>
-          </LinkTo>
-        </div>
-
-        <div class="col-md-4">
-          <LinkTo @route="db" @model="biosample" class="card text-decoration-none h-100">
-            <div class="card-body">
-              <h2 class="card-title h5">BioSample</h2>
-              <p class="card-text text-body-secondary mb-0">Biological sample metadata.</p>
-            </div>
-          </LinkTo>
-        </div>
+      <div class="grid gap-4 md:grid-cols-3">
+        <NavCard @route="db" @model="st26" @title="ST.26" @description="Patent sequence listings (ST.26 XML)." />
+        <NavCard @route="db" @model="bioproject" @title="BioProject" @description="Biological project metadata." />
+        <NavCard @route="db" @model="biosample" @title="BioSample" @description="Biological sample metadata." />
       </div>
     {{else}}
       <div class="flex justify-center py-12">


### PR DESCRIPTION
Stacked on #1816.

## Summary

- Introduce \`NavCard\`, a small Glimmer component for the link-card pattern.
- Use it on the five landing pages: home (logged-in branch), \`/:db\`, \`/admin\`, \`/admin/:db\`, \`account\`.
- Page titles drop \`.display-6\` for \`text-3xl font-light\`. \`/admin\` section subheadings use an uppercase muted style (\`text-base font-medium text-gray-500 uppercase\`) instead of an h-class.

Remaining Bootstrap-styled surfaces (list/detail pages, navbar, breadcrumb, badges, modal/toast) are left for follow-up PRs.

## Test plan

- [x] \`pnpm lint\` (clean)
- [x] \`pnpm test\` (13 runs)
- [x] \`pnpm build\` (clean)
- [ ] Smoke test each migrated landing in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)