### PR TITLE
Phase 3 spike: D-way BioProject one-shot import + admin show

### DIFF
--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -1,21 +1,18 @@
 module Admin
   class SubmissionsController < ApplicationController
     def index
-      scope = Submission.includes(request: :user).order(id: :desc)
+      scope = Submission.includes(:user).order(id: :desc)
       scope = scope.where(db: params[:db]) if params[:db].present?
-
-      if params[:user].present?
-        scope = scope.where(request: SubmissionRequest.where(user: User.where(uid: params[:user])))
-      end
+      scope = scope.where(user: User.where(uid: params[:user])) if params[:user].present?
 
       @pagy, @submissions = pagy(scope)
     end
 
     def show
-      @submission         = Submission.includes(:user, :updates, :project).find(params[:id])
-      @materialised       = @submission.materialised_record
-      @canonical_bytes    = @materialised && DDBJRecord::Canonicalizer.canonicalize(@materialised, for_diff: false)
-      @sha256             = @materialised && DDBJRecord::Canonicalizer.sha256(@materialised, for_diff: true)
+      @submission      = Submission.includes(:user).find(params[:id])
+      @materialised    = @submission.materialised_record
+      @canonical_bytes = @materialised && DDBJRecord::Canonicalizer.canonicalize(@materialised)
+      @sha256          = @materialised && DDBJRecord::Canonicalizer.sha256(@materialised)
     end
   end
 end

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -10,5 +10,12 @@ module Admin
 
       @pagy, @submissions = pagy(scope)
     end
+
+    def show
+      @submission         = Submission.includes(:user, :updates, :project).find(params[:id])
+      @materialised       = @submission.materialised_record
+      @canonical_bytes    = @materialised && DDBJRecord::Canonicalizer.canonicalize(@materialised, for_diff: false)
+      @sha256             = @materialised && DDBJRecord::Canonicalizer.sha256(@materialised, for_diff: true)
+    end
   end
 end

--- a/app/models/bio_project/converter.rb
+++ b/app/models/bio_project/converter.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+
+module BioProject
+  # D-way BioProject XML → DDBJ Record v3 hash. Phase 3 spike scope: enough
+  # fields to drive the admin show page (accession / project_type / title /
+  # description / organism / locus_tag / submitters). Full field coverage is
+  # tracked in Phase 4 of tmp/data-migration/implementation-plan.md.
+  class Converter
+    SOURCE_FORMAT = 'dway_bp_xml'
+
+    def initialize(xml:, project_row:)
+      @xml         = xml
+      @project_row = project_row
+    end
+
+    def call
+      doc = Nokogiri::XML(@xml)
+      doc.remove_namespaces!
+
+      project_node    = doc.at_xpath('//Project/Project')
+      submission_node = doc.at_xpath('//Submission/Submission')
+
+      {
+        'schema_version' => 'v3',
+        'provenance'     => {'source_format' => SOURCE_FORMAT},
+        'submission'     => submission_block(submission_node),
+        'project'        => project_block(project_node)
+      }.compact.reject {|_, v| v.respond_to?(:empty?) && v.empty? }
+    end
+
+    private
+
+    def submission_block(node)
+      return nil unless node
+
+      submitters = node.xpath('.//Contact').filter_map {|contact|
+        {
+          'email' => contact['email'],
+          'first' => contact.at_xpath('./Name/First')&.text,
+          'last'  => contact.at_xpath('./Name/Last')&.text
+        }.compact.presence
+      }
+
+      {'submitters' => submitters}.reject {|_, v| v.blank? }.presence
+    end
+
+    def project_block(node)
+      return nil unless node
+
+      organism_node = node.at_xpath('.//Target/Organism')
+      locus_tag     = node.at_xpath('.//ProjectDescr/LocusTagPrefix')&.text
+
+      {
+        'accession'        => node.at_xpath('.//ProjectID/ArchiveID/@accession')&.value,
+        'project_type'     => @project_row.fetch(:project_type),
+        'title'            => node.at_xpath('.//ProjectDescr/Title')&.text,
+        'description'      => node.at_xpath('.//ProjectDescr/Description')&.text,
+        'organism'         => organism_block(organism_node),
+        'locus_tag_prefix' => locus_tag.present? ? [locus_tag] : nil
+      }.compact
+    end
+
+    def organism_block(node)
+      return nil unless node
+
+      {
+        'taxonomy_id' => node['taxID']&.to_i,
+        'name'        => node.at_xpath('./OrganismName')&.text
+      }.compact.presence
+    end
+  end
+end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -31,4 +31,20 @@ class Submission < ApplicationRecord
 
     Pathname.new(base).join(user.uid, 'submissions', id.to_s)
   end
