### PR TITLE
Fix Flatfile::Buffer#wrap infinite loop on deeply-indented lines

### DIFF
--- a/app/jobs/apply_submission_request_job.rb
+++ b/app/jobs/apply_submission_request_job.rb
@@ -5,13 +5,18 @@ class ApplySubmissionRequestJob < ApplicationJob
     request.applying!
 
     apply request
-  rescue => e
+  rescue Exception => e # rubocop:disable Lint/RescueException
+    # StandardError 以外（SystemStackError 等）でも必ず終端状態に落とす。
+    # ここで取り逃すと request が applying のまま取り残され、クライアントが
+    # status を永久にポーリングし続ける。シグナル等は記録だけして上位へ流す。
     Rails.error.report e
 
     request.update!(
       status:        :application_failed,
       error_message: e.message
     )
+
+    raise unless e.is_a?(StandardError)
   else
     request.applied!
   end

--- a/app/jobs/apply_submission_update_job.rb
+++ b/app/jobs/apply_submission_update_job.rb
@@ -10,13 +10,17 @@ class ApplySubmissionUpdateJob < ApplicationJob
       apply update
     rescue NoChange
       update.no_change!
-    rescue => e
+    rescue Exception => e # rubocop:disable Lint/RescueException
+      # StandardError 以外（SystemStackError 等）でも必ず終端状態に落とす。
+      # ここで取り逃すと update が applying のまま取り残される。
       Rails.error.report e
 
       update.update!(
         status:        :application_failed,
         error_message: e.message
       )
+
+      raise unless e.is_a?(StandardError)
     else
       update.applied!
     end

--- a/app/models/ddbj_record_validator.rb
+++ b/app/models/ddbj_record_validator.rb
@@ -10,7 +10,11 @@ module DDBJRecordValidator
     ActiveRecord::Base.transaction do
       begin
         _validate subject
-      rescue => e
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        # StandardError 以外（SystemStackError 等）でも必ず終端状態に落とす。
+        # ここで取り逃すと subject が validating のまま取り残される。
+        # この rescue はトランザクション内なので、再 raise すると
+        # validation_failed の書き込みごとロールバックされてしまう。記録のみ行う。
         Rails.error.report e
 
         subject.validation_failed!

--- a/app/models/flatfile/buffer.rb
+++ b/app/models/flatfile/buffer.rb
@@ -34,37 +34,45 @@ class Flatfile::Buffer
 
   private
 
+  # 80 桁を超える行を、継続行を indent で揃えながら折り返してすべて出力する。
+  #
+  # 折り返し桁 b（この行に残す末尾の桁）は必ず indent 幅より右に取る。継続行は
+  # `indent + 残り` なので、b < indent.size だと行が縮まず無限ループになる。
+  # COMMENT 内に埋め込んだ feature table のように indent が 40 桁を超える行
+  # （巨大な化学名など空白で折り返せない値）で実際にこれが起きる。再帰実装の
+  # 頃は同じ条件で SystemStackError になっていた。
   def wrap(io, line)
-    if line.size <= 80
-      io.puts line
-      return
-    end
+    loop do
+      if line.size <= 80
+        io.puts line
+        return
+      end
 
-    indent = case line
-    when /\A((?:COMMENT|\s{7})\s{5})([A-Z]{2})(\s+)/
-      ' ' * $1.size + $2 + ' ' * $3.size
-    when /\A([A-Z\s]{,12}\s*)/
-      ' ' * $1.size
-    else
-      raise 'unreachable'
-    end
+      indent = case line
+      when /\A((?:COMMENT|\s{7})\s{5})([A-Z]{2})(\s+)/
+        ' ' * $1.size + $2 + ' ' * $3.size
+      when /\A([A-Z\s]{,12}\s*)/
+        ' ' * $1.size
+      else
+        raise 'unreachable'
+      end
 
-    late = line[40..79]
+      late = line[40..79]
 
-    if i = late.rindex(' ')
-      io.puts (line[0..39] + late[0..i]).delete_suffix(' ')
+      # 空白優先、次に区切り文字、どちらも indent より右に無ければ 80 桁で固定折り。
+      # いずれも b >= indent.size を満たすものだけ採用して前進を保証する。
+      b =
+        if (i = late.rindex(' ')) && 40 + i >= indent.size
+          40 + i
+        elsif (i = %w[, - / ( )].filter_map { late.rindex(it) }.max) && 40 + (pos = late[i] == '(' ? i - 1 : i) >= indent.size
+          40 + pos
+        else
+          [79, indent.size].max
+        end
 
-      wrap io, indent + late[(i + 1)..] + line[80..]
-    elsif i = %w[, - / ( )].filter_map { late.rindex(it) }.max
-      wrap_pos = late[i] == '(' ? i - 1 : i
+      io.puts line[0..b].delete_suffix(' ')
 
-      io.puts (line[0..39] + late[0..wrap_pos]).delete_suffix(' ')
-
-      wrap io, indent + late[(wrap_pos + 1)..] + line[80..]
-    else
-      io.puts line[0..79].delete_suffix(' ')
-
-      wrap io, indent + line[80..]
+      line = indent + line[(b + 1)..]
     end
   end
 end

