### PR TITLE
Fix CLAUDE.md test-framework drift (rspec → minitest)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ app/              Rails application
 web/              Ember.js frontend
 schema/           OpenAPI schema
 docker/           SeaweedFS configuration
-spec/             RSpec tests
+test/             Minitest tests
 data/             Qualifier/feature reference data
 ```
 
@@ -43,7 +43,7 @@ data/             Qualifier/feature reference data
 ```sh
 bin/setup          # Initial setup
 bin/dev            # Start all services (Rails, Ember, SeaweedFS, etc.)
-bundle exec rspec  # Run backend tests
+bin/rails test     # Run backend tests
 cd web && pnpm test  # Run frontend tests
 cd web && pnpm lint  # Run frontend linters
 ```
@@ -51,7 +51,7 @@ cd web && pnpm lint  # Run frontend linters
 ## CI
 
 Two workflows on push:
-- **API** (`api.yml`): `rspec`, `brakeman`, `rubocop`
+- **API** (`api.yml`): `bin/rails test`, `brakeman`, `rubocop`
 - **Web** (`web.yml`): `pnpm lint`, `pnpm test`
 
 ## Key Architecture


### PR DESCRIPTION
`CLAUDE.md` described the backend test setup as RSpec, but the backend actually uses Minitest under `test/` (run via `bin/rails test`, as CI does). There is no `spec/`, `.rspec`, or rspec gem.

Fix three spots to match reality:
- Repository Structure: `spec/ RSpec tests` → `test/ Minitest tests`
- Development Commands: `bundle exec rspec` → `bin/rails test`
- CI (API): `rspec` → `bin/rails test` (matches `api.yml`)

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)