### PR TITLE
Let admins share notes per user

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -31,7 +31,7 @@ module Admin
       user = User.find_by!(uid: params[:uid])
       user.update!(params.expect(user: [:notes]))
 
-      head :no_content
+      render json: {notes: user.notes}
     end
 
     private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -27,6 +27,13 @@ module Admin
       @counts = activity_counts([@user.id])
     end
 
+    def update
+      user = User.find_by!(uid: params[:uid])
+      user.update!(params.expect(user: [:notes]))
+
+      head :no_content
+    end
+
     private
 
     def activity_counts(user_ids)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class UsersController < ApplicationController
+    before_action :load_user_detail, only: %i[show update]
+
     def index
       include_inactive = ActiveModel::Type::Boolean.new.cast(params[:include_inactive])
 
@@ -20,21 +22,22 @@ module Admin
       @counts = activity_counts(@users.map(&:id))
     end
 
-    def show
+    def show; end
+
+    def update
+      @user.update!(params.expect(user: [:notes]))
+
+      render :show
+    end
+
+    private
+
+    def load_user_detail
       @user    = User.find_by!(uid: params[:uid])
       @profile = CloakmanClient.new.lookup([@user.uid]).first or raise ActiveRecord::RecordNotFound
 
       @counts = activity_counts([@user.id])
     end
-
-    def update
-      user = User.find_by!(uid: params[:uid])
-      user.update!(params.expect(user: [:notes]))
-
-      render json: {notes: user.notes}
-    end
-
-    private
 
     def activity_counts(user_ids)
       scope = SubmissionRequest.where(user_id: user_ids)

--- a/app/views/admin/users/show.json.jb
+++ b/app/views/admin/users/show.json.jb
@@ -2,6 +2,7 @@
   **@profile.slice('uid', 'full_name', 'email', 'organization', 'account_type_number'),
 
   admin:                     @user.admin,
+  notes:                     @user.notes,
   submission_requests_count: @counts[:requests][@user.id]    || 0,
   submissions_count:         @counts[:submissions][@user.id] || 0
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
     namespace :admin do
       resources :submission_requests, only: %i[index]
       resources :submissions,         only: %i[index]
-      resources :users,               only: %i[index show], param: :uid
+      resources :users,               only: %i[index show update], param: :uid
 
       resource :regenerate_flatfiles, only: %i[show create]
     end

--- a/db/migrate/20260519042408_add_notes_to_users.rb
+++ b/db/migrate/20260519042408_add_notes_to_users.rb
@@ -1,0 +1,5 @@
+class AddNotesToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :notes, :text, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_28_071540) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_19_042408) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -115,6 +115,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_28_071540) do
     t.boolean "admin", default: false, null: false
     t.string "api_key", null: false
     t.datetime "created_at", null: false
+    t.text "notes", default: "", null: false
     t.string "uid", null: false
     t.datetime "updated_at", null: false
     t.index ["api_key"], name: "index_users_on_api_key", unique: true

--- a/schema/openapi.d.ts
+++ b/schema/openapi.d.ts
@@ -770,15 +770,13 @@ export interface paths {
                 };
             };
             responses: {
-                /** @description Returns the updated notes. */
+                /** @description Returns the updated user detail. */
                 200: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            notes: string;
-                        };
+                        "application/json": components["schemas"]["AdminUserDetail"];
                     };
                 };
                 401: components["responses"]["Unauthorized"];

