### PR TITLE
Avoid Regexp.timeout on multi-MB sequences in the validator

### DIFF
--- a/app/models/ddbj_record_validator.rb
+++ b/app/models/ddbj_record_validator.rb
@@ -1,4 +1,14 @@
 module DDBJRecordValidator
+  # IUPAC nucleotide codes (upper and lower case). The sequence-character
+  # checks below match against this set with String#count instead of a
+  # case-insensitive regexp: a multi-MB sequence would otherwise blow past
+  # Rails' 1-second Regexp.timeout and surface as a TRD_R9999 catch-all
+  # ("regexp match timeout") even though the sequence is perfectly valid.
+  # Keep this a plain set of letters: String#count treats a leading '^' as
+  # negation and '-'/'\' as range/escape, so adding those would silently
+  # change the matching semantics.
+  NUCLEOTIDE_CODES = 'acgtmrwsykvhdbnACGTMRWSYKVHDBN'
+
   module_function
 
   def validate(subject)
@@ -110,7 +120,7 @@ module DDBJRecordValidator
 
       aa = entry.source_features.any? { it.source&.mol_type == 'protein' }
 
-      if !aa && seq.match?(/\AN+\z/i)
+      if !aa && !seq.empty? && seq.count('^Nn').zero?
         details << {
           entry_id:,
           code:     'TRD_R0003',
@@ -119,7 +129,7 @@ module DDBJRecordValidator
         }
       end
 
-      if aa && seq.match?(/\AX+\z/i)
+      if aa && !seq.empty? && seq.count('^Xx').zero?
         details << {
           entry_id:,
           code:     'TRD_R0004',
@@ -128,7 +138,7 @@ module DDBJRecordValidator
         }
       end
 
-      if !aa && seq.match?(/[^acgtmrwsykvhdbn]/i)
+      if !aa && seq.count("^#{NUCLEOTIDE_CODES}").positive?
         details << {
           entry_id:,
           code:     'TRD_R0005',

--- a/app/models/ddbj_record_validator.rb
+++ b/app/models/ddbj_record_validator.rb
@@ -7,7 +7,12 @@ module DDBJRecordValidator
   # Keep this a plain set of letters: String#count treats a leading '^' as
   # negation and '-'/'\' as range/escape, so adding those would silently
   # change the matching semantics.
-  NUCLEOTIDE_CODES = 'acgtmrwsykvhdbnACGTMRWSYKVHDBN'
+  NUCLEOTIDE_CODES = 'acgtmrwsykvhdbnACGTMRWSYKVHDBN'.freeze
+
+  # Pre-negated form for `String#count` — "any character outside the IUPAC
+  # nucleotide set" — cached so the per-entry loop below doesn't rebuild
+  # the argument String on every call.
+  INVALID_NUCLEOTIDE_PATTERN = "^#{NUCLEOTIDE_CODES}".freeze
 
   module_function
 
@@ -138,7 +143,7 @@ module DDBJRecordValidator
         }
       end
 
