### PR TITLE
Drop seconds from formatDatetime

### DIFF
--- a/web/app/helpers/format-datetime.ts
+++ b/web/app/helpers/format-datetime.ts
@@ -12,9 +12,8 @@ export default function formatDatetime(date: Date | string | null): string {
   const _date = padZero(date.getDate());
   const hours = padZero(date.getHours());
   const minutes = padZero(date.getMinutes());
-  const seconds = padZero(date.getSeconds());
 
-  return `${year}-${month}-${_date} ${hours}:${minutes}:${seconds}`;
+  return `${year}-${month}-${_date} ${hours}:${minutes}`;
 }
 
 function padZero(n: number) {

--- a/web/tests/integration/helpers/format-datetime-test.gts
+++ b/web/tests/integration/helpers/format-datetime-test.gts
@@ -12,7 +12,7 @@ module('Integration | Helper | format-datetime', function (hooks) {
 
     await render(<template>{{formatDatetime date}}</template>);
 
-    assert.dom().hasText('2024-01-02 03:04:56');
+    assert.dom().hasText('2024-01-02 03:04');
   });
 
   test('string', async function (assert) {
@@ -20,6 +20,6 @@ module('Integration | Helper | format-datetime', function (hooks) {
 
     await render(<template>{{formatDatetime date}}</template>);
 
-    assert.dom().hasText('2024-01-02 03:04:56');
+    assert.dom().hasText('2024-01-02 03:04');
   });
 });


### PR DESCRIPTION
## Summary

- `formatDatetime` ヘルパーを「分まで」表示に固定（`YYYY-MM-DD HH:mm`）。秒は削除
- 全呼び出し側 (admin 一覧 / db 一覧 / submission/request/update 詳細など) が自動的に分まで表示になる
- helper test の期待値を更新

## Why

Submission の作成・更新時刻は時系列の把握が目的で、秒の粒度は実用上意味がない（処理時間を測りたい用途ではない）。表示をシンプルに。

## Test plan

- [x] `pnpm test:ember` 19/19 pass
- [x] `pnpm lint` clean