### PR TITLE
Source admin users list from local users table

### DIFF
--- a/app/clients/cloakman_client.rb
+++ b/app/clients/cloakman_client.rb
@@ -4,7 +4,7 @@ class CloakmanClient
   end
 
   def search(query)
-    connection.get('api/users', {query:}.compact).body
+    connection.get('api/users', {query:}).body
   end
 
   def lookup(uids)

--- a/app/clients/cloakman_client.rb
+++ b/app/clients/cloakman_client.rb
@@ -3,12 +3,14 @@ class CloakmanClient
     @config = config
   end
 
-  def users(query: nil, uids: nil)
-    return [] if uids&.empty?
+  def search(query)
+    connection.get('api/users', {query:}.compact).body
+  end
 
-    res = connection.get('api/users', {query:, uids:}.compact)
+  def lookup(uids)
+    return [] if uids.empty?
 
-    res.body
+    connection.get('api/users/lookup', {uids:}).body
   end
 
   private

--- a/app/clients/cloakman_client.rb
+++ b/app/clients/cloakman_client.rb
@@ -3,8 +3,10 @@ class CloakmanClient
     @config = config
   end
 
-  def users(query: nil)
-    res = connection.get('api/users', {query:}.compact)
+  def users(query: nil, uids: nil)
+    return [] if uids&.empty?
+
+    res = connection.get('api/users', {query:, uids:}.compact)
 
     res.body
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,7 +1,16 @@
 module Admin
   class UsersController < ApplicationController
     def index
-      @users = CloakmanClient.new.users(query: params[:query].presence)
+      client = CloakmanClient.new
+
+      @users = if query = params[:query].presence
+        users           = client.users(query:)
+        registered_uids = User.where(uid: users.map { it['uid'] }).pluck(:uid).to_set
+
+        users.select { registered_uids.include?(it['uid']) }
+      else
+        client.users(uids: User.order(:uid).pluck(:uid))
+      end
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,15 +1,13 @@
 module Admin
   class UsersController < ApplicationController
     def index
-      client = CloakmanClient.new
-
       @users = if query = params[:query].presence
-        users           = client.users(query:)
+        users           = CloakmanClient.new.users(query:)
         registered_uids = User.where(uid: users.map { it['uid'] }).pluck(:uid).to_set
 
         users.select { registered_uids.include?(it['uid']) }
       else
-        client.users(uids: User.order(:uid).pluck(:uid))
+        CloakmanClient.new.users(uids: User.order(:uid).pluck(:uid))
       end
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,10 +2,10 @@ module Admin
   class UsersController < ApplicationController
     def index
       @users = if query = params[:query].presence
-        users           = CloakmanClient.new.users(query:)
-        registered_uids = User.where(uid: users.map { it['uid'] }).pluck(:uid).to_set
+        cloakman_users  = CloakmanClient.new.users(query:)
+        registered_uids = User.where(uid: cloakman_users.map { it['uid'] }).pluck(:uid).to_set
 
-        users.select { registered_uids.include?(it['uid']) }
+        cloakman_users.select { registered_uids.include?(it['uid']) }
       else
         CloakmanClient.new.users(uids: User.order(:uid).pluck(:uid))
       end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,12 +2,12 @@ module Admin
   class UsersController < ApplicationController
     def index
       @users = if query = params[:query].presence
-        cloakman_users  = CloakmanClient.new.users(query:)
+        cloakman_users  = CloakmanClient.new.search(query)
         registered_uids = User.where(uid: cloakman_users.map { it['uid'] }).pluck(:uid).to_set
 
         cloakman_users.select { registered_uids.include?(it['uid']) }
       else
-        CloakmanClient.new.users(uids: User.order(:uid).pluck(:uid))
+        CloakmanClient.new.lookup(User.order(:uid).pluck(:uid))
       end
     end
   end

--- a/test/integration/admin/users_test.rb
+++ b/test/integration/admin/users_test.rb
@@ -30,7 +30,7 @@ class AdminUsersTest < ActionDispatch::IntegrationTest
       }
     ]
 
-    stub = stub_request(:get, 'http://cloakman.example.com/api/users')
+    stub = stub_request(:get, 'http://cloakman.example.com/api/users/lookup')
       .with(query: {uids: %w[alice bob carol]}, headers: {Authorization: 'Bearer notasecret'})
       .to_return(status: 200, body: body.to_json, headers: {'Content-Type' => 'application/json'})
 

