### PR TITLE
Add activity counts to admin users views

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,8 +1,10 @@
 module Admin
   class UsersController < ApplicationController
     def index
+      include_inactive = ActiveModel::Type::Boolean.new.cast(params[:include_inactive])
+
       scope = User.order(:uid)
-      scope = scope.with_submission_requests unless params[:include_inactive] == '1'
+      scope = scope.with_submission_requests unless include_inactive
 
       @users = scope.to_a
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,19 +1,39 @@
 module Admin
   class UsersController < ApplicationController
     def index
-      @users = if query = params[:query].presence
-        cloakman_users  = CloakmanClient.new.search(query)
-        registered_uids = User.where(uid: cloakman_users.map { it['uid'] }).pluck(:uid).to_set
+      scope = User.order(:uid)
+      scope = scope.with_submission_requests unless params[:include_inactive] == '1'
 
-        cloakman_users.select { registered_uids.include?(it['uid']) }
+      @users = scope.to_a
+
+      uids = @users.map(&:uid)
+
+      @profiles = if query = params[:query].presence
+        registered = uids.to_set
+        CloakmanClient.new.search(query).select { registered.include?(it['uid']) }
       else
-        CloakmanClient.new.lookup(User.order(:uid).pluck(:uid))
+        CloakmanClient.new.lookup(uids)
       end
+
+      @counts = activity_counts(@users.map(&:id))
     end
 
     def show
       @user    = User.find_by!(uid: params[:uid])
       @profile = CloakmanClient.new.lookup([@user.uid]).first or raise ActiveRecord::RecordNotFound
+
+      @counts = activity_counts([@user.id])
+    end
+
+    private
+
+    def activity_counts(user_ids)
+      scope = SubmissionRequest.where(user_id: user_ids)
+
+      {
+        requests:    scope.group(:user_id).count,
+        submissions: scope.where.not(submission_id: nil).group(:user_id).count
+      }
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
   has_many :submissions,        through: :submission_requests
   has_many :submission_updates, through: :submissions, source: :updates
 
+  scope :with_submission_requests, -> { where(id: SubmissionRequest.select(:user_id)) }
+
   before_create do |user|
     user.api_key ||= self.class.generate_api_key
   end

--- a/app/views/admin/users/index.json.jb
+++ b/app/views/admin/users/index.json.jb
@@ -1,1 +1,12 @@
-@users
+users_by_uid = @users.index_by(&:uid)
+
+@profiles.map {|profile|
+  user = users_by_uid.fetch(profile['uid'])
+
+  {
+    **profile,
+
+    submission_requests_count: @counts[:requests][user.id]    || 0,
+    submissions_count:         @counts[:submissions][user.id] || 0
+  }
+}

--- a/app/views/admin/users/show.json.jb
+++ b/app/views/admin/users/show.json.jb
@@ -1,5 +1,7 @@
 {
   **@profile.slice('uid', 'full_name', 'email', 'organization', 'account_type_number'),
 
-  admin: @user.admin
+  admin:                     @user.admin,
+  submission_requests_count: @counts[:requests][@user.id]    || 0,
+  submissions_count:         @counts[:submissions][@user.id] || 0
 }