-      if !aa && seq.count("^#{NUCLEOTIDE_CODES}").positive?
+      if !aa && seq.count(INVALID_NUCLEOTIDE_PATTERN).positive?
         details << {
           entry_id:,
           code:     'TRD_R0005',

--- a/test/models/ddbj_record_validator_test.rb
+++ b/test/models/ddbj_record_validator_test.rb
@@ -1,0 +1,123 @@
+require 'test_helper'
+
+class DDBJRecordValidatorTest < ActiveSupport::TestCase
+  # Minimal valid v2 record carrying a single entry. The sequence and its
+  # mol_type are injected by the caller so each test can exercise a specific
+  # shape (nucleotide vs protein).
+  def attach_record(request, sequence, mol_type: 'genomic DNA')
+    record = {
+      schema_version: 'v2',
+      provenance:     {source_format: 'ST26'},
+
+      submission: {
+        submitters:                                   [],
+        db_xrefs:                                     [],
+        references:                                   [],
+        comments:                                     [],
+        division:                                     'PAT',
+        earliest_priority_application_identifications: [],
+
+        application_identification: {
+          application_number_text: '2026-123456',
+          filing_date:             '2026-01-15',
+          ip_office_code:          'JP'
+        }
+      },
+
+      experiments: [],
+
+      sequences: {
+        common_source: {organism: '', mol_type: '', qualifiers: {}},
+
+        entries: [
+          {
+            id:       'SEQ|JP|2026123456|A|1',
+            type:     'other',
+            topology: 'linear',
+            sequence:,
+            length:   sequence.length,
+            tax_id:   9606,
+
+            source_features: [
+              {
+                id:       'source_1',
+                location: "1..#{sequence.length}",
+
+                source: {
+                  organism:   'Homo sapiens',
+                  mol_type:,
+                  qualifiers: {}
+                }
+              }
+            ]
+          }
+        ]
+      },
+
+      features: []
+    }
+
+    request.ddbj_record.attach(
+      io:           StringIO.new(Oj.dump(record, mode: :rails)),
+      filename:     'record.json',
+      content_type: 'application/json'
+    )
+  end
+
+  def codes(request)
+    request.validation.details.pluck(:code)
+  end
+
+  # Regression guard: a large but valid nucleotide sequence must not be
+  # misclassified as an error, and must never surface as TRD_R9999. The
+  # sequence checks used to run a case-insensitive regexp over the whole
+  # sequence, which blows past Regexp.timeout on multi-MB inputs. We pin an
+  # aggressive timeout so a revert to the regexp form fails here rather than
+  # only on production-sized (80M+ char) sequences.
+  test 'large valid nucleotide sequence does not trip Regexp.timeout' do
+    request = submission_requests(:st26)
+    attach_record request, 'acgt' * 8_000_000 # 32 MB, valid
+
+    with_regexp_timeout 0.05 do
+      DDBJRecordValidator.validate request
+    end
+
+    refute_includes codes(request), 'TRD_R9999',
+                    'valid sequence produced a regexp match timeout'
+    assert_predicate request.reload, :ready_to_apply?
+  end
+
+  test 'nucleotide sequence character checks classify correctly without regexp' do
+    with_regexp_timeout 0.05 do
+      assert_includes validate_sequence('n' * 100), 'TRD_R0003'   # N-only
+      assert_includes validate_sequence('acgtx'),   'TRD_R0005'   # invalid char
+      refute_includes validate_sequence('acgtn'),   'TRD_R0003'   # mixed, not N-only
+      refute_includes validate_sequence('acgtn'),   'TRD_R0005'   # all IUPAC
+    end
+  end
+
+  test 'protein X-only check classifies correctly without regexp' do
+    with_regexp_timeout 0.05 do
+      assert_includes validate_sequence('x' * 100, mol_type: 'protein'), 'TRD_R0004' # X-only
+      refute_includes validate_sequence('mkvx',    mol_type: 'protein'), 'TRD_R0004' # mixed, not X-only
+    end
+  end
+
+  private
+
+  def validate_sequence(sequence, mol_type: 'genomic DNA')
+    request = submission_requests(:st26)
+    request.ddbj_record.purge if request.ddbj_record.attached?
+    attach_record(request, sequence, mol_type:)
+    DDBJRecordValidator.validate request
+    codes request
+  end
+
+  def with_regexp_timeout(seconds)
+    original       = Regexp.timeout
+    Regexp.timeout = seconds
+    yield
+  ensure
+    Regexp.timeout = original
+  end
+end


### PR DESCRIPTION
## Summary

- Replace three case-insensitive sequence-character regexps in `DDBJRecordValidator` with `String#count` scans, so multi-MB entries stop tripping Rails' 1-second `Regexp.timeout` and getting rejected as `TRD_R9999`.
- The failing case was a real ~83M-char JPO patent sequence: `/[^acgtmrwsykvhdbn]/i` took ~0.5s locally and blew past the timeout under load. `String#count` is a C-level scan with no regexp engine involved (~23x faster here, independent of size).
- Add a regression test that pins `Regexp.timeout = 0.05` so a revert to the regexp form fails without needing a production-sized fixture.

The follow-up commit (`43aa410d`) freezes `NUCLEOTIDE_CODES` and caches `INVALID_NUCLEOTIDE_PATTERN = "^#{NUCLEOTIDE_CODES}"` so the per-entry hot loop doesn't re-allocate the argument String on every call.

## Test plan

- [x] `bundle exec rails test test/models/ddbj_record_validator_test.rb` (3 runs, 16 assertions, green)
- [x] `bundle exec rails test` full suite (103 runs, 315 assertions, green)
- [x] `bundle exec rubocop app/models/ddbj_record_validator.rb` clean
- [ ] JPO の実 XML (~83M-char entry) を staging に流して TRD_R9999 が出ないことを確認
- [ ] admin/submission_requests の validation エラー傾向を数日観察 (真陽性の R0003/R0004/R0005 が意図通りに出ていること)

🤖 Generated with [Claude Code](https://claude.com/claude-code)