### PR TITLE
空 organism 時に COMMENT OS を unidentified にフォールバック

### DIFF
--- a/app/models/flatfile/entry.rb
+++ b/app/models/flatfile/entry.rb
@@ -85,7 +85,7 @@ module Flatfile
     end
 
     def organism
-      raw_primary_source_feature&.source&.organism || 'unidentified'
+      raw_primary_source_feature&.source&.organism.presence || 'unidentified'
     end
 
     def primary_source_feature

--- a/test/models/flatfile_test.rb
+++ b/test/models/flatfile_test.rb
@@ -58,6 +58,24 @@ class FlatfileTest < ActiveSupport::TestCase
     refute_match(/^ {12}PI /, output)
   end
 
+  test 'renders unidentified in COMMENT OS when the source organism is blank' do
+    record = build_record
+
+    entries = record.sequences.entries.map {|entry|
+      entry.with(
+        source_features: entry.source_features.map {|sf|
+          sf.with(source: sf.source.with(organism: ' '))
+        }
+      )
+    }
+
+    record = record.with(sequences: record.sequences.with(entries:))
+    output = Flatfile.render(record, record.sequences.entries).read
+
+    assert_includes output, "COMMENT     OS   unidentified\n"
+    refute_match(/^COMMENT {5}OS {3}$/, output)
+  end
+
   test 'renders flatfile from Data objects' do
     record = build_record
     output = Flatfile.render(record, record.sequences.entries).read


### PR DESCRIPTION
## 背景

source feature の `organism` 値が空（XML の `<INSDQualifier_value>` が空白のみ、または値要素なし）の場合、FF の `COMMENT OS` 行が **空欄**になっていた。

クライアント（submission-bulk-st26）は空の organism を空文字 `''` で送る。FF 生成の各行のうち：

- `SOURCE` / `ORGANISM` / `/organism=` は tax_id（空 organism → **taxon:32644**）由来の scientific_name を使うため `unidentified` になる
- しかし `COMMENT OS` 行だけは**生の `source.organism`** を使っており、`source.organism || 'unidentified'` のフォールバックが truthy な空文字に阻まれて空欄になっていた（`/mol_type=""` と同じ「空文字が truthy」パターン）

## 変更

`Flatfile::Entry#organism` で `.presence` を挟み、空文字・空白を欠損扱いにする。

```ruby
def organism
  raw_primary_source_feature&.source&.organism.presence || 'unidentified'
end
```

organism が有る場合は生値をそのまま保持し（例: `COMMENT OS Artificial Sequqence`）、空・空白のときだけ `unidentified` になる。エントリ除外は発生しない（意図どおり）。

## テスト

`test/models/flatfile_test.rb` に回帰テストを追加。修正前は `COMMENT OS ` 空欄で fail、修正後は `COMMENT OS unidentified` で pass することを確認済み。`bin/rails test test/models/flatfile_test.rb` green、rubocop クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)