--- a/schema/openapi.d.ts
+++ b/schema/openapi.d.ts
@@ -680,6 +680,8 @@ export interface paths {
                 query?: {
                     /** @description Partial match against uid, email, and full name. */
                     query?: string;
+                    /** @description Include users without any submission requests or submissions. */
+                    include_inactive?: "1";
                 };
                 header?: never;
                 path?: never;
@@ -828,6 +830,8 @@ export interface components {
             email: string | null;
             organization: string | null;
             account_type_number: string;
+            submission_requests_count: number;
+            submissions_count: number;
         };
         AdminUserDetail: {
             uid: string;
@@ -836,6 +840,8 @@ export interface components {
             organization: string | null;
             account_type_number: string;
             admin: boolean;
+            submission_requests_count: number;
+            submissions_count: number;
         };
         SubmissionRequestSummary: {
             id: number;

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -574,6 +574,14 @@ paths:
           schema:
             type: string
 
+        - name: include_inactive
+          in: query
+          description: Include users without any submission requests or submissions.
+
+          schema:
+            type: string
+            enum: ['1']
+
       responses:
         '200':
           description: Returns the list of users.
@@ -762,6 +770,8 @@ components:
         - email
         - organization
         - account_type_number
+        - submission_requests_count
+        - submissions_count
 
       properties:
         uid:
@@ -785,6 +795,12 @@ components:
         account_type_number:
           type: string
 
+        submission_requests_count:
+          type: number
+
+        submissions_count:
+          type: number
+
     AdminUserDetail:
       type: object
       additionalProperties: false
@@ -796,6 +812,8 @@ components:
         - organization
         - account_type_number
         - admin
+        - submission_requests_count
+        - submissions_count
 
       properties:
         uid:
@@ -821,6 +839,12 @@ components:
 
         admin:
           type: boolean
+
+        submission_requests_count:
+          type: number
+
+        submissions_count:
+          type: number
 
     SubmissionRequestSummary:
       type: object

--- a/test/integration/admin/users_test.rb
+++ b/test/integration/admin/users_test.rb
@@ -5,64 +5,62 @@ class AdminUsersTest < ActionDispatch::IntegrationTest
     default_headers['Authorization'] = "Bearer #{users(:bob).api_key}"
   end
 
-  test 'index lists registered users with profile fetched from cloakman' do
-    body = [
-      {
-        uid:                 'alice',
-        full_name:           'Alice Liddell',
-        email:               'alice@example.com',
-        organization:        'Wonderland',
-        account_type_number: 'general'
-      },
-      {
-        uid:                 'bob',
-        full_name:           'Bob Builder',
-        email:               'bob@example.com',
-        organization:        'Construction',
-        account_type_number: 'general'
-      },
-      {
-        uid:                 'carol',
-        full_name:           'Carol King',
-        email:               'carol@example.com',
-        organization:        'Music',
-        account_type_number: 'general'
-      }
-    ]
-
-    stub = stub_request(:get, 'http://cloakman.example.com/api/users/lookup')
-      .with(query: {uids: %w[alice bob carol]}, headers: {Authorization: 'Bearer notasecret'})
-      .to_return(status: 200, body: body.to_json, headers: {'Content-Type' => 'application/json'})
+  test 'index lists active users with profile fetched from cloakman' do
+    stub_request(:get, 'http://cloakman.example.com/api/users/lookup')
+      .with(query: {uids: %w[alice]})
+      .to_return(
+        status:  200,
+        body:    [{uid: 'alice', full_name: 'Alice Liddell', email: 'alice@example.com', organization: 'Wonderland', account_type_number: 'general'}].to_json,
+        headers: {'Content-Type' => 'application/json'}
+      )
 
     get admin_users_path
 
     assert_conform_schema 200
 
-    assert_equal body.map(&:stringify_keys), response.parsed_body
-    assert_requested stub
+    body = response.parsed_body
+
+    assert_equal %w[alice],         body.map { it['uid'] }
+    assert_equal 'Alice Liddell',   body.first['full_name']
+    assert_equal 3,                 body.first['submission_requests_count']
+    assert_equal 3,                 body.first['submissions_count']
   end
 
-  test 'index filters cloakman search results to registered users only' do
-    body = [
-      {
-        uid:                 'alice',
-        full_name:           'Alice Liddell',
-        email:               'alice@example.com',
-        organization:        'Wonderland',
-        account_type_number: 'general'
-      },
-      {
-        uid:                 'alicia',
-        full_name:           'Alicia Keys',
-        email:               'alicia@example.com',
-        organization:        'Music',
-        account_type_number: 'general'
-      }
-    ]
+  test 'index includes inactive users when include_inactive=1' do
+    stub_request(:get, 'http://cloakman.example.com/api/users/lookup')
+      .with(query: {uids: %w[alice bob carol]})
+      .to_return(
+        status:  200,
+        body:    [
+          {uid: 'alice', full_name: 'Alice Liddell', email: 'alice@example.com', organization: 'Wonderland',   account_type_number: 'general'},
+          {uid: 'bob',   full_name: 'Bob Builder',   email: 'bob@example.com',   organization: 'Construction', account_type_number: 'general'},
+          {uid: 'carol', full_name: 'Carol King',    email: 'carol@example.com', organization: 'Music',        account_type_number: 'general'}
+        ].to_json,
+        headers: {'Content-Type' => 'application/json'}
+      )
 
+    get admin_users_path, params: {include_inactive: '1'}
+
+    assert_response :ok
+
+    body = response.parsed_body
+
+    assert_equal %w[alice bob carol], body.map { it['uid'] }
+    assert_equal 0,                   body.find { it['uid'] == 'bob' }['submission_requests_count']
+    assert_equal 0,                   body.find { it['uid'] == 'carol' }['submissions_count']
+  end
+
+  test 'index filters cloakman search results to registered active users' do
     stub_request(:get, 'http://cloakman.example.com/api/users')
       .with(query: {query: 'ali'})
-      .to_return(status: 200, body: body.to_json, headers: {'Content-Type' => 'application/json'})
+      .to_return(
+        status:  200,
+        body:    [
+          {uid: 'alice',  full_name: 'Alice Liddell', email: 'alice@example.com',  organization: 'Wonderland', account_type_number: 'general'},
+          {uid: 'alicia', full_name: 'Alicia Keys',   email: 'alicia@example.com', organization: 'Music',      account_type_number: 'general'}
+        ].to_json,
+        headers: {'Content-Type' => 'application/json'}
+      )
 
     get admin_users_path, params: {query: 'ali'}
 
@@ -70,7 +68,7 @@ class AdminUsersTest < ActionDispatch::IntegrationTest
     assert_equal %w[alice], response.parsed_body.map { it['uid'] }
   end
 
-  test 'show returns the user profile combined with the admin flag' do
+  test 'show returns the user profile combined with the admin flag and counts' do
     stub_request(:get, 'http://cloakman.example.com/api/users/lookup')
       .with(query: {uids: %w[alice]})
       .to_return(
@@ -86,6 +84,8 @@ class AdminUsersTest < ActionDispatch::IntegrationTest
     assert_equal 'alice',         response.parsed_body['uid']
     assert_equal 'Alice Liddell', response.parsed_body['full_name']
     assert_equal false,           response.parsed_body['admin']
+    assert_equal 3,               response.parsed_body['submission_requests_count']
+    assert_equal 3,               response.parsed_body['submissions_count']
   end
 
   test 'show returns 404 when the user is not registered locally' do

--- a/web/app/controllers/admin/users/index.ts
+++ b/web/app/controllers/admin/users/index.ts
@@ -2,7 +2,8 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
 export default class extends Controller {
-  queryParams = ['query'];
+  queryParams = ['query', 'include_inactive'];
 
   @tracked query = '';
+  @tracked include_inactive = '';
 }

--- a/web/app/routes/admin/users/index.ts
+++ b/web/app/routes/admin/users/index.ts
@@ -10,16 +10,14 @@ export default class extends Route {
   @service declare requestManager: RequestManager;
 
   queryParams = {
-    query: {
-      refreshModel: true,
-      replace: true,
-    },
+    query: { refreshModel: true, replace: true },
+    include_inactive: { refreshModel: true, replace: true },
   };
 
-  async model({ query }: { query?: string }) {
+  async model({ query, include_inactive }: { query?: string; include_inactive?: string }) {
     const { content } = await this.requestManager.request<AdminUsers>({
       url: '/admin/users',
-      options: { params: { query } },
+      options: { params: { query, include_inactive } },
     });
 
     return {

--- a/web/app/templates/admin/users/index.gts
+++ b/web/app/templates/admin/users/index.gts
@@ -6,6 +6,7 @@ import { service } from '@ember/service';
 import { array, hash, uniqueId } from '@ember/helper';
 
 import { pageTitle } from 'ember-page-title';
+import { eq } from 'ember-truth-helpers';
 
 import Breadcrumb from 'repository/components/breadcrumb';
 
@@ -28,6 +29,11 @@ class UsersIndex extends Component<{ Args: { model: Model; controller: Controlle
     const value = new FormData(form).get('query');
 
     this.args.controller.query = typeof value === 'string' ? value : '';
+  }
+
+  @action
+  toggleInactive(e: Event) {
+    this.args.controller.include_inactive = (e.target as HTMLInputElement).checked ? '1' : '';
   }
 
   <template>
@@ -75,6 +81,21 @@ class UsersIndex extends Component<{ Args: { model: Model; controller: Controlle
       {{/let}}
     </form>
 
+    <div class="form-check mb-3">
+      {{#let (uniqueId) as |id|}}
+        <input
+          type="checkbox"
+          id={{id}}
+          class="form-check-input"
+          checked={{eq @controller.include_inactive "1"}}
+          {{on "change" this.toggleInactive}}
+        />
+        <label for={{id}} class="form-check-label">
+          Include users without submission requests
+        </label>
+      {{/let}}
+    </div>
+
     <p class="text-body-secondary small">
       Up to 100 users are shown. Refine your search if you don't see the user you're looking for.
     </p>
@@ -87,6 +108,8 @@ class UsersIndex extends Component<{ Args: { model: Model; controller: Controlle
           <th>Email</th>
           <th>Organization</th>
           <th>Account type</th>
+          <th class="text-end">Requests</th>
+          <th class="text-end">Submissions</th>
         </tr>
       </thead>
 
@@ -106,10 +129,12 @@ class UsersIndex extends Component<{ Args: { model: Model; controller: Controlle
             <td>{{user.email}}</td>
             <td>{{user.organization}}</td>
             <td>{{user.account_type_number}}</td>
+            <td class="text-end">{{user.submission_requests_count}}</td>
+            <td class="text-end">{{user.submissions_count}}</td>
           </tr>
         {{else}}
           <tr>
-            <td colspan="5" class="text-center text-body-secondary py-4">No users found.</td>
+            <td colspan="7" class="text-center text-body-secondary py-4">No users found.</td>
           </tr>
         {{/each}}
       </tbody>

--- a/web/app/templates/admin/users/user.gts
+++ b/web/app/templates/admin/users/user.gts
@@ -64,7 +64,7 @@ class AdminUserDetailPage extends Component<{ Args: { model: Model } }> {
       <div class="col-md-6">
         <LinkTo @route="admin.requests" @query={{hash user=@model.uid}} class="card text-decoration-none h-100">
           <div class="card-body">
-            <h3 class="card-title h6">Submission requests</h3>
+            <h3 class="card-title h6">Submission requests ({{@model.submission_requests_count}})</h3>
             <p class="card-text text-body-secondary mb-0">View this user's submission requests.</p>
           </div>
         </LinkTo>
@@ -73,7 +73,7 @@ class AdminUserDetailPage extends Component<{ Args: { model: Model } }> {
       <div class="col-md-6">
         <LinkTo @route="admin.submissions" @query={{hash user=@model.uid}} class="card text-decoration-none h-100">
           <div class="card-body">
-            <h3 class="card-title h6">Submissions</h3>
+            <h3 class="card-title h6">Submissions ({{@model.submissions_count}})</h3>
             <p class="card-text text-body-secondary mb-0">View this user's applied submissions.</p>
           </div>
         </LinkTo>

--- a/web/tests/acceptance/admin/users-test.gts
+++ b/web/tests/acceptance/admin/users-test.gts
@@ -10,48 +10,37 @@ import { worker } from '../../msw/worker';
 
 const userURL = `${ENV.apiURL}/admin/users/alice`;
 
+const profile = {
+  uid: 'alice',
+  full_name: 'Alice Liddell',
+  email: 'alice@example.com',
+  organization: 'Wonderland',
+  account_type_number: 'general',
+  admin: false,
+  submission_requests_count: 5,
+  submissions_count: 3,
+};
+
 module('Acceptance | admin | user detail', function (hooks) {
   setupApplicationTest(hooks);
   setupAuthentication(hooks, { admin: true });
 
-  test('renders the cloakman profile and activity links', async (assert) => {
-    worker.use(
-      mswHttp.get(userURL, () => {
-        return HttpResponse.json({
-          uid: 'alice',
-          full_name: 'Alice Liddell',
-          email: 'alice@example.com',
-          organization: 'Wonderland',
-          account_type_number: 'general',
-          admin: false,
-        });
-      }),
-    );
+  hooks.beforeEach(() => {
+    worker.use(mswHttp.get(userURL, () => HttpResponse.json(profile)));
+  });
 
+  test('renders the cloakman profile and activity links with counts', async (assert) => {
     await visit('/admin/users/alice');
 
     assert.dom('h1').hasText('alice');
     assert.dom('dl').includesText('Alice Liddell');
     assert.dom('dl').includesText('alice@example.com');
     assert.dom('dl').includesText('Wonderland');
-    assert.dom('a[href*="/admin/requests"]').exists();
-    assert.dom('a[href*="/admin/submissions"]').exists();
+    assert.dom('a[href*="/admin/requests"]').includesText('Submission requests (5)');
+    assert.dom('a[href*="/admin/submissions"]').includesText('Submissions (3)');
   });
 
   test('proxy login toggle activates and deactivates', async (assert) => {
-    worker.use(
-      mswHttp.get(userURL, () => {
-        return HttpResponse.json({
-          uid: 'alice',
-          full_name: 'Alice Liddell',
-          email: 'alice@example.com',
-          organization: 'Wonderland',
-          account_type_number: 'general',
-          admin: false,
-        });
-      }),
-    );
-
     await visit('/admin/users/alice');
 
     assert.dom('main button').includesText('Proxy login as alice');


### PR DESCRIPTION
## Summary

- admin/users 一覧と詳細に **submission_requests_count / submissions_count** を表示
- デフォルトは「submission_request を持つ user のみ表示」(activity ある user だけ)
- 一覧上部に **"Include users without submission requests"** checkbox を追加 (`?include_inactive=1` で全件表示)
- 詳細ページの Activity リンクに `Submission requests (N)` / `Submissions (N)` の数を表示

## Changes

### API
- `User.with_submission_requests` scope (`where(id: SubmissionRequest.select(:user_id))`)
- `Admin::UsersController#index`: scope に include_inactive 条件、counts 集計
- `Admin::UsersController#show`: 同 user の counts も返す
- `activity_counts(user_ids)` は 1 つの SubmissionRequest クエリで request 数と submission 数 (`submission_id IS NOT NULL`) を集計し `{requests:, submissions:}` の hash を返す
- OpenAPI: AdminUserSummary / AdminUserDetail に 2 つの count フィールド、`include_inactive` query parameter (enum: `['1']`)
- integration test: default は activity あり user のみ、include_inactive=1 で全件、counts の値検証

### Web
- 一覧テンプレ: Requests / Submissions カラム追加、checkbox + queryParams `include_inactive`
- 詳細テンプレ: Activity カードのタイトルに `(count)`
- acceptance test: 詳細の counts 表示を検証

## Test plan

- [x] `bin/rails test` (91/91 pass)
- [x] `cd web && pnpm test:ember` (21/21 pass)
- [x] `cd web && pnpm lint` clean
- [ ] staging デプロイ後にブラウザで checkbox 切替 + counts 表示を確認 (dev は CLOAKMAN_API_TOKEN 未設定で 500 のため skip)