### PR TITLE
jpo_na の採番 prefix に QW, QX を追加

### DIFF
--- a/config/sequence.yml
+++ b/config/sequence.yml
@@ -1,6 +1,6 @@
 shared:
   jpo_na:
-    <% ('QP'..'QU').without('QR').each do |prefix| %>
+    <% ('QP'..'QX').without('QR', 'QV').each do |prefix| %>
     - prefix: '<%= prefix %>'
       digits: 6
     <% end %>


### PR DESCRIPTION
## 背景

JPO 累積データ（PATENT-370）の再登録で、単一ファイル `JP2023037643.xml`（実配列 **1,410,489 件**、入力 1.6GB）の採番が `Sequence::Exhausted` で失敗し、ファイルごと未登録になった。

調査の結果、原因は accession 枯渇と判明：

- `jpo_na` の prefix リストは `QP, QQ, QS, QT, QU`（QR 除外・6桁、上限 **QU999999**）
- 本番シーケンスの現在値は `jpo_na = QT705693`（リセット開始点 QS396394 から成功分 1,309,298 件を採番した位置）
- 残容量 `QT705693 → QU999999 = 1,294,306` < ファイル需要 `1,410,489` → 一括採番できず `Exhausted`
- バッチ全体の NA 需要（約 2.72M）が既存 prefix の容量（QS396394 以降で約 2.60M）を超過

## 変更

`jpo_na` の prefix 末尾に **QW, QX** を追加（QR に加え QV も欠番として飛ばす）。

```
QP, QQ, QS, QT, QU  →  QP, QQ, QS, QT, QU, QW, QX
```

- 展開結果: `["QP","QQ","QS","QT","QU","QW","QX"]`（7 prefix、容量 700万件）
- `('QP'..'QX').without('QR', 'QV')` で実現

## デプロイ後の復旧手順（クライアント側）

1. 本番デプロイで prefix 拡張を反映
2. `bin/st26 submit --date <日付> production`（**`-f` 不要**：失敗ファイルは `st26_files` 未記録のため自動再試行。JP2023037643 は本番 st26_files に未登録を確認済み）
3. `bin/st26 reconcile production` で欠番ゼロ確認

## テスト

`bin/rails test test/models/sequence_test.rb` — green（先頭 QP→QQ の採番検証、末尾追加には非依存）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)