### PR TITLE
Exhausted の文言に読み手がいることを書いておく

### DIFF
--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -58,6 +58,12 @@ class Sequence < ApplicationRecord
 
       # 使い切った prefix から次へ送るのはここだけ。まだ採番が残っているのに次が無い
       # ときだけ Exhausted になる。
+      #
+      # **この文言は submission-bulk-st26 が読んでいる**（`Submission::SEQUENCE_EXHAUSTED`
+      # が `/no numbers left/` で見る）。ApplySubmissionRequestJob が message をそのまま
+      # error_message に載せるので、それが「採番が尽きた」と分かる唯一の手がかりになって
+      # いる。文言を変えると向こうは静かに検出をやめ、残容量に収まる小さいファイルだけが
+      # 通って採番の切れ目が散らばる。変えるときは向こうも一緒に直すこと。
       if avail <= 0
         raise Exhausted, "#{scope}: no numbers left after #{prefix} (wanted #{count} more)" if i + 1 >= prefixes.size
 


### PR DESCRIPTION
コメント 1 箇所のみの変更です。

## 背景

submission-bulk-st26 は `Sequence::Exhausted` のメッセージを `/no numbers left/` で見て、採番が尽きたらラン全体を打ち切ります（[#84](https://github.com/ddbj/submission-bulk-st26/pull/84) / [#85](https://github.com/ddbj/submission-bulk-st26/pull/85)）。`ApplySubmissionRequestJob` が `e.message` をそのまま `error_message` に載せるので、クライアントから見るとそれが「採番が尽きた」と分かる唯一の手がかりです。

実際 #1976 でこの文言を付けた際、クライアント側は例外クラス名で見ていたため検出が効かなくなりました（#85 で追随）。**文言を変えると向こうは静かに検出をやめ、残容量に収まる小さいファイルだけが通って採番の切れ目が散らばります。**

クライアント側には「サーバを触るときはここも見ること」と書いてありますが、こちら側には何の印もないので、`raise` の隣に書いておきます。

## 補足

本来は機械可読な識別子（`error_code` 等）を返すのが筋です。OpenAPI 変更とデプロイ順序が絡むので今回は見送っていますが、この文字列結合を消すならその方向になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)