### PR TITLE
Resolve frontend backend URLs relative to the serving origin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,6 @@ RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
 FROM docker.io/library/node:24.17.0 AS web
 
-ARG APP_URL
-ENV APP_URL=${APP_URL:?}
-
 RUN npm install --global pnpm
 
 WORKDIR /web

--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -11,10 +11,6 @@ volumes:
   - /mnt/submission:/submission
   - /lustre9/open/home/ddbjshare:/ddbjshare:ro
 
-builder:
-  args:
-    APP_URL: https://repository.ddbj.nig.ac.jp
-
 accessories:
   postgres:
     host: repository-production

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -15,10 +15,6 @@ volumes:
   - /mnt/submission:/submission
   - /lustre9/open/home/ddbjshare:/ddbjshare:ro
 
-builder:
-  args:
-    APP_URL: https://repository-staging.ddbj.nig.ac.jp
-
 accessories:
   postgres:
     host: repository-staging

--- a/web/app/config/environment.ts
+++ b/web/app/config/environment.ts
@@ -23,6 +23,7 @@ export default config as {
   APP: Record<string, unknown>;
   apiURL: string;
   appURL: string;
+  authURL: string;
   directUploadURL: string;
   adminURL: string;
 } & Record<string, unknown>;

--- a/web/app/services/current-user.ts
+++ b/web/app/services/current-user.ts
@@ -98,7 +98,7 @@ export default class CurrentUserService extends Service {
 
     // /session is outside /api, so RequestManager's BaseURLHandler wouldn't
     // route it; AuthHandler would also attach a stale bearer token.
-    const sessionUrl = new URL('/session', ENV.apiURL).toString();
+    const sessionUrl = `${ENV.appURL}/session`;
 
     try {
       // eslint-disable-next-line warp-drive/no-external-request-patterns

--- a/web/app/templates/index.gts
+++ b/web/app/templates/index.gts
@@ -7,7 +7,7 @@ import ENV from 'repository/config/environment';
 
 import type CurrentUserService from 'repository/services/current-user';
 
-const authURL = new URL('/auth/keycloak', ENV.apiURL).href;
+const authURL = ENV.authURL;
 
 export default class extends Component {
   @service declare currentUser: CurrentUserService;

--- a/web/config/environment.js
+++ b/web/config/environment.js
@@ -1,6 +1,23 @@
 'use strict';
 
 module.exports = function (environment) {
+  // Origin of the Rails backend, used as the base for every backend URL below.
+  //
+  // In production the built assets are served from the same origin as the API,
+  // so we leave this empty and let the URLs resolve relative to wherever the app
+  // is served. That keeps a single production image environment-agnostic (no
+  // per-environment APP_URL baked in at build time).
+  //
+  // In development the Ember and Rails servers run on separate origins, so we
+  // honour APP_URL (e.g. a Caddy endpoint terminating a socket) and fall back to
+  // the default Puma port.
+  const appURL =
+    environment === 'development'
+      ? process.env.APP_URL || 'http://localhost:3000'
+      : environment === 'test'
+        ? 'http://localhost:3000'
+        : '';
+
   const ENV = {
     modulePrefix: 'repository',
     environment,
@@ -19,12 +36,13 @@ module.exports = function (environment) {
       // when it is created
     },
 
-    appURL: process.env.APP_URL || 'http://localhost:3000',
+    appURL,
   };
 
-  ENV.apiURL = new URL('/api', ENV.appURL).toString();
-  ENV.adminURL = new URL('/admin', ENV.appURL).toString();
-  ENV.directUploadURL = new URL('/rails/active_storage/direct_uploads', ENV.appURL).toString();
+  ENV.apiURL = `${appURL}/api`;
+  ENV.adminURL = `${appURL}/admin`;
+  ENV.authURL = `${appURL}/auth/keycloak`;
+  ENV.directUploadURL = `${appURL}/rails/active_storage/direct_uploads`;
 
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;

--- a/web/tests/msw/handlers.ts
+++ b/web/tests/msw/handlers.ts
@@ -4,8 +4,8 @@ import ENV from 'repository/config/environment';
 
 import { http } from './http';
 
-const directUploadURL = new URL('/rails/active_storage/direct_uploads', ENV.apiURL).toString();
-const diskURL = new URL('/rails/active_storage/disk/', ENV.apiURL).toString();
+const directUploadURL = ENV.directUploadURL;
+const diskURL = `${ENV.appURL}/rails/active_storage/disk/`;
 
 export const handlers = [
   http.get('/me', ({ response }) => {


### PR DESCRIPTION
## 背景

本番 https://repository.ddbj.nig.ac.jp でログインすると idp-staging に飛ぶ事象の根本対応です。

原因はフロントエンドのビルド時に `APP_URL` を絶対 URL として焼き込んでいたこと。staging 向けにビルドしたイメージを `kamal deploy -P`（ビルドをスキップして既存イメージを流用）で本番に出すと、本番上のフロントが staging バックエンドを指し、ログインが `RAILS_ENV=staging` → idp-staging に流れていた。

## 変更

バックエンドのビルド成果物は API と同一オリジンで配信されるので、本番ビルドでは URL を**相対パス**で組み立てるようにした。これで 1 つの本番イメージが環境非依存になり、`-P` での使い回しでも事故らない。

- `web/config/environment.js` — `appURL` を環境別に解決
  - production: `''`（＝同一オリジンに相対解決）
  - development: `process.env.APP_URL || 'http://localhost:3000'`（Ember と Rails が別オリジン。Caddy 終端の socket 等を尊重）
  - test: `'http://localhost:3000'` 固定（MSW。開発者シェルの `APP_URL` に左右されないよう dev とは分離）
  - 派生 URL（`apiURL` / `adminURL` / `authURL` / `directUploadURL`）をテンプレート文字列化、`authURL` を追加
- 消費側を新 ENV に追従: `web/app/templates/index.gts`、`web/app/services/current-user.ts`、`web/tests/msw/handlers.ts`、型定義 `web/app/config/environment.ts`
- `Dockerfile` と `config/deploy.{production,staging}.yml` から `APP_URL` ビルド引数を削除（Rails 側の app_url は `config/app.yml` 由来で影響なし）

## テスト

- `cd web && pnpm lint` ✅
- `cd web && pnpm test` ✅（8 件 pass）
- `/code-review`（high effort）で correctness バグ 0 件

🤖 Generated with [Claude Code](https://claude.com/claude-code)