### PR TITLE
Make web and admin login/logout independent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,7 @@
 !/tmp/storage/.keep
 
 # Ignore master key for decrypting credentials and more.
-/config/credentials/production.key
-/config/credentials/staging.key
+/config/credentials/*.key
 /config/master.key
 
 # Ignore compiled SCSS output (built by dartsass-rails).

--- a/app/controllers/admin/proxy_logins_controller.rb
+++ b/app/controllers/admin/proxy_logins_controller.rb
@@ -3,7 +3,11 @@ module Admin
     def create
       User.find_by!(uid: params[:user_uid])
 
-      redirect_to_web '/web/', proxy_login: params[:user_uid]
+      # The web client is JWT-only, so hand it the admin's own token (this
+      # action is session-authenticated) alongside the proxy target. It
+      # logs in with that token and then acts as `user_uid` via the
+      # X-Dway-User-Id header — no separate web login required.
+      redirect_to_web '/web/login', token: current_user.token, proxy_login: params[:user_uid]
     end
   end
 end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -5,5 +5,11 @@ module Admin
     def new
       @origin = params[:origin].presence || admin_root_path
     end
+
+    def destroy
+      reset_session
+
+      redirect_to new_admin_session_path
+    end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 class SessionsController < ApplicationController
   ADMIN_ACCOUNT_TYPE = 3
 
-  skip_before_action :authenticate!, only: %i[create destroy]
+  skip_before_action :authenticate!, only: %i[create]
 
   def create
     uid  = request.env.dig('omniauth.auth', 'extra', 'raw_info', 'preferred_username')
@@ -9,20 +9,17 @@ class SessionsController < ApplicationController
 
     user.update! admin: request.env.dig('omniauth.auth', 'extra', 'raw_info', 'account_type_number') == ADMIN_ACCOUNT_TYPE
 
-    session[:user_id] = user.id
-
     origin = request.env['omniauth.origin']
 
     if origin == '/admin' || origin&.start_with?('/admin/')
+      # Admin uses a Rails session cookie; the web client is JWT-only. Only
+      # mint the cookie for the admin flow so the two logins stay
+      # independent (a web login must not silently grant an admin session,
+      # and vice versa).
+      session[:user_id] = user.id
       redirect_to origin
     else
       redirect_to_web '/web/login', token: user.token
     end
-  end
-
-  def destroy
-    reset_session
-
-    redirect_to_web
   end
 end

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -27,7 +27,7 @@
                 <li><%= link_to 'Back to repository', '/web/', class: 'dropdown-item', data: {turbo: false} %></li>
                 <li><hr class="dropdown-divider"></li>
                 <li>
-                  <%= button_to 'Logout', session_path, method: :delete, class: 'dropdown-item', data: {turbo: false} %>
+                  <%= button_to 'Logout', admin_session_path, method: :delete, class: 'dropdown-item', data: {turbo: false} %>
                 </li>
               </ul>
             </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,6 @@ Rails.application.routes.draw do
   get 'auth/:provider/callback', to: 'sessions#create'
   get 'auth/failure',            to: 'sessions#failure'
 
-  resource :session, only: %i[destroy]
-
   scope :api, defaults: {format: :json} do
     resource :api_key, only: [] do
       post :regenerate
@@ -37,7 +35,7 @@ Rails.application.routes.draw do
   namespace :admin do
     root to: 'dashboard#show'
 
-    resource :session, only: %i[new]
+    resource :session, only: %i[new destroy]
 
     resources :submission_requests, only: %i[index]
     resources :submissions,         only: %i[index]

--- a/test/integration/admin/users_test.rb
+++ b/test/integration/admin/users_test.rb
@@ -128,9 +128,11 @@ class AdminUsersTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
-  test 'proxy_login redirects to web with the proxy_login query parameter' do
+  test 'proxy_login redirects to the web login with the admin token and proxy target' do
     post admin_user_proxy_login_path(user_uid: 'alice')
 
-    assert_redirected_to %r{http://repository\.example\.com:4200/web/\?proxy_login=alice}
+    # The web client is JWT-only, so proxy-login hands it the admin's own
+    # token plus the proxy target; the web login route then acts as alice.
+    assert_redirected_to %r{http://repository\.example\.com:4200/web/login\?token=.+&proxy_login=alice}
   end
 end

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class SessionsTest < ActionDispatch::IntegrationTest
+  def mock_keycloak(user)
+    OmniAuth.config.mock_auth[:keycloak] = OmniAuth::AuthHash.new(
+      'provider' => 'keycloak',
+      'uid'      => user.uid,
+
+      'extra' => {
+        'raw_info' => {
+          'preferred_username'  => user.uid,
+          'account_type_number' => user.admin? ? SessionsController::ADMIN_ACCOUNT_TYPE : 1
+        }
+      }
+    )
+  end
+
+  test 'admin-origin login mints the session cookie and returns to admin' do
+    mock_keycloak(users(:bob))
+
+    get '/auth/keycloak/callback', env: {'omniauth.origin' => '/admin/users'}
+
+    assert_redirected_to '/admin/users'
+    assert_equal users(:bob).id, session[:user_id]
+  end
+
+  test 'web-origin login issues a JWT to the web client without an admin session' do
+    mock_keycloak(users(:alice))
+
+    get '/auth/keycloak/callback' # no admin origin → web branch
+
+    assert_match %r{/web/login\?token=}, response.location
+    assert_nil session[:user_id] # a web login must not leak an admin session
+  end
+
+  test 'admin logout clears the session and returns to the admin login' do
+    sign_in_as users(:bob)
+    assert session[:user_id]
+
+    delete admin_session_path
+
+    assert_redirected_to new_admin_session_path
+    assert_nil session[:user_id]
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -77,7 +77,9 @@ class ActionDispatch::IntegrationTest
       }
     )
 
-    get '/auth/keycloak/callback'
+    # Drive the admin-origin branch so the callback mints the session
+    # cookie (the web branch is JWT-only and sets no session).
+    get '/auth/keycloak/callback', env: {'omniauth.origin' => '/admin'}
   end
 
   def stub_cloakman_lookup(profiles, uids: profiles.map { it[:uid] })

--- a/web/app/routes/application.ts
+++ b/web/app/routes/application.ts
@@ -24,16 +24,6 @@ export default class ApplicationRoute extends Route {
         throw err;
       }
     }
-
-    const url = new URL(location.href);
-    const proxyUid = url.searchParams.get('proxy_login');
-
-    if (proxyUid && this.currentUser.isLoggedIn) {
-      this.currentUser.startProxy(proxyUid);
-
-      url.searchParams.delete('proxy_login');
-      window.history.replaceState(null, '', url.toString());
-    }
   }
 
   @action

--- a/web/app/routes/login.ts
+++ b/web/app/routes/login.ts
@@ -7,8 +7,10 @@ export default class LoginRoute extends Route {
   @service declare currentUser: CurrentUserService;
 
   async beforeModel() {
-    const token = new URL(location.href).searchParams.get('token')!;
+    const params = new URL(location.href).searchParams;
+    const token = params.get('token')!;
+    const proxyUid = params.get('proxy_login') ?? undefined;
 
-    await this.currentUser.login(token);
+    await this.currentUser.login(token, proxyUid);
   }
 }

--- a/web/app/services/current-user.ts
+++ b/web/app/services/current-user.ts
@@ -2,7 +2,6 @@ import Service, { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
-import ENV from 'repository/config/environment';
 import User from 'repository/models/user';
 
 import type { RequestManager } from '@warp-drive/core';
@@ -78,11 +77,18 @@ export default class CurrentUserService extends Service {
     this.router.transitionTo('index');
   }
 
-  async login(token: string) {
+  async login(token: string, proxyUid?: string) {
     this.clear();
     localStorage.setItem('token', token);
 
     await this.restore();
+
+    // Proxy-login hands the admin's token plus a target uid in one hop
+    // (see Admin::ProxyLoginsController); start acting as the target here,
+    // after the token is in place.
+    if (proxyUid) {
+      this.startProxy(proxyUid);
+    }
 
     if (this.previousTransition) {
       this.previousTransition.retry();
@@ -92,20 +98,12 @@ export default class CurrentUserService extends Service {
     }
   }
 
-  async logout() {
+  logout() {
+    // The web session is just the JWT in localStorage (stateless, no
+    // server-side session to clear — that's the admin's cookie, which is
+    // now independent). Clearing local state is the whole logout.
     this.clear();
     localStorage.removeItem('token');
-
-    // /session is outside /api, so RequestManager's BaseURLHandler wouldn't
-    // route it; AuthHandler would also attach a stale bearer token.
-    const sessionUrl = `${ENV.appURL}/session`;
-
-    try {
-      // eslint-disable-next-line warp-drive/no-external-request-patterns
-      await fetch(sessionUrl, { method: 'DELETE', credentials: 'include' });
-    } catch {
-      // Network failures are non-fatal: local state is already cleared.
-    }
 
     this.router.transitionTo('index');
   }

--- a/web/app/templates/application.gts
+++ b/web/app/templates/application.gts
@@ -22,8 +22,8 @@ export default class extends Component {
   @service declare toast: ToastService;
 
   @action
-  async logout() {
-    await this.currentUser.logout();
+  logout() {
+    this.currentUser.logout();
 
     this.toast.show('Logged out.', 'success');
   }


### PR DESCRIPTION
## What

Decouple the web-client and admin login state so each app logs in/out independently.

Today a single OAuth callback sets the Rails **session cookie on every login**, so:
- a **web** login also grants an admin session (and a web logout resets it),
- an **admin** logout dumps you into the web client,

even though the two are really independent — **admin = session cookie**, **web = JWT (localStorage)**, and the API never reads the session cookie.

## Changes

- `SessionsController#create` mints the session cookie **only for the admin origin**; the web flow gets a JWT and no cookie. Drops the now-unused top-level `session#destroy` route.
- **Web logout** just clears its localStorage token (no server call). **Admin logout** gets its own `Admin::SessionsController#destroy` → `reset_session` → back to the admin login.
- **Proxy-login** now hands the web client the admin's own token alongside the proxy target (it was relying on the admin already holding a web JWT), so it works from an admin-only session.
- Hardened `.gitignore` to cover `config/credentials/dev.key` (separate commit).

## Notes

- The OAuth callback stays shared (one Keycloak client, branched on `origin`). "Independent" = independent app sessions; Keycloak SSO keeps re-login one-click.
- Added `test/integration/sessions_test.rb` (there was no session coverage before).
- This targets **main**; `data-migration` will pick it up on its next rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)