### PR TITLE
最終 prefix の最終番号を払い出せるようにする

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -2,21 +2,16 @@ class StatsController < ApplicationController
   skip_before_action :authenticate!
 
   def index
-    config = Rails.application.config_for(:sequence)
-
     render json: {
+      # 番号の組み立ても残量の計算も Sequence 側。ここで写すと、払い出しが実際に出す
+      # 番号と表示がずれる（pad の有無、prefix の送り待ち）。
       sequences: Sequence.order(:id).map {|seq|
-        prefixes = config.fetch(seq.scope.to_sym)
-        total    = prefixes.sum { 10 ** it[:digits] - 1 }
-        i        = prefixes.index { it[:prefix] == seq.prefix }
-        used     = prefixes.take(i).sum { 10 ** it[:digits] - 1 } + (seq.next - 1)
-
         {
           scope:     seq.scope,
-          next:      "#{seq.prefix}#{seq.next.to_s.rjust(prefixes[i][:digits], '0')}",
-          total:,
-          used:,
-          remaining: total - used
+          next:      seq.peek,
+          total:     seq.total,
+          used:      seq.used,
+          remaining: seq.remaining
         }
       },
 

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -16,57 +16,93 @@ class Sequence < ApplicationRecord
     def allocate!(scope, count)
       ensure_records!
 
-      list = config.fetch(scope)
+      transaction {
+        lock.find_by!(scope:).allocate!(count)
+      }
+    end
+  end
 
-      transaction do
-        seq = lock.find_by!(scope:)
-        out = []
+  # scope に割り当てられた prefix の一覧。先頭から順に使い切っていく。
+  def prefixes = self.class.config.fetch(scope.to_sym)
 
-        while count > 0
-          unless i = list.index { it[:prefix] == seq.prefix }
-            raise "Prefix #{seq.prefix} not found in scope #{scope}"
-          end
+  # 次に払い出される番号。使い切っていれば nil。
+  #
+  # allocate! は使い切った prefix を送る仕事を次の呼び出しに残すので、`next` が
+  # 今の prefix の最大値を超えたまま休んでいることがある。表示する側はそれを
+  # 解決してからでないと、桁の合わない番号（QP1000000）を名乗ってしまう。
+  def peek
+    i, value = position
 
-          digits  = list[i][:digits]
-          pad     = list[i].fetch(:pad, true)
-          max_val = (10 ** digits) - 1
-          start   = seq.next
-          avail   = max_val - start + 1
+    i && format_number(prefixes[i], value)
+  end
 
-          # 使い切った prefix から次へ送るのはここだけ。まだ採番が残っているのに次が無い
-          # ときだけ Exhausted になる。
-          if avail <= 0
-            raise Exhausted if i + 1 >= list.size
+  def total = prefixes.sum { max_value(it) }
 
-            seq.update!(
-              prefix: list[i + 1][:prefix],
-              next:   1
-            )
+  # 送りを解決する必要はない。next が最大値を超えていても、それは今の prefix を
+  # 使い切ったという意味で、消費数としては正しい。
+  def used = prefixes.take(current_index).sum { max_value(it) } + (self.next - 1)
 
-            next
-          end
+  def remaining = total - used
 
-          take = [count, avail].min
-          stop = start + take - 1
+  # count 個を払い出して番号の配列を返す。足りなければ 1 個も払い出さない
+  # （呼び出し側がトランザクションを張っているので、raise でここの update! も巻き戻る）。
+  def allocate!(count)
+    out = []
 
-          out.concat format_range(seq.prefix, start, stop, digits, pad)
-          count -= take
+    while count > 0
+      i       = current_index
+      entry   = prefixes[i]
+      max_val = max_value(entry)
+      start   = self.next
+      avail   = max_val - start + 1
 
-          # 使い切った場合は next が max_val + 1 になり、次の周回（あるいは次の呼び出し）が
-          # 上で送る。ここで送ろうとすると、最後の prefix の最終番号でぴったり終わった採番が
-          # 「次の prefix が無い」という理由で Exhausted になり、全件成功しているのに
-          # ロールバックされる。その番号は永久に払い出せなくなる。
-          seq.update! next: stop + 1
-        end
+      # 使い切った prefix から次へ送るのはここだけ。まだ採番が残っているのに次が無い
+      # ときだけ Exhausted になる。
+      if avail <= 0
+        raise Exhausted, "#{scope}: no numbers left after #{prefix} (wanted #{count} more)" if i + 1 >= prefixes.size
 
-        out
+        update!(
+          prefix: prefixes[i + 1][:prefix],
+          next:   1
+        )
+
+        next
       end
+
+      take = [count, avail].min
+      stop = start + take - 1
+
+      out.concat (start..stop).map { format_number(entry, it) }
+      count -= take
+
+      # 使い切った場合は next が max_val + 1 になり、次の周回（あるいは次の呼び出し）が
+      # 上で送る。ここで送ろうとすると、最後の prefix の最終番号でぴったり終わった採番が
+      # 「次の prefix が無い」という理由で Exhausted になり、全件成功しているのに
+      # ロールバックされる。その番号は永久に払い出せなくなる。
+      update! next: stop + 1
     end
 
-    private
+    out
+  end
 
-    def format_range(prefix, from, to, digits, pad)
-      (from..to).map { "#{prefix}#{pad ? it.to_s.rjust(digits, '0') : it.to_s}" }
-    end
+  private
+
+  def current_index
+    prefixes.index { it[:prefix] == prefix } or raise "Prefix #{prefix} not found in scope #{scope}"
+  end
+
+  # 送りを解決した [prefix の位置, 番号]。使い切っていれば nil。
+  def position
+    i = current_index
+
+    return [i, self.next] if self.next <= max_value(prefixes[i])
+
+    [i + 1, 1] if i + 1 < prefixes.size
+  end
+
+  def max_value(entry) = (10 ** entry[:digits]) - 1
+
+  def format_number(entry, value)
+    entry.fetch(:pad, true) ? "#{entry[:prefix]}#{value.to_s.rjust(entry[:digits], '0')}" : "#{entry[:prefix]}#{value}"
   end
 end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -33,6 +33,8 @@ class Sequence < ApplicationRecord
           start   = seq.next
           avail   = max_val - start + 1
 
+          # 使い切った prefix から次へ送るのはここだけ。まだ採番が残っているのに次が無い
+          # ときだけ Exhausted になる。
           if avail <= 0
             raise Exhausted if i + 1 >= list.size
 
@@ -50,16 +52,11 @@ class Sequence < ApplicationRecord
           out.concat format_range(seq.prefix, start, stop, digits, pad)
           count -= take
 
-          if stop == max_val
-            raise Exhausted if i + 1 >= list.size
-
-            seq.update!(
-              prefix: list[i + 1][:prefix],
-              next:   1
-            )
-          else
-            seq.update! next: stop + 1
-          end
+          # 使い切った場合は next が max_val + 1 になり、次の周回（あるいは次の呼び出し）が
+          # 上で送る。ここで送ろうとすると、最後の prefix の最終番号でぴったり終わった採番が
+          # 「次の prefix が無い」という理由で Exhausted になり、全件成功しているのに
+          # ロールバックされる。その番号は永久に払い出せなくなる。
+          seq.update! next: stop + 1
         end
 
         out

--- a/schema/openapi.d.ts
+++ b/schema/openapi.d.ts
@@ -1027,6 +1027,68 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * @description How much of each accession space has been handed out, and the state
+         *     of the loaded taxonomy. No authentication: these are counts, not
+         *     anybody's data.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Returns the sequence and taxdump counters. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            sequences: {
+                                scope: string;
+                                /**
+                                 * @description The number the next allocation will hand out.
+                                 *     `null` once every prefix in the space is used
+                                 *     up, which is also when `remaining` reaches 0.
+                                 */
+                                next: string | null;
+                                total: number;
+                                used: number;
+                                remaining: number;
+                            }[];
+                            taxdump: {
+                                names_count: number;
+                                nodes_count: number;
+                                /**
+                                 * Format: date-time
+                                 * @description `null` before the first load.
+                                 */
+                                loaded_at: string | null;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -565,6 +565,8 @@ paths:
       tags:
         - Submission Requests
 
+      security: []
+
       responses:
         '200':
           description: Returns the submission request.
@@ -591,6 +593,8 @@ paths:
 
       tags:
         - Submission Requests
+
+      security: []
 
       parameters:
         - name: page
@@ -1018,6 +1022,85 @@ paths:
 
         '404':
           $ref: '#/components/responses/NotFound'
+
+  /stats:
+    get:
+      description: |
+        How much of each accession space has been handed out, and the state
+        of the loaded taxonomy. No authentication: these are counts, not
+        anybody's data.
+
+      tags:
+        - Stats
+
+      security: []
+
+      responses:
+        '200':
+          description: Returns the sequence and taxdump counters.
+
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [sequences, taxdump]
+
+                properties:
+                  sequences:
+                    type: array
+
+                    items:
+                      type: object
+                      additionalProperties: false
+                      required: [scope, next, total, used, remaining]
+
+                      properties:
+                        # Deliberately not an enum. The set of spaces grows
+                        # as databases are migrated in, and a client that
+                        # rejects an unfamiliar scope would break on the
+                        # release that adds one rather than ignore it.
+                        scope:
+                          type: string
+
+                        next:
+                          description: |
+                            The number the next allocation will hand out.
+                            `null` once every prefix in the space is used
+                            up, which is also when `remaining` reaches 0.
+                          type:
+                            - string
+                            - 'null'
+
+                        total:
+                          type: number
+
+                        used:
+                          type: number
+
+                        remaining:
+                          type: number
+
+                  taxdump:
+                    type: object
+                    additionalProperties: false
+                    required: [names_count, nodes_count, loaded_at]
+
+                    properties:
+                      names_count:
+                        type: number
+
+                      nodes_count:
+                        type: number
+
+                      loaded_at:
+                        description: '`null` before the first load.'
+
+                        type:
+                          - string
+                          - 'null'
+
+                        format: date-time
 
 components:
   schemas:

--- a/test/integration/stats_test.rb
+++ b/test/integration/stats_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class StatsTest < ActionDispatch::IntegrationTest
+  # 認証不要。番号の残量は外から見えてよい情報として出している。
+  test 'index reports the next number and the remaining capacity per scope' do
+    Sequence.ensure_records!
+    Sequence.find_by!(scope: 'jpo_na').update! prefix: 'QP', next: 42
+
+    get stats_path
+
+    assert_conform_schema 200
+
+    stat = response.parsed_body['sequences'].find { it['scope'] == 'jpo_na' }
+
+    assert_equal 'QP000042', stat['next']
+    assert_equal 41,         stat['used']
+    assert_equal stat['total'] - 41, stat['remaining']
+  end
+
+  # 表示が払い出しと食い違わないこと。prefix を使い切った直後は `next` がその
+  # prefix の最大値を超えたまま休むので、素朴に組み立てると QP1000000 という
+  # 存在し得ない番号を名乗る。
+  test 'index resolves a prefix that has been used up' do
+    Sequence.ensure_records!
+    Sequence.find_by!(scope: 'jpo_na').update! prefix: 'QP', next: 1000000
+
+    get stats_path
+
+    assert_conform_schema 200
+
+    stat = response.parsed_body['sequences'].find { it['scope'] == 'jpo_na' }
+
+    assert_equal 'QQ000001', stat['next']
+    assert_equal 999999,     stat['used']
+  end
+
+  # pad: false の scope で桁を埋めない。
+  test 'index does not pad the BioProject number' do
+    Sequence.ensure_records!
+    Sequence.find_by!(scope: 'bp').update! next: 42366
+
+    get stats_path
+
+    assert_conform_schema 200
+
+    stat = response.parsed_body['sequences'].find { it['scope'] == 'bp' }
+
+    assert_equal 'PRJDB42366', stat['next']
+  end
+end

--- a/test/models/sequence_test.rb
+++ b/test/models/sequence_test.rb
@@ -1,6 +1,11 @@
 require 'test_helper'
 
 class SequenceTest < ActiveSupport::TestCase
+  # 使い切りの試験は「最後の prefix」の性質を見るもので、それが QX であることは
+  # 見ていない。空きが尽きたときの手当ては config に prefix を足すことなので、
+  # 直書きすると障害対応の真っ最中に無関係な赤が出る。
+  LAST_JPO_NA = Sequence.config.fetch(:jpo_na).last[:prefix]
+
   test 'allocate! generates sequential accession numbers' do
     assert_equal 'QP000001', Sequence.allocate!(:jpo_na, 1).last
 
@@ -20,21 +25,22 @@ class SequenceTest < ActiveSupport::TestCase
   # すると、全件成功しているのにロールバックされ、その番号は永久に払い出せなくなる。
   test 'allocate! issues the last number of the last prefix' do
     Sequence.ensure_records!
-    Sequence.find_by!(scope: 'jpo_na').update! prefix: 'QX', next: 999998
+    Sequence.find_by!(scope: 'jpo_na').update! prefix: LAST_JPO_NA, next: 999998
 
-    assert_equal %w[QX999998 QX999999], Sequence.allocate!(:jpo_na, 2)
+    assert_equal ["#{LAST_JPO_NA}999998", "#{LAST_JPO_NA}999999"], Sequence.allocate!(:jpo_na, 2)
 
     assert_raises Sequence::Exhausted do
       Sequence.allocate! :jpo_na, 1
     end
   end
 
-  # 足りないときは 1 件も払い出さない。ApplySubmissionRequestJob はこれと
+  # 足りないときは 1 件も払い出さない。ApplySubmissionRequestJob は allocate! と
   # create_submission! を同一トランザクションに置いているので、部分的な消費が
   # 起きると「番号が消費された ⟺ submission が存在する」が崩れる。
+  # （entries の COPY はそのトランザクションの外なので、そこから先は別の話）
   test 'allocate! consumes nothing when the remaining capacity is short' do
     Sequence.ensure_records!
-    Sequence.find_by!(scope: 'jpo_na').update! prefix: 'QX', next: 999998
+    Sequence.find_by!(scope: 'jpo_na').update! prefix: LAST_JPO_NA, next: 999998
 
     assert_raises Sequence::Exhausted do
       Sequence.allocate! :jpo_na, 3
@@ -42,8 +48,54 @@ class SequenceTest < ActiveSupport::TestCase
 
     seq = Sequence.find_by!(scope: 'jpo_na')
 
-    assert_equal 'QX',   seq.prefix
-    assert_equal 999998, seq.next
+    assert_equal LAST_JPO_NA, seq.prefix
+    assert_equal 999998,      seq.next
+  end
+
+  # 使い切ったことは、どの scope でも「番号が尽きた」としか読めないメッセージで
+  # 落ちてはいけない。ApplySubmissionRequestJob がこれをそのまま
+  # request.error_message に書くので、登録者の画面に出る文言そのもの。
+  test 'Exhausted names the scope and the prefix it ran out on' do
+    Sequence.ensure_records!
+    Sequence.find_by!(scope: 'jpo_na').update! prefix: LAST_JPO_NA, next: 1000000
+
+    error = assert_raises Sequence::Exhausted do
+      Sequence.allocate! :jpo_na, 2
+    end
+
+    assert_match(/jpo_na/,       error.message)
+    assert_match(/#{LAST_JPO_NA}/, error.message)
+    assert_match(/2/,            error.message)
+  end
+
+  # peek は allocate! が実際に出す番号でなければならない。使い切った prefix の
+  # 送りは次の呼び出しに残るので、その状態を解決せずに組み立てると桁が溢れる。
+  test 'peek resolves a prefix that has been used up' do
+    Sequence.ensure_records!
+    seq = Sequence.find_by!(scope: 'jpo_na')
+    seq.update! prefix: 'QP', next: 1000000
+
+    assert_equal 'QQ000001', seq.peek
+    assert_equal seq.peek,   Sequence.allocate!(:jpo_na, 1).sole
+  end
+
+  test 'peek is nil once every prefix is used up' do
+    Sequence.ensure_records!
+    seq = Sequence.find_by!(scope: 'jpo_na')
+    seq.update! prefix: LAST_JPO_NA, next: 1000000
+
+    assert_nil seq.peek
+    assert_equal 0, seq.remaining
+  end
+
+  # pad を無視して組み立てると PRJDB000042366 になる。allocate! が出すのは
+  # PRJDB42366 で、そちらが本物。
+  test 'peek honours the pad flag' do
+    Sequence.ensure_records!
+    seq = Sequence.find_by!(scope: 'bp')
+    seq.update! next: 42366
+
+    assert_equal 'PRJDB42366', seq.peek
   end
 
   test 'bp scope emits PRJDB-prefixed numbers without zero padding' do

--- a/test/models/sequence_test.rb
+++ b/test/models/sequence_test.rb
@@ -9,6 +9,43 @@ class SequenceTest < ActiveSupport::TestCase
     assert_equal 'QQ000001', Sequence.allocate!(:jpo_na, 1).last
   end
 
+  test 'allocate! spans prefixes within a single call' do
+    Sequence.ensure_records!
+    Sequence.find_by!(scope: 'jpo_na').update! prefix: 'QP', next: 999999
+
+    assert_equal %w[QP999999 QQ000001 QQ000002], Sequence.allocate!(:jpo_na, 3)
+  end
+
+  # 最後の prefix の最終番号でぴったり終わる採番は成立している。ここで Exhausted に
+  # すると、全件成功しているのにロールバックされ、その番号は永久に払い出せなくなる。
+  test 'allocate! issues the last number of the last prefix' do
+    Sequence.ensure_records!
+    Sequence.find_by!(scope: 'jpo_na').update! prefix: 'QX', next: 999998
+
+    assert_equal %w[QX999998 QX999999], Sequence.allocate!(:jpo_na, 2)
+
+    assert_raises Sequence::Exhausted do
+      Sequence.allocate! :jpo_na, 1
+    end
+  end
+
+  # 足りないときは 1 件も払い出さない。ApplySubmissionRequestJob はこれと
+  # create_submission! を同一トランザクションに置いているので、部分的な消費が
+  # 起きると「番号が消費された ⟺ submission が存在する」が崩れる。
+  test 'allocate! consumes nothing when the remaining capacity is short' do
+    Sequence.ensure_records!
+    Sequence.find_by!(scope: 'jpo_na').update! prefix: 'QX', next: 999998
+
+    assert_raises Sequence::Exhausted do
+      Sequence.allocate! :jpo_na, 3
+    end
+
+    seq = Sequence.find_by!(scope: 'jpo_na')
+
+    assert_equal 'QX',   seq.prefix
+    assert_equal 999998, seq.next
+  end
+
   test 'bp scope emits PRJDB-prefixed numbers without zero padding' do
     Sequence.ensure_records!
     Sequence.find_by!(scope: 'bp').update! next: 42366


### PR DESCRIPTION
## 症状

最後の prefix の最終番号（`jpo_na` なら `QX999999`、`jpo_aa` なら `ZZZ9999999`、`bs` なら `SAMD99999999`）でぴったり終わる採番が、**全件成功しているのに `Sequence::Exhausted` でロールバックされる**。

```ruby
Sequence.find_by!(scope: 'jpo_na').update! prefix: 'QX', next: 999999

Sequence.allocate! :jpo_na, 1   # => Sequence::Exhausted（本来 ["QX999999"]）
```

`ApplySubmissionRequestJob` は `allocate!` と `create_submission!` を同一トランザクションに置いているので、この場合は submission ごと失敗する。残容量にちょうど収まるファイルが 1 つ落ち、その番号は以降どの prefix を足しても払い出せない。

## 原因

prefix を使い切ったときの繰り上げが、ループの先頭（`avail <= 0`）と末尾（`stop == max_val`）に重複していた。末尾側は `count` が 0 になっていても — つまり要求された分をすべて払い出し終えていても — 「次の prefix が無い」というだけで `Exhausted` を上げる。

## 修正

末尾は `next` を進めるだけにして、繰り上げを先頭の分岐に一本化した。使い切った直後は `next` が `max_val + 1` になり、**次の周回か次の呼び出し**がそこで繰り上げる（残りが無ければそこで `Exhausted`）。

払い出す番号列は変わらない。1 回の呼び出しの中で prefix をまたぐケースも、`avail <= 0` の分岐が同じ周回で処理するので従来どおり。

## テスト

3 本追加。うち「最終番号を払い出せる」は修正前に落ちることを確認済み。

- 1 回の呼び出しで prefix をまたぐ（`QP999999` → `QQ000001`）
- 最後の prefix の最終番号を払い出し、その次で `Exhausted` になる
- 足りないときは 1 件も消費しない（`prefix` / `next` が動かないこと）

901 runs / 2938 assertions / 0 failures。

## 関連

クライアント側（submission-bulk-st26 #84）が `Sequence::Exhausted` を検出してランを打ち切るようにしたので、この誤検出はそのまま「残りのファイルを処理しない」に繋がる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)