--- a/test/integration/admin/users_test.rb
+++ b/test/integration/admin/users_test.rb
@@ -2,12 +2,10 @@ require 'test_helper'
 
 class AdminUsersTest < ActionDispatch::IntegrationTest
   setup do
-    @admin = users(:alice).tap { it.update!(admin: true) }
-
-    default_headers['Authorization'] = "Bearer #{@admin.api_key}"
+    default_headers['Authorization'] = "Bearer #{users(:bob).api_key}"
   end
 
-  test 'index proxies to cloakman and returns user list' do
+  test 'index lists registered users with profile fetched from cloakman' do
     body = [
       {
         uid:                 'alice',
@@ -15,11 +13,25 @@ class AdminUsersTest < ActionDispatch::IntegrationTest
         email:               'alice@example.com',
         organization:        'Wonderland',
         account_type_number: 'general'
+      },
+      {
+        uid:                 'bob',
+        full_name:           'Bob Builder',
+        email:               'bob@example.com',
+        organization:        'Construction',
+        account_type_number: 'general'
+      },
+      {
+        uid:                 'carol',
+        full_name:           'Carol King',
+        email:               'carol@example.com',
+        organization:        'Music',
+        account_type_number: 'general'
       }
     ]
 
-    stub_request(:get, 'http://cloakman.example.com/api/users')
-      .with(headers: {Authorization: 'Bearer notasecret'})
+    stub = stub_request(:get, 'http://cloakman.example.com/api/users')
+      .with(query: {uids: %w[alice bob carol]}, headers: {Authorization: 'Bearer notasecret'})
       .to_return(status: 200, body: body.to_json, headers: {'Content-Type' => 'application/json'})
 
     get admin_users_path
@@ -27,17 +39,35 @@ class AdminUsersTest < ActionDispatch::IntegrationTest
     assert_conform_schema 200
 
     assert_equal body.map(&:stringify_keys), response.parsed_body
+    assert_requested stub
   end
 
-  test 'index forwards query param to cloakman' do
-    stub = stub_request(:get, 'http://cloakman.example.com/api/users')
+  test 'index filters cloakman search results to registered users only' do
+    body = [
+      {
+        uid:                 'alice',
+        full_name:           'Alice Liddell',
+        email:               'alice@example.com',
+        organization:        'Wonderland',
+        account_type_number: 'general'
+      },
+      {
+        uid:                 'alicia',
+        full_name:           'Alicia Keys',
+        email:               'alicia@example.com',
+        organization:        'Music',
+        account_type_number: 'general'
+      }
+    ]
+
+    stub_request(:get, 'http://cloakman.example.com/api/users')
       .with(query: {query: 'ali'})
-      .to_return(status: 200, body: '[]', headers: {'Content-Type' => 'application/json'})
+      .to_return(status: 200, body: body.to_json, headers: {'Content-Type' => 'application/json'})
 
     get admin_users_path, params: {query: 'ali'}
 
     assert_response :ok
-    assert_requested stub
+    assert_equal %w[alice], response.parsed_body.map { it['uid'] }
   end
 
   test 'index returns 403 for non-admin users' do


### PR DESCRIPTION
## Summary

- 管理画面のユーザ一覧 (`GET /admin/users`) のソースを cloakman 全件から「users テーブルに登録されているユーザ」に変更
- 追加情報（full_name / email / organization / account_type_number）は cloakman に bulk 問い合わせて補完
- 検索クエリありの場合は今まで通り cloakman の全文検索を使い、結果を users テーブル所属で絞り込む
- `CloakmanClient#users` を `#search(query)` と `#lookup(uids)` の 2 メソッドに分割（ddbj/cloakman#392 と対称）

## Why

「proxy login の対象」「権限付与の対象」は repository に登録があるユーザに限られるので、cloakman 全体（D-way ユーザ全員）を見せるより、登録済みユーザだけを出すほうが管理画面として使いやすい。

## Depends on

- ddbj/cloakman#392 — `GET /api/users/lookup` の新規アクション追加。先にこちらをマージ／デプロイする必要があります。

## Test plan

- [x] `test/integration/admin/users_test.rb` で query なし／query あり／非 admin の 3 ケースを更新（pass）
- [ ] cloakman#392 がデプロイされた環境で、admin として `/admin/users` を開いて users テーブルの全ユーザが出ること、検索で D-way だけのユーザが弾かれることを確認