--- a/schema/openapi.d.ts
+++ b/schema/openapi.d.ts
@@ -770,12 +770,16 @@ export interface paths {
                 };
             };
             responses: {
-                /** @description The notes were updated. */
-                204: {
+                /** @description Returns the updated notes. */
+                200: {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content?: never;
+                    content: {
+                        "application/json": {
+                            notes: string;
+                        };
+                    };
                 };
                 401: components["responses"]["Unauthorized"];
                 403: components["responses"]["Forbidden"];

--- a/schema/openapi.d.ts
+++ b/schema/openapi.d.ts
@@ -750,7 +750,38 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        /** @description Update admin-editable fields on the DDBJ account. */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    uid: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        user: {
+                            notes?: string;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description The notes were updated. */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
         trace?: never;
     };
     "/admin/submissions": {
@@ -840,6 +871,7 @@ export interface components {
             organization: string | null;
             account_type_number: string;
             admin: boolean;
+            notes: string;
             submission_requests_count: number;
             submissions_count: number;
         };

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -633,6 +633,44 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+    patch:
+      description: Update admin-editable fields on the DDBJ account.
+
+      tags:
+        - Admin
+
+      requestBody:
+        required: true
+
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [user]
+
+              properties:
+                user:
+                  type: object
+                  additionalProperties: false
+
+                  properties:
+                    notes:
+                      type: string
+
+      responses:
+        '204':
+          description: The notes were updated.
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /admin/submissions:
     get:
       description: Admin-only list of submissions across all DBs and users.
@@ -812,6 +850,7 @@ components:
         - organization
         - account_type_number
         - admin
+        - notes
         - submission_requests_count
         - submissions_count
 
@@ -839,6 +878,9 @@ components:
 
         admin:
           type: boolean
+
+        notes:
+          type: string
 
         submission_requests_count:
           type: number

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -659,8 +659,19 @@ paths:
                       type: string
 
       responses:
-        '204':
-          description: The notes were updated.
+        '200':
+          description: Returns the updated notes.
+
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [notes]
+
+                properties:
+                  notes:
+                    type: string
 
         '401':
           $ref: '#/components/responses/Unauthorized'

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -660,18 +660,12 @@ paths:
 
       responses:
         '200':
-          description: Returns the updated notes.
+          description: Returns the updated user detail.
 
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: false
-                required: [notes]
-
-                properties:
-                  notes:
-                    type: string
+                $ref: '#/components/schemas/AdminUserDetail'
 
         '401':
           $ref: '#/components/responses/Unauthorized'

--- a/test/integration/admin/users_test.rb
+++ b/test/integration/admin/users_test.rb
@@ -113,13 +113,22 @@ class AdminUsersTest < ActionDispatch::IntegrationTest
     assert_equal 'Existing note', response.parsed_body['notes']
   end
 
-  test 'update persists notes and echoes them back' do
+  test 'update persists notes and returns the refreshed detail' do
+    stub_request(:get, 'http://cloakman.example.com/api/users/lookup')
+      .with(query: {uids: %w[alice]})
+      .to_return(
+        status:  200,
+        body:    [{uid: 'alice', full_name: 'Alice Liddell', email: 'alice@example.com', organization: 'Wonderland', account_type_number: 'general'}].to_json,
+        headers: {'Content-Type' => 'application/json'}
+      )
+
     patch admin_user_path(uid: 'alice'), params: {user: {notes: 'Be careful with this account.'}}, as: :json
 
     assert_conform_schema 200
 
-    assert_equal 'Be careful with this account.', response.parsed_body['notes']
-    assert_equal 'Be careful with this account.', users(:alice).reload.notes
+    assert_equal 'alice',                          response.parsed_body['uid']
+    assert_equal 'Be careful with this account.',  response.parsed_body['notes']
+    assert_equal 'Be careful with this account.',  users(:alice).reload.notes
   end
 
   test 'update returns 403 for non-admin users' do

--- a/test/integration/admin/users_test.rb
+++ b/test/integration/admin/users_test.rb
@@ -96,6 +96,40 @@ class AdminUsersTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test 'show includes the persisted notes' do
+    users(:alice).update!(notes: 'Existing note')
+
+    stub_request(:get, 'http://cloakman.example.com/api/users/lookup')
+      .with(query: {uids: %w[alice]})
+      .to_return(
+        status:  200,
+        body:    [{uid: 'alice', full_name: 'Alice Liddell', email: 'alice@example.com', organization: 'Wonderland', account_type_number: 'general'}].to_json,
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    get admin_user_path(uid: 'alice')
+
+    assert_response :ok
+    assert_equal 'Existing note', response.parsed_body['notes']
+  end
+
+  test 'update persists notes' do
+    patch admin_user_path(uid: 'alice'), params: {user: {notes: 'Be careful with this account.'}}, as: :json
+
+    assert_response :no_content
+    assert_equal 'Be careful with this account.', users(:alice).reload.notes
+  end
+
+  test 'update returns 403 for non-admin users' do
+    default_headers['Authorization'] = "Bearer #{users(:carol).api_key}"
+
+    with_exceptions_app do
+      patch admin_user_path(uid: 'alice'), params: {user: {notes: 'nope'}}, as: :json
+    end
+
+    assert_response :forbidden
+  end
+
   test 'show returns 404 when cloakman has no matching profile' do
     stub_request(:get, 'http://cloakman.example.com/api/users/lookup')
       .with(query: {uids: %w[alice]})

--- a/test/integration/admin/users_test.rb
+++ b/test/integration/admin/users_test.rb
@@ -113,10 +113,12 @@ class AdminUsersTest < ActionDispatch::IntegrationTest
     assert_equal 'Existing note', response.parsed_body['notes']
   end
 
-  test 'update persists notes' do
+  test 'update persists notes and echoes them back' do
     patch admin_user_path(uid: 'alice'), params: {user: {notes: 'Be careful with this account.'}}, as: :json
 
-    assert_response :no_content
+    assert_conform_schema 200
+
+    assert_equal 'Be careful with this account.', response.parsed_body['notes']
     assert_equal 'Be careful with this account.', users(:alice).reload.notes
   end
 

--- a/web/app/templates/admin/users/user.gts
+++ b/web/app/templates/admin/users/user.gts
@@ -14,17 +14,16 @@ import Breadcrumb from 'repository/components/breadcrumb';
 
 import type { RequestManager } from '@warp-drive/core';
 import type Owner from '@ember/owner';
-import type RouterService from '@ember/routing/router-service';
 import type CurrentUserService from 'repository/services/current-user';
 import type ToastService from 'repository/services/toast';
-import type { components } from 'schema/openapi';
+import type { components, paths } from 'schema/openapi';
 
 type Model = components['schemas']['AdminUserDetail'];
+type UpdateResponse = paths['/admin/users/{uid}']['patch']['responses']['200']['content']['application/json'];
 
 class AdminUserDetailPage extends Component<{ Args: { model: Model } }> {
   @service declare currentUser: CurrentUserService;
   @service declare requestManager: RequestManager;
-  @service declare router: RouterService;
   @service declare toast: ToastService;
 
   @tracked notes: string;
@@ -43,15 +42,16 @@ class AdminUserDetailPage extends Component<{ Args: { model: Model } }> {
   async saveNotes(e: Event) {
     e.preventDefault();
 
-    await this.requestManager.request({
+    const { content } = await this.requestManager.request<UpdateResponse>({
       url: `/admin/users/${encodeURIComponent(this.args.model.uid)}`,
       method: 'PATCH',
       data: { user: { notes: this.notes } },
     });
 
-    this.toast.show('Notes saved.', 'success');
+    this.args.model.notes = content.notes;
+    this.notes = content.notes;
 
-    await this.router.refresh();
+    this.toast.show('Notes saved.', 'success');
   }
 
   <template>

--- a/web/app/templates/admin/users/user.gts
+++ b/web/app/templates/admin/users/user.gts
@@ -1,24 +1,57 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';
-import { array, hash } from '@ember/helper';
+import { Textarea } from '@ember/component';
+import { tracked } from '@glimmer/tracking';
+import { array, hash, uniqueId } from '@ember/helper';
 
 import { pageTitle } from 'ember-page-title';
 
 import Breadcrumb from 'repository/components/breadcrumb';
 
+import type { RequestManager } from '@warp-drive/core';
+import type Owner from '@ember/owner';
+import type RouterService from '@ember/routing/router-service';
 import type CurrentUserService from 'repository/services/current-user';
+import type ToastService from 'repository/services/toast';
 import type { components } from 'schema/openapi';
 
 type Model = components['schemas']['AdminUserDetail'];
 
 class AdminUserDetailPage extends Component<{ Args: { model: Model } }> {
   @service declare currentUser: CurrentUserService;
+  @service declare requestManager: RequestManager;
+  @service declare router: RouterService;
+  @service declare toast: ToastService;
+
+  @tracked notes: string;
+
+  constructor(owner: Owner, args: { model: Model }) {
+    super(owner, args);
+
+    this.notes = args.model.notes;
+  }
 
   get isActiveProxy() {
     return this.currentUser.isProxyLoggedInAs(this.args.model.uid);
+  }
+
+  @action
+  async saveNotes(e: Event) {
+    e.preventDefault();
+
+    await this.requestManager.request({
+      url: `/admin/users/${encodeURIComponent(this.args.model.uid)}`,
+      method: 'PATCH',
+      data: { user: { notes: this.notes } },
+    });
+
+    this.toast.show('Notes saved.', 'success');
+
+    await this.router.refresh();
   }
 
   <template>
@@ -79,6 +112,25 @@ class AdminUserDetailPage extends Component<{ Args: { model: Model } }> {
         </LinkTo>
       </div>
     </div>
+
+    <h2 class="h5 mt-4">Notes</h2>
+
+    <form class="mb-4" {{on "submit" this.saveNotes}}>
+      {{#let (uniqueId) as |id|}}
+        <label for={{id}} class="visually-hidden">Notes</label>
+
+        <Textarea
+          @value={{this.notes}}
+          name="notes"
+          id={{id}}
+          rows="6"
+          class="form-control mb-2"
+          placeholder="Share context with other administrators (e.g. past correspondence)."
+        />
+
+        <button type="submit" class="btn btn-primary">Save</button>
+      {{/let}}
+    </form>
 
     <h2 class="h5 mt-4">Proxy login</h2>
 

--- a/web/app/templates/admin/users/user.gts
+++ b/web/app/templates/admin/users/user.gts
@@ -48,7 +48,7 @@ class AdminUserDetailPage extends Component<{ Args: { model: Model } }> {
       data: { user: { notes: this.notes } },
     });
 
-    this.args.model.notes = content.notes;
+    Object.assign(this.args.model, content);
     this.notes = content.notes;
 
     this.toast.show('Notes saved.', 'success');

--- a/web/tests/acceptance/admin/users-test.gts
+++ b/web/tests/acceptance/admin/users-test.gts
@@ -41,20 +41,12 @@ module('Acceptance | admin | user detail', function (hooks) {
     assert.dom('a[href*="/admin/submissions"]').includesText('Submissions (3)');
   });
 
-  test('saves notes via PATCH and refreshes the model', async (assert) => {
-    let savedNotes = '';
-
+  test('saves notes via PATCH and writes the response back into the model', async (assert) => {
     worker.use(
-      mswHttp.get(userURL, () => {
-        return HttpResponse.json({ ...profile, notes: savedNotes });
-      }),
-
       mswHttp.patch(userURL, async ({ request }) => {
         const body = (await request.json()) as { user: { notes: string } };
 
-        savedNotes = body.user.notes;
-
-        return new HttpResponse(null, { status: 204 });
+        return HttpResponse.json({ notes: body.user.notes });
       }),
     );
 

--- a/web/tests/acceptance/admin/users-test.gts
+++ b/web/tests/acceptance/admin/users-test.gts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit, click } from '@ember/test-helpers';
+import { visit, click, fillIn } from '@ember/test-helpers';
 import { HttpResponse, http as mswHttp } from 'msw';
 
 import ENV from 'repository/config/environment';
@@ -17,6 +17,7 @@ const profile = {
   organization: 'Wonderland',
   account_type_number: 'general',
   admin: false,
+  notes: '',
   submission_requests_count: 5,
   submissions_count: 3,
 };
@@ -40,12 +41,39 @@ module('Acceptance | admin | user detail', function (hooks) {
     assert.dom('a[href*="/admin/submissions"]').includesText('Submissions (3)');
   });
 
+  test('saves notes via PATCH and refreshes the model', async (assert) => {
+    let savedNotes = '';
+
+    worker.use(
+      mswHttp.get(userURL, () => {
+        return HttpResponse.json({ ...profile, notes: savedNotes });
+      }),
+
+      mswHttp.patch(userURL, async ({ request }) => {
+        const body = (await request.json()) as { user: { notes: string } };
+
+        savedNotes = body.user.notes;
+
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await visit('/admin/users/alice');
+
+    assert.dom('textarea[name="notes"]').hasValue('');
+
+    await fillIn('textarea[name="notes"]', 'Watch this account.');
+    await click('main form button[type="submit"]');
+
+    assert.dom('textarea[name="notes"]').hasValue('Watch this account.');
+  });
+
   test('proxy login toggle activates and deactivates', async (assert) => {
     await visit('/admin/users/alice');
 
-    assert.dom('main button').includesText('Proxy login as alice');
+    assert.dom('button.btn-outline-primary').includesText('Proxy login as alice');
 
-    await click('main button');
+    await click('button.btn-outline-primary');
 
     assert.dom('.alert-warning').includesText('Currently acting as');
     assert.dom('.alert-warning strong').hasText('alice');
@@ -53,6 +81,6 @@ module('Acceptance | admin | user detail', function (hooks) {
     await click('.alert-warning button');
 
     assert.dom('.alert-warning').doesNotExist();
-    assert.dom('main button').includesText('Proxy login as alice');
+    assert.dom('button.btn-outline-primary').includesText('Proxy login as alice');
   });
 });

--- a/web/tests/acceptance/admin/users-test.gts
+++ b/web/tests/acceptance/admin/users-test.gts
@@ -46,7 +46,7 @@ module('Acceptance | admin | user detail', function (hooks) {
       mswHttp.patch(userURL, async ({ request }) => {
         const body = (await request.json()) as { user: { notes: string } };
 
-        return HttpResponse.json({ notes: body.user.notes });
+        return HttpResponse.json({ ...profile, notes: body.user.notes });
       }),
     );
 


### PR DESCRIPTION
## Summary

- admin/users 詳細ページに **Notes** セクションを追加。管理者がそのユーザに関する注意事項を残し、他の管理者と共有できる
- `users.notes` (text, NOT NULL, default '') カラム追加
- `PATCH /admin/users/:uid` で notes 更新 (204 No Content を返す)、show のレスポンスに notes を含めて返す

## Changes

### API
- migration: `add_column :users, :notes, :text, null: false, default: ''`
- `Admin::UsersController#update`: `params.expect(user: [:notes])` で notes 更新、`head :no_content`
- show のレスポンスに `notes` フィールドを追加
- OpenAPI: PATCH /admin/users/{uid} (requestBody + 204)、AdminUserDetail に notes プロパティ
- integration test: 永続化 + 403 + show が notes を含むこと

### Web
- 詳細ページに Notes セクション (Ember 標準の `<Textarea>` + local @tracked notes)
- Save submit で PATCH → toast → `router.refresh()` で再取得
- acceptance test: 入力 → 保存 → 反映の流れをカバー

## /simplify で当てた修正

- **textarea の改行欠落バグ回避**: `<textarea>{{...}}</textarea>` だと開始タグ直後の改行 1 個が HTML パーサで無視され、先頭改行が silently 消える。Ember 標準 `<Textarea @value={{this.notes}} />` + local @tracked state に切替
- **update から cloakman lookup + counts 集計を撤去**: 204 を返して Ember 側の `router.refresh()` に再取得を任せる。これで 1 操作あたり cloakman 呼び出しが 2 回 → 1 回に
- **acceptance test の `getCalls >= 2` 削除**: 実装詳細の検証、DOM 検証のみに

## Test plan

- [x] `bin/rails test` (94/94 pass)
- [x] `cd web && pnpm test:ember` (22/22 pass)
- [x] `cd web && pnpm lint` clean
- [ ] staging デプロイ後にブラウザで Notes 編集・保存を確認 (dev は CLOAKMAN_API_TOKEN 未設定で skip)