--- a/test/jobs/apply_submission_request_job_test.rb
+++ b/test/jobs/apply_submission_request_job_test.rb
@@ -25,4 +25,33 @@ class ApplySubmissionRequestJobTest < ActiveSupport::TestCase
     assert_equal submission.accessions.count, histories.count
     assert histories.all? { it.action == 'create' && it.user == request.user }
   end
+
+  # SystemStackError は StandardError ではないので、rescue を取り違えると
+  # request が applying のまま取り残され、クライアントが status を永久に
+  # ポーリングし続ける。終端状態 (application_failed) に落ちることを保証する。
+  test 'marks the request as application_failed even on a non-StandardError' do
+    request = SubmissionRequest.new(user: users(:alice), db: 'st26')
+
+    request.ddbj_record.attach(
+      io:           file_fixture('ddbj_record/example.json').open,
+      filename:     'example.json',
+      content_type: 'application/json'
+    )
+
+    request.save!
+
+    boom = ->(*) { raise SystemStackError, 'stack level too deep' }
+
+    assert_raises SystemStackError do
+      DDBJRecord::StreamingParser.stub :new, boom do
+        ApplySubmissionRequestJob.perform_now request
+      end
+    end
+
+    request.reload
+
+    assert request.application_failed?
+    assert_equal 'stack level too deep', request.error_message
+    assert_not request.processing?
+  end
 end

--- a/test/models/flatfile/buffer_test.rb
+++ b/test/models/flatfile/buffer_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+class Flatfile::BufferTest < ActiveSupport::TestCase
+  test 'wraps a single line to 80 columns' do
+    io = StringIO.new
+
+    Flatfile::Buffer.new(io).tap {|buf|
+      buf << '                     /note="' + ('ACGT' * 30) + '"'
+      buf.flush
+    }
+
+    lines = io.string.lines(chomp: true)
+
+    assert_operator lines.size, :>, 1
+    assert lines.all? { it.size <= 80 }, 'every wrapped line must be <= 80 chars'
+    assert_equal lines.join.delete(' '), '/note="' + ('ACGT' * 30) + '"'
+  end
+
+  # 巨大な qualifier 値（数百 KB の継ぎ目なし 1 行）でも落ちないこと。
+  # wrap が再帰実装だった頃はここで SystemStackError になり、apply ジョブが
+  # request を applying のまま取り残していた。
+  test 'wraps an extremely long line without overflowing the stack' do
+    io = StringIO.new
+
+    assert_nothing_raised do
+      Flatfile::Buffer.new(io).tap {|buf|
+        buf << '                     /note="' + ('A' * 1_000_000) + '"'
+        buf.flush
+      }
+    end
+
+    assert io.string.lines(chomp: true).all? { it.size <= 80 }
+  end
+
+  # COMMENT 内に埋め込んだ feature table の行は indent が 40 桁を超えることがある。
+  # 値が空白で折り返せない（化学名など）と、折り返し位置が indent 内に落ちて行が
+  # 縮まず、wrap が無限ループ（再帰実装では SystemStackError）になっていた。
+  test 'wraps a deeply indented unbreakable value without looping forever' do
+    io   = StringIO.new
+    line = '            FT' + (' ' * 31) + ('(2S,4R)-1-[29-' * 50) # indent 45 桁, 空白なし
+
+    assert_operator line.size, :>, 80
+
+    Flatfile::Buffer.new(io).tap {|buf|
+      buf << line
+      buf.flush
+    }
+
+    lines = io.string.lines(chomp: true)
+
+    assert_operator lines.size, :>, 1
+    assert lines.all? { it.size <= 80 }, 'every wrapped line must be <= 80 chars'
+  end
+end


### PR DESCRIPTION
## 背景

production で `bin/st26 submit` を実行中、特定の submission が「成功とも失敗とも結果を返さないままスタック」する事象が報告された。サーバ側では該当 request が `applying` 状態のまま固まり、クライアントは `/status` を永久にポーリングし続けていた（実機で 2 件: req 19078 / 20492）。

## 根本原因（2 段構え）

1. **`Flatfile::Buffer#wrap` の無限ループ** — 継続行の `indent` が折り返し窓（40 桁）を超え、かつ値が indent より右で折り返せない（空白の無い長い化学名など。COMMENT 内に埋め込まれた feature table で発生）と、継続行 `indent + 残り` が縮まず前進しない。再帰実装では `SystemStackError`、ループに直すと無限ループになる。
   - 折り返し桁 `b` を必ず `>= indent.size` に取り、毎回必ず行が縮むように `wrap` を書き直した（3 分岐の重複も解消）。

2. **`SystemStackError` を job が握れない** — `SystemStackError` は `StandardError` ではないため apply/validate job の `rescue => e` で捕まらず、request が `applying` のまま取り残されていた。rescue を `Exception` に広げ、必ず終端状態に落ちるようにした（StandardError 以外は記録後に再 raise。validator はトランザクション内なので記録のみ）。

## 検証

- 実機データ（req 19078 の 61KB JSON）でループ再現 → 修正後は 0.03s で完走、全行 ≤80 桁。
- backend 全テスト 100 runs green / rubocop / brakeman clean。
- 回帰テスト追加: deep-indent 無限ループ、超長行、非 StandardError → application_failed。

## 残作業（このPRには含まない）

- production の stuck 2 件（req 19078 / 20492）の復旧。allocate 済み accession を再利用して output を再生成する方針を別途実施予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)