+
+  # Materialise the current state of the record by replaying every
+  # SubmissionUpdate's JSON Patch from the empty document. Returns nil when
+  # there are no updates yet (a freshly inserted Submission row pre-baseline).
+  #
+  # Phase 3 spike: lazy, no cache. canonical-json.md §1.6 prescribes a
+  # write-through cache (`has_one_attached :current_record` blob) when
+  # 30-patch chains start to bite latency budgets — defer until measured.
+  def materialised_record
+    raw_patches = updates.order(:id).pluck(:patch)
+    return nil if raw_patches.empty?
+
+    raw_patches.reduce({}) {|state, raw|
+      DDBJRecord::Canonicalizer.apply(state, Oj.load(raw, mode: :strict))
+    }
+  end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -32,19 +32,35 @@ class Submission < ApplicationRecord
     Pathname.new(base).join(user.uid, 'submissions', id.to_s)
   end
 
+  class MaterialisationFailed < StandardError
+    attr_reader :update_id, :original
+
+    def initialize(update_id:, original:)
+      @update_id = update_id
+      @original  = original
+      super("SubmissionUpdate ##{update_id} replay failed: #{original.class}: #{original.message}")
+    end
+  end
+
   # Materialise the current state of the record by replaying every
   # SubmissionUpdate's JSON Patch from the empty document. Returns nil when
   # there are no updates yet (a freshly inserted Submission row pre-baseline).
+  # Raises MaterialisationFailed (carrying the offending update_id) when any
+  # patch fails to apply, so callers can localise the poisoned row.
   #
   # Phase 3 spike: lazy, no cache. canonical-json.md §1.6 prescribes a
   # write-through cache (`has_one_attached :current_record` blob) when
   # 30-patch chains start to bite latency budgets — defer until measured.
   def materialised_record
-    raw_patches = updates.order(:id).pluck(:patch)
-    return nil if raw_patches.empty?
+    rows = updates.order(:id).pluck(:id, :patch)
+    return nil if rows.empty?
 
-    raw_patches.reduce({}) {|state, raw|
-      DDBJRecord::Canonicalizer.apply(state, Oj.load(raw, mode: :strict))
+    rows.reduce({}) {|state, (id, raw)|
+      begin
+        DDBJRecord::Canonicalizer.apply(state, Oj.load(raw, mode: :strict))
+      rescue StandardError => e
+        raise MaterialisationFailed.new(update_id: id, original: e)
+      end
     }
   end
 end

--- a/app/views/admin/submissions/index.html.erb
+++ b/app/views/admin/submissions/index.html.erb
@@ -23,9 +23,9 @@
   <tbody>
     <% @submissions.each do |submission| %>
       <tr>
-        <td>Submission-<%= submission.id %></td>
+        <td><%= link_to "Submission-#{submission.id}", admin_submission_path(submission) %></td>
         <td><%= db_label(submission.db) %></td>
-        <td><%= submission.request.user.uid %></td>
+        <td><%= submission.user&.uid || submission.request&.user&.uid %></td>
         <td><%= submission.created_at.to_fs(:db) %></td>
         <td><%= submission.updated_at.to_fs(:db) %></td>
       </tr>

--- a/app/views/admin/submissions/index.html.erb
+++ b/app/views/admin/submissions/index.html.erb
@@ -25,7 +25,7 @@
       <tr>
         <td><%= link_to "Submission-#{submission.id}", admin_submission_path(submission) %></td>
         <td><%= db_label(submission.db) %></td>
-        <td><%= submission.user&.uid || submission.request&.user&.uid %></td>
+        <td><%= submission.user.uid %></td>
         <td><%= submission.created_at.to_fs(:db) %></td>
         <td><%= submission.updated_at.to_fs(:db) %></td>
       </tr>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -28,16 +28,14 @@
   <dd class="col-sm-9"><%= @submission.created_at.to_fs(:db) %> / <%= @submission.updated_at.to_fs(:db) %></dd>
 
   <dt class="col-sm-3">Updates</dt>
-  <dd class="col-sm-9"><%= @submission.updates.count %></dd>
-
-  <% if @sha256 %>
-    <dt class="col-sm-3">Content SHA-256 (for_diff)</dt>
-    <dd class="col-sm-9"><code><%= @sha256 %></code></dd>
-  <% end %>
+  <dd class="col-sm-9"><%= @submission.updates.size %></dd>
 
   <% if @canonical_bytes %>
     <dt class="col-sm-3">Canonical bytes</dt>
     <dd class="col-sm-9"><%= number_with_delimiter(@canonical_bytes.bytesize) %> bytes</dd>
+
+    <dt class="col-sm-3">Canonical SHA-256</dt>
+    <dd class="col-sm-9"><code><%= @sha256 %></code></dd>
   <% end %>
 </dl>
 

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -1,0 +1,50 @@
+<% content_for :title, "Submission-#{@submission.id}" %>
+
+<%= render 'admin/shared/breadcrumb', items: [
+  {label: 'Administration', path: admin_root_path},
+  {label: 'Submissions',    path: admin_submissions_path},
+  {label: "Submission-#{@submission.id}"}
+] %>
+
+<h1 class="display-6 mb-4">Submission-<%= @submission.id %></h1>
+
+<dl class="row">
+  <dt class="col-sm-3">Database</dt>
+  <dd class="col-sm-9"><%= db_label(@submission.db) %></dd>
+
+  <dt class="col-sm-3">Source ID</dt>
+  <dd class="col-sm-9"><%= @submission.source_id || '—' %></dd>
+
+  <dt class="col-sm-3">User</dt>
+  <dd class="col-sm-9"><%= @submission.user.uid %></dd>
+
+  <dt class="col-sm-3">Canonical version</dt>
+  <dd class="col-sm-9">ddbj-canon/v<%= @submission.canonical_version %></dd>
+
+  <dt class="col-sm-3">Converter version</dt>
+  <dd class="col-sm-9"><%= @submission.converter_version || '—' %></dd>
+
+  <dt class="col-sm-3">Created / Updated</dt>
+  <dd class="col-sm-9"><%= @submission.created_at.to_fs(:db) %> / <%= @submission.updated_at.to_fs(:db) %></dd>
+
+  <dt class="col-sm-3">Updates</dt>
+  <dd class="col-sm-9"><%= @submission.updates.count %></dd>
+
+  <% if @sha256 %>
+    <dt class="col-sm-3">Content SHA-256 (for_diff)</dt>
+    <dd class="col-sm-9"><code><%= @sha256 %></code></dd>
+  <% end %>
+
+  <% if @canonical_bytes %>
+    <dt class="col-sm-3">Canonical bytes</dt>
+    <dd class="col-sm-9"><%= number_with_delimiter(@canonical_bytes.bytesize) %> bytes</dd>
+  <% end %>
+</dl>
+
+<h2 class="h4 mt-4">Materialised v3 record</h2>
+
+<% if @materialised %>
+  <pre class="bg-body-tertiary border rounded p-3" style="max-height: 60vh; overflow: auto;"><%= JSON.pretty_generate(@materialised) %></pre>
+<% else %>
+  <p class="text-body-secondary">No updates have been applied yet — nothing to materialise.</p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
     root to: 'dashboard#show'
 
     resources :submission_requests, only: %i[index]
-    resources :submissions,         only: %i[index]
+    resources :submissions,         only: %i[index show]
     resources :users,               only: %i[index show update], param: :uid do
       resource :proxy_login, only: %i[create]
     end

--- a/lib/tasks/data_migration.rake
+++ b/lib/tasks/data_migration.rake
@@ -1,0 +1,43 @@
+namespace :data_migration do
+  desc 'Import a single BioProject from a D-way XML file (Phase 3 spike scope; single record)'
+  task :import_bp_from_file, %i[xml_path user_uid project_type] => :environment do |_, args|
+    xml_path     = args.fetch(:xml_path)
+    user_uid     = args.fetch(:user_uid)
+    project_type = args[:project_type].presence || 'primary'
+
+    xml  = File.read(xml_path)
+    user = User.find_by!(uid: user_uid)
+
+    record    = BioProject::Converter.new(xml:, project_row: {project_type:}).call
+    accession = record.dig('project', 'accession') or
+      raise 'XML had no /Project/Project/ProjectID/ArchiveID/@accession; cannot derive source_id'
+
+    submission = Submission.find_or_create_by!(db: :bioproject, source_id: accession) {|s|
+      s.user              = user
+      s.canonical_version = 1
+      s.converter_version = "bp_v3/#{BioProject::Converter::SOURCE_FORMAT}"
+    }
+
+    submission.project ||
+      Project.create!(
+        submission:,
+        accession:,
+        project_type:,
+        status:    :public,
+        title:     record.dig('project', 'title')
+      )
+
+    baseline = [{'op' => 'add', 'path' => '', 'value' => record}]
+
+    submission.updates.create!(
+      db:                       'bioproject',
+      status:                   :applied,
+      actor:                    "migration:#{user_uid}",
+      source:                   :migration,
+      patch:                    Oj.dump(baseline, mode: :strict),
+      patch_canonical_version:  1
+    )
+
+    puts "Imported #{accession} → Submission ##{submission.id} (#{submission.updates.count} update[s])"
+  end
+end

--- a/lib/tasks/data_migration.rake
+++ b/lib/tasks/data_migration.rake
@@ -1,7 +1,12 @@
 namespace :data_migration do
-  desc 'Import a single BioProject from a D-way XML file (Phase 3 spike scope; single record)'
-  task :import_bp_from_file, %i[xml_path user_uid project_type] => :environment do |_, args|
+  # Phase 3 spike scope: import a single BioProject from a D-way XML file.
+  # Idempotent on re-run with the same source XML (skips the SubmissionUpdate
+  # insert when the prior tail patch is byte-identical to the new baseline);
+  # raises on cross-user collision instead of silently re-attributing.
+  desc 'Import a single BioProject from a D-way XML file (Phase 3 spike, single record)'
+  task :import_bp_from_file, %i[xml_path psub_id user_uid project_type] => :environment do |_, args|
     xml_path     = args.fetch(:xml_path)
+    psub_id      = args.fetch(:psub_id)
     user_uid     = args.fetch(:user_uid)
     project_type = args[:project_type].presence || 'primary'
 
@@ -10,34 +15,55 @@ namespace :data_migration do
 
     record    = BioProject::Converter.new(xml:, project_row: {project_type:}).call
     accession = record.dig('project', 'accession') or
-      raise 'XML had no /Project/Project/ProjectID/ArchiveID/@accession; cannot derive source_id'
-
-    submission = Submission.find_or_create_by!(db: :bioproject, source_id: accession) {|s|
-      s.user              = user
-      s.canonical_version = 1
-      s.converter_version = "bp_v3/#{BioProject::Converter::SOURCE_FORMAT}"
-    }
-
-    submission.project ||
-      Project.create!(
-        submission:,
-        accession:,
-        project_type:,
-        status:    :public,
-        title:     record.dig('project', 'title')
-      )
+      raise 'XML had no /Project/Project/ProjectID/ArchiveID/@accession; cannot derive accession'
 
     baseline = [{'op' => 'add', 'path' => '', 'value' => record}]
+    patch    = Oj.dump(baseline, mode: :strict)
 
-    submission.updates.create!(
-      db:                       'bioproject',
-      status:                   :applied,
-      actor:                    "migration:#{user_uid}",
-      source:                   :migration,
-      patch:                    Oj.dump(baseline, mode: :strict),
-      patch_canonical_version:  1
-    )
+    Submission.transaction do
+      submission = Submission.find_or_create_by!(db: :bioproject, source_id: psub_id) {|s|
+        s.user           = user
+        s.migration_run_id = SecureRandom.uuid
+      }
 
-    puts "Imported #{accession} → Submission ##{submission.id} (#{submission.updates.count} update[s])"
+      if submission.user_id != user.id
+        raise "Submission #{psub_id} already exists under user '#{submission.user.uid}'; " \
+              "refusing to silently re-attribute to '#{user_uid}'."
+      end
+
+      # `update_columns` bypasses the v2-era `validates :ddbj_record, on: :update`
+      # constraint — migration-sourced submissions store state in
+      # submission_updates patches, not in the ddbj_record blob.
+      submission.update_columns(
+        canonical_version: 1,
+        converter_version: "bp_v3/#{BioProject::Converter::SOURCE_FORMAT}",
+        updated_at:        Time.current
+      )
+
+      submission.project ||
+        Project.create!(
+          submission:,
+          accession:,
+          project_type:,
+          status:    :public,
+          title:     record.dig('project', 'title')
+        )
+
+      last_patch = submission.updates.order(:id).last&.patch
+      if last_patch == patch
+        puts "Skipped: Submission ##{submission.id} (#{accession}) — baseline patch unchanged"
+      else
+        submission.updates.create!(
+          db:                       'bioproject',
+          status:                   :applied,
+          actor:                    "migration:#{user_uid}",
+          source:                   :migration,
+          patch:                    patch,
+          patch_canonical_version:  1
+        )
+
+        puts "Imported #{accession} → Submission ##{submission.id} (#{submission.updates.count} update[s])"
+      end
+    end
   end
 end

--- a/test/fixtures/files/data_migration/bio_project/PSUB000604.xml
+++ b/test/fixtures/files/data_migration/bio_project/PSUB000604.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<PackageSet>
+	<Package>
+		<Project>
+			<Project>
+				<ProjectID>
+					<ArchiveID accession="PRJDB502" archive="DDBJ" />
+				</ProjectID>
+				<ProjectDescr>
+					<Title>Chromosome Mycobacterium avium sequencing</Title>
+					<Description>Mycobacterium avium complex (MAC) infection causes mainly two types of disease: disseminated disease in immmunocompromised hosts such as AIDS patients; and pulmonary disease in persons without systemic immunosuppression. To explore bacterial factors that affect different forms of MAC disease, we determine complete genome sequence of M. avium strain TH135 isolated from HIV-negative patient with pulmonary MAC disease, and compare with the genome of M. avium strain 104 derived from an AIDS patient with MAC infection</Description>
+					<Grant GrantId="24590164">
+						<Title>Comparative genome analysis of nontuberculous mycobacteria and clinical application</Title>
+						<Agency abbr="JSPC">Japan Society for the Promotion of Science</Agency>
+					</Grant>
+					<ProjectReleaseDate>2013-05-30T17:44:31.148+09:00</ProjectReleaseDate>
+					<Relevance>
+						<Medical>yes</Medical>
+					</Relevance>
+					<LocusTagPrefix>MAH</LocusTagPrefix>
+				</ProjectDescr>
+				<ProjectType>
+					<ProjectTypeSubmission>
+						<Target sample_scope="eMonoisolate" material="eGenome" capture="eWhole">
+							<Organism taxID="1229671">
+								<OrganismName>Mycobacterium avium subsp. hominissuis TH135</OrganismName>
+								<Strain>TH135</Strain>
+								<BiologicalProperties>
+									<Morphology>
+										<Gram>ePositive</Gram>
+										<Enveloped>eNo</Enveloped>
+										<Shape>eCocci</Shape>
+										<Endospores>eNo</Endospores>
+										<Motility>eNo</Motility>
+									</Morphology>
+									<Environment>
+										<Salinity>eMesophilic</Salinity>
+										<OxygenReq>eAerobic</OxygenReq>
+										<OptimumTemperature>37</OptimumTemperature>
+										<TemperatureRange>eMesophilic</TemperatureRange>
+										<Habitat>eMultiple</Habitat>
+									</Environment>
+									<Phenotype>
+										<BioticRelationship>eParasite</BioticRelationship>
+										<TrophicLevel>eAutotroph</TrophicLevel>
+										<Disease>Mycobacterium avium complex disease</Disease>
+									</Phenotype>
+								</BiologicalProperties>
+								<Organization>eColonial</Organization>
+								<Reproduction>eAsexual</Reproduction>
+								<RepliconSet>
+									<Replicon>
+										<Type location="eNuclearProkaryote" isSingle="false">ePlasmid</Type>
+										<Name>plasmid</Name>
+										<Size units="Kb">20</Size>
+									</Replicon>
+									<Ploidy type="eHaploid" />
+									<Count repliconType="ePlasmid">1</Count>
+								</RepliconSet>
+								<GenomeSize units="Mb">5</GenomeSize>
+							</Organism>
+							<Provider>Higashinagoya National Hospital</Provider>
+						</Target>
+						<Method method_type="eSequencing" />
+						<Objectives>
+							<Data data_type="eSequence" />
+						</Objectives>
+						<ProjectDataTypeSet>
+							<DataType>Genome Sequencing</DataType>
+						</ProjectDataTypeSet>
+					</ProjectTypeSubmission>
+				</ProjectType>
+			</Project>
+		</Project>
+		<Submission>
+			<Submission submitted="2012-09-04">
+				<Description>
+					<Organization type="center" role="owner">
+						<Name>Meijo University faculty of pharmacy</Name>
+						<Contact email="sample-1@example.test">
+							<Name>
+								<First>Sample-First-1</First>
+								<Last>Sample-Last-1</Last>
+							</Name>
+						</Contact>
+						<Contact email="sample-2@example.test">
+							<Name>
+								<First>Sample-First-2</First>
+								<Last>Sample-Last-2</Last>
+							</Name>
+						</Contact>
+					</Organization>
+					<Access>public</Access>
+				</Description>
+			</Submission>
+		</Submission>
+	</Package>
+</PackageSet>

--- a/test/integration/admin/submissions_test.rb
+++ b/test/integration/admin/submissions_test.rb
@@ -47,4 +47,33 @@ class AdminSubmissionsTest < ActionDispatch::IntegrationTest
 
     assert_response :forbidden
   end
+
+  test 'show renders the materialised v3 record' do
+    submission = submissions(:bioproject)
+    record     = {'project' => {'accession' => 'PRJDB502', 'title' => 'hello'}}
+    submission.updates.create!(
+      db:                       'bioproject',
+      status:                   :applied,
+      actor:                    'migration:test',
+      source:                   :migration,
+      patch:                    Oj.dump([{'op' => 'add', 'path' => '', 'value' => record}], mode: :strict),
+      patch_canonical_version:  1
+    )
+
+    get admin_submission_path(submission)
+
+    assert_response :ok
+    assert_match "Submission-#{submission.id}", response.body
+    assert_match 'PRJDB502',                    response.body
+    assert_match 'hello',                       response.body
+  end
+
+  test 'show falls back gracefully when no updates have been applied' do
+    submission = submissions(:bioproject)
+
+    get admin_submission_path(submission)
+
+    assert_response :ok
+    assert_match 'nothing to materialise', response.body
+  end
 end

--- a/test/models/bio_project/converter_test.rb
+++ b/test/models/bio_project/converter_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class BioProject::ConverterTest < ActiveSupport::TestCase
+  test 'PSUB000604 (PRJDB502, primary) — minimum field mapping' do
+    xml         = file_fixture('data_migration/bio_project/PSUB000604.xml').read
+    project_row = {project_type: 'primary'}
+
+    record = BioProject::Converter.new(xml:, project_row:).call
+
+    assert_equal 'v3',                                     record['schema_version']
+    assert_equal({'source_format' => 'dway_bp_xml'},       record['provenance'])
+
+    project = record.fetch('project')
+    assert_equal 'PRJDB502',                               project['accession']
+    assert_equal 'primary',                                project['project_type']
+    assert_equal 'Chromosome Mycobacterium avium sequencing', project['title']
+    assert_match(/Mycobacterium avium complex/,            project['description'])
+    assert_equal ['MAH'],                                  project['locus_tag_prefix']
+    assert_equal({'taxonomy_id' => 1229671, 'name' => 'Mycobacterium avium subsp. hominissuis TH135'},
+                 project['organism'])
+
+    submitters = record.dig('submission', 'submitters')
+    assert_equal 2, submitters.size
+    assert_equal({'email' => 'sample-1@example.test', 'first' => 'Sample-First-1', 'last' => 'Sample-Last-1'},
+                 submitters[0])
+    assert_equal({'email' => 'sample-2@example.test', 'first' => 'Sample-First-2', 'last' => 'Sample-Last-2'},
+                 submitters[1])
+  end
+
+  test 'canonicalises cleanly via the production pipeline' do
+    xml    = file_fixture('data_migration/bio_project/PSUB000604.xml').read
+    record = BioProject::Converter.new(xml:, project_row: {project_type: 'primary'}).call
+
+    # If any string in the converter output trips §2 normalisation (control
+    # chars, alphabet-restricted sequence path, etc.) this raises. Acts as a
+    # smoke test that converter output is canon-compatible.
+    bytes = DDBJRecord::Canonicalizer.canonicalize(record)
+
+    assert_kind_of String, bytes
+    assert_includes bytes, '"accession":"PRJDB502"'
+  end
+end

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -46,4 +46,23 @@ class SubmissionTest < ActiveSupport::TestCase
 
     assert_equal 'second', submission.materialised_record.dig('project', 'title')
   end
+
+  test '#materialised_record raises MaterialisationFailed carrying the offending update_id' do
+    submission = submissions(:bioproject)
+    bad_update = submission.updates.create!(
+      db:                      'bioproject',
+      status:                  'applied',
+      actor:                   'test',
+      source:                  'manual',
+      patch:                   'not-json-at-all',
+      patch_canonical_version: 1
+    )
+
+    error = assert_raises(Submission::MaterialisationFailed) do
+      submission.materialised_record
+    end
+
+    assert_equal bad_update.id, error.update_id
+    assert_kind_of Oj::ParseError, error.original
+  end
 end

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class SubmissionTest < ActiveSupport::TestCase
+  test '#materialised_record returns nil before any update is appended' do
+    submission = submissions(:bioproject)
+
+    assert_nil submission.materialised_record
+  end
+
+  test '#materialised_record replays a single baseline patch into the full v3 hash' do
+    submission = submissions(:bioproject)
+    record     = {
+      'schema_version' => 'v3',
+      'project'        => {'accession' => 'PRJDB502', 'title' => 'sample'}
+    }
+    baseline = [{'op' => 'add', 'path' => '', 'value' => record}]
+
+    submission.updates.create!(
+      db:                      'bioproject',
+      status:                  'applied',
+      actor:                   'migration',
+      source:                  'migration',
+      patch:                   Oj.dump(baseline, mode: :strict),
+      patch_canonical_version: DDBJRecord::Canonicalizer::VERSION
+    )
+
+    assert_equal record, submission.materialised_record
+  end
+
+  test '#materialised_record replays a chain of patches in id order' do
+    submission = submissions(:bioproject)
+
+    baseline = [{'op' => 'add', 'path' => '', 'value' => {'project' => {'title' => 'first'}}}]
+    edit     = [{'op' => 'replace', 'path' => '/project/title', 'value' => 'second'}]
+
+    [baseline, edit].each do |patch|
+      submission.updates.create!(
+        db:                      'bioproject',
+        status:                  'applied',
+        actor:                   'migration',
+        source:                  'migration',
+        patch:                   Oj.dump(patch, mode: :strict),
+        patch_canonical_version: DDBJRecord::Canonicalizer::VERSION
+      )
+    end
+
+    assert_equal 'second', submission.materialised_record.dig('project', 'title')
+  end
+end


### PR DESCRIPTION
## Summary

End-to-end spike that gets a single D-way BioProject into the
ddbj-repository DB and renders the resulting v3 record on
`/admin/submissions/:id`. Goal: prove the migration loop without
waiting for the full Phase 3 patch-chain materialisation work or
Phase 4's exhaustive BP converter.

### What ships

- **`BioProject::Converter`** (`app/models/bio_project/converter.rb`)
  — Nokogiri XPath traversal of a D-way BP submission XML → v3 hash.
  Minimal mapping for the spike: accession / project_type / title /
  description / organism / locus_tag_prefix / submitters. Full
  field coverage is Phase 4.
- **`Submission#materialised_record`** (`app/models/submission.rb`)
  — lazy JSON Patch chain replay via
  `DDBJRecord::Canonicalizer.apply` over `submission_updates.patch`
  in id order. Raises `Submission::MaterialisationFailed` carrying
  the offending update_id when a patch fails, so triage can land on
  a specific row instead of a generic 500.
- **`data_migration:import_bp_from_file[xml_path,psub_id,user_uid,project_type]`**
  rake task — wraps Submission + Project + baseline SubmissionUpdate
  inside a transaction, idempotent on identical re-runs, raises on
  cross-user re-attribution, populates `migration_run_id` so a bad
  run can be rolled back as a unit. `source_id` stores the D-way
  PSUB id (was earlier conflated with the PRJDB accession — fixed
  during in-branch review).
- **`Admin::SubmissionsController#show`** + view — renders the
  materialised v3 hash as pretty-printed JSON inside a `<pre>` block
  alongside canonical byte count + SHA-256.
- **Admin index** now links each row to its show; preloads
  `submission.user` to keep the paginated list off N+1.

### Code review pass

`/code-review` (9 finder angles × 1-vote verify × sweep, 86 agents)
surfaced 15 issues; the 12 confirmed real defects were fixed in the
follow-up commit:

- Rake idempotency / safety (7): transactional writes, baseline-dedup,
  cross-user guard, PSUB / PRJDB identifier separation, populated
  `migration_run_id`, etc.
- View N+1 / dead code (3): `submission.user` direct read with proper
  preload; dropped a Phase-1-dead `request.user` fallback; removed
  unused `:updates` / `:project` from the show controller's includes.
- materialised_record diagnostics (1): `MaterialisationFailed`
  surfaces the failing update_id.
- show-page metric consistency (1): byte count and SHA-256 now
  describe the same canonical document.

### Out of scope (Phase 4 / Phase 6 follow-ups)

- in-progress D-way submissions (no `ArchiveID/@accession` yet)
- Full BP field mapping (~30 form fields, umbrella relations, …)
- BS (1 submission = N records / EAV-heavy)
- Batched ETL job, progress tracking, retry semantics
- D-way `submitter_id` → ddbj-repository `User` lookup (rake currently
  takes operator uid as a placeholder)
- v2-shaped consumer porting (carried over from Phase 2)

## Test plan

- [ ] CI: `rspec` / `brakeman` / `rubocop`
- [ ] CI: `pnpm lint` / `pnpm test`
- [ ] Manually run the rake against a known staging BP, then visit
      `/admin/submissions/<id>` and verify the v3 JSON renders
- [ ] Re-run the rake with identical args → should print "Skipped"
- [ ] Re-run with a different `user_uid` → should raise the
      cross-user re-attribution error
- [ ] (Optional) Insert a malformed patch by hand and visit the show
      page → should surface `MaterialisationFailed` with the
      offending update_id

Full suite locally: 224 runs, 630 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)