### PR TITLE
適用の失敗に機械可読なコードを付ける

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -31,6 +31,37 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
 
+  # openapi.d.ts is generated from openapi.yml and typechecks the whole web
+  # client. Nothing else notices when it goes stale: `pnpm lint` typechecks
+  # against whatever is committed, so a schema change without a regenerate
+  # leaves the client agreeing with a server contract that no longer exists.
+  schema:
+    name: Schema
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    defaults:
+      run:
+        working-directory: schema
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6.0.9
+        with:
+          package_json_file: schema/package.json
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+          cache-dependency-path: schema/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm generate
+      - name: Check openapi.d.ts is up to date
+        run: git diff --exit-code openapi.d.ts
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,9 +104,14 @@ Two-pass streaming:
 1. Collect entry IDs and NA/AA classification → allocate accessions
 2. Stream entries → write JSON (StreamingWriter) + flatfiles (StreamingRenderer) simultaneously
 
-### Validation Codes
+### Result Codes
 
-Defined in `DDBJRecordValidator`. Reference in README.md.
+One flat `TRD_R` series over both phases, tabulated in README.md. Validation
+codes live in `DDBJRecordValidator` and land per finding in
+`validation_details.code`; application codes live in
+`ApplySubmissionRequestJob::ERROR_CODES` and land once per request in
+`submission_requests.error_code`. A new code goes in whichever of those two
+places matches its phase, plus a row in the README table.
 
 ## Admin Screen Conventions
 
@@ -187,6 +192,10 @@ until dismissed, not in a flash.
 
 ## File Conventions
 
+- `schema/openapi.yml` — the API contract. `schema/openapi.d.ts` is generated
+  from it (`pnpm --dir schema generate`) and is what typechecks the web client,
+  so a change to the yml means regenerating and committing both. The `Schema`
+  CI job fails if they have drifted.
 - `config/seaweedfs.yml` — S3 credentials per environment
 - `config/storage.yml` — ActiveStorage config (quotes ERB values to prevent YAML type coercion)
 - `docker/seaweedfs/` — entrypoint.sh, s3 config JSON for dev/production

--- a/README.md
+++ b/README.md
@@ -142,22 +142,31 @@ erDiagram
     validations ||--o{ validation_details : "has many"
 ```
 
-## Validation Codes
+## Result Codes
 
-| Code | Severity | Description |
-|------|----------|-------------|
-| TRD_R0001 | error | ApplicationNumberText contains invalid characters (only alphanumeric, hyphen, and slash are allowed) |
-| TRD_R0002 | error | Sequence length is zero |
-| TRD_R0003 | error | N-only nucleotide sequence |
-| TRD_R0004 | error | X-only amino acid sequence |
-| TRD_R0005 | error | Invalid characters in nucleotide sequence |
-| TRD_R0006 | warning | Undefined feature key |
-| TRD_R0007 | warning | Undefined qualifier key |
-| TRD_R0008 | error | Invalid presence of qualifier value (missing value for non-boolean qualifier, or value present for boolean qualifier) |
-| TRD_R0009 | error | ST.26 fields (applicant/inventor names, invention titles) contain non-ASCII characters |
-| TRD_R0010 | error | No source feature with mol_type found |
-| TRD_R0011 | warning | ApplicationNumberText is not in the expected format of yyyy-nnnnnn |
-| TRD_R9999 | error | Unexpected internal error during validation |
+One flat `TRD_R` series covering both phases. Validation codes appear per finding
+in `validation_details.code`; application codes appear once per request in
+`submission_requests.error_code`. `TRD_R9999` is the catch-all for either.
+
+Branch on the code rather than on the accompanying message, whose wording changes
+without notice, and treat an unrecognised code the same as `TRD_R9999` — codes are
+added as failures are classified, so the set grows.
+
+| Code | Phase | Severity | Description |
+|------|-------|----------|-------------|
+| TRD_R0001 | validation | error | ApplicationNumberText contains invalid characters (only alphanumeric, hyphen, and slash are allowed) |
+| TRD_R0002 | validation | error | Sequence length is zero |
+| TRD_R0003 | validation | error | N-only nucleotide sequence |
+| TRD_R0004 | validation | error | X-only amino acid sequence |
+| TRD_R0005 | validation | error | Invalid characters in nucleotide sequence |
+| TRD_R0006 | validation | warning | Undefined feature key |
+| TRD_R0007 | validation | warning | Undefined qualifier key |
+| TRD_R0008 | validation | error | Invalid presence of qualifier value (missing value for non-boolean qualifier, or value present for boolean qualifier) |
+| TRD_R0009 | validation | error | ST.26 fields (applicant/inventor names, invention titles) contain non-ASCII characters |
+| TRD_R0010 | validation | error | No source feature with mol_type found |
+| TRD_R0011 | validation | warning | ApplicationNumberText is not in the expected format of yyyy-nnnnnn |
+| TRD_R0012 | application | error | No accession numbers left in the scope; extend its prefix list in `config/sequence.yml`. Nothing was consumed, so the request can be applied again once it is extended |
+| TRD_R9999 | both | error | Unexpected internal error |
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ added as failures are classified, so the set grows.
 | TRD_R0009 | validation | error | ST.26 fields (applicant/inventor names, invention titles) contain non-ASCII characters |
 | TRD_R0010 | validation | error | No source feature with mol_type found |
 | TRD_R0011 | validation | warning | ApplicationNumberText is not in the expected format of yyyy-nnnnnn |
-| TRD_R0012 | application | error | No accession numbers left in the scope; extend its prefix list in `config/sequence.yml`. Nothing was consumed, so the request can be applied again once it is extended |
+| TRD_R0012 | application | error | No accession numbers left in the scope; extend its prefix list in `config/sequence.yml`. Nothing was consumed — no accession was burned and no submission created — so once it is extended the file can be submitted afresh |
 | TRD_R9999 | both | error | Unexpected internal error |
 
 ## Tech Stack

--- a/app/jobs/apply_submission_request_job.rb
+++ b/app/jobs/apply_submission_request_job.rb
@@ -1,8 +1,26 @@
 class ApplySubmissionRequestJob < ApplicationJob
   include SubmissionOutputWriter
 
+  # 分類できた失敗だけがコードを持ち、残りは catch-all になる。増やすときはここに 1 行
+  # 足して README の表に書く。クライアントは知らないコードを catch-all と同じに扱えば
+  # よいので、追加は常に additive。
+  #
+  # error_message の方は人間向けで、文言は予告なく変わる。**機械的な判断はコードで
+  # 行うこと。**
+  ERROR_CODES = {
+    Sequence::Exhausted => 'TRD_R0012'
+  }.freeze
+
+  UNEXPECTED_ERROR_CODE = 'TRD_R9999'
+
   def perform(request)
-    request.applying!
+    # 前回の失敗の痕跡を残さない。コードは機械的な判断に使われるので、古い値が
+    # 残っていると「今まさに失敗している」と読まれる。
+    request.update!(
+      status:        :applying,
+      error_code:    nil,
+      error_message: nil
+    )
 
     apply request
   rescue Exception => e # rubocop:disable Lint/RescueException
@@ -13,6 +31,7 @@ class ApplySubmissionRequestJob < ApplicationJob
 
     request.update!(
       status:        :application_failed,
+      error_code:    error_code_for(e),
       error_message: e.message
     )
 
@@ -22,6 +41,12 @@ class ApplySubmissionRequestJob < ApplicationJob
   end
 
   private
+
+  def error_code_for(error)
+    _, code = ERROR_CODES.find {|klass, _| error.is_a?(klass) }
+
+    code || UNEXPECTED_ERROR_CODE
+  end
 
   def apply(request)
     request.ddbj_record.open do |file|

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -59,11 +59,10 @@ class Sequence < ApplicationRecord
       # 使い切った prefix から次へ送るのはここだけ。まだ採番が残っているのに次が無い
       # ときだけ Exhausted になる。
       #
-      # **この文言は submission-bulk-st26 が読んでいる**（`Submission::SEQUENCE_EXHAUSTED`
-      # が `/no numbers left/` で見る）。ApplySubmissionRequestJob が message をそのまま
-      # error_message に載せるので、それが「採番が尽きた」と分かる唯一の手がかりになって
-      # いる。文言を変えると向こうは静かに検出をやめ、残容量に収まる小さいファイルだけが
-      # 通って採番の切れ目が散らばる。変えるときは向こうも一緒に直すこと。
+      # **この例外はクライアントが分岐に使う。** ApplySubmissionRequestJob::ERROR_CODES が
+      # TRD_R0012 に対応づけ、submission_requests.error_code に載せている（README の表）。
+      # クラスを変えたり別の例外に差し替えたりするときは、あちらも一緒に直すこと。
+      # 文言の方は人間向けなので自由に変えてよい。
       if avail <= 0
         raise Exhausted, "#{scope}: no numbers left after #{prefix} (wanted #{count} more)" if i + 1 >= prefixes.size
 

--- a/app/views/statuses/show.json.jb
+++ b/app/views/statuses/show.json.jb
@@ -2,6 +2,7 @@
   **@request.slice(
     :id,
     :status,
+    :error_code,
     :error_message
   ),
 

--- a/app/views/submission_requests/_submission_request.json.jb
+++ b/app/views/submission_requests/_submission_request.json.jb
@@ -7,6 +7,7 @@ payload = {
     :id,
     :db,
     :status,
+    :error_code,
     :error_message,
     :created_at,
     :closed_at

--- a/db/migrate/20260810020933_add_error_code_to_submission_requests.rb
+++ b/db/migrate/20260810020933_add_error_code_to_submission_requests.rb
@@ -1,0 +1,5 @@
+class AddErrorCodeToSubmissionRequests < ActiveRecord::Migration[8.1]
+  def change
+    add_column :submission_requests, :error_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_07_160000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_020933) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -333,6 +333,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_07_160000) do
     t.datetime "closed_at"
     t.datetime "created_at", null: false
     t.string "db", null: false
+    t.string "error_code"
     t.string "error_message"
     t.uuid "migration_run_id"
     t.integer "status", default: 0, null: false

--- a/schema/openapi.d.ts
+++ b/schema/openapi.d.ts
@@ -1126,6 +1126,13 @@ export interface components {
         SubmissionRequestStatus: {
             id: number;
             status: components["schemas"]["SubmissionOperationStatus"];
+            /**
+             * @description Machine-readable reason the application failed. Null until it does.
+             *     Branch on this rather than on `error_message`, whose wording changes
+             *     without notice. An unknown code means an unexpected internal error;
+             *     treat it like `TRD_R9999`.
+             */
+            error_code: string | null;
             error_message: string | null;
             processing: boolean;
         };
@@ -1133,6 +1140,13 @@ export interface components {
             id: number;
             db: components["schemas"]["Db"];
             status: components["schemas"]["SubmissionOperationStatus"];
+            /**
+             * @description Machine-readable reason the application failed. Null until it does.
+             *     Branch on this rather than on `error_message`, whose wording changes
+             *     without notice. An unknown code means an unexpected internal error;
+             *     treat it like `TRD_R9999`.
+             */
+            error_code: string | null;
             error_message: string | null;
             /** Format: date-time */
             created_at: string;
@@ -1174,6 +1188,13 @@ export interface components {
             id: number;
             db: components["schemas"]["Db"];
             status: components["schemas"]["SubmissionOperationStatus"];
+            /**
+             * @description Machine-readable reason the application failed. Null until it does.
+             *     Branch on this rather than on `error_message`, whose wording changes
+             *     without notice. An unknown code means an unexpected internal error;
+             *     treat it like `TRD_R9999`.
+             */
+            error_code: string | null;
             error_message: string | null;
             /** Format: date-time */
             created_at: string;

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -1206,6 +1206,7 @@ components:
       required:
         - id
         - status
+        - error_code
         - error_message
         - processing
 
@@ -1215,6 +1216,16 @@ components:
 
         status:
           $ref: '#/components/schemas/SubmissionOperationStatus'
+
+        error_code:
+          description: |
+            Machine-readable reason the application failed. Null until it does.
+            Branch on this rather than on `error_message`, whose wording changes
+            without notice. An unknown code means an unexpected internal error;
+            treat it like `TRD_R9999`.
+          type:
+            - string
+            - 'null'
 
         error_message:
           type:
@@ -1232,6 +1243,7 @@ components:
         - id
         - db
         - status
+        - error_code
         - error_message
         - created_at
         - closed_at
@@ -1253,6 +1265,16 @@ components:
 
         status:
           $ref: '#/components/schemas/SubmissionOperationStatus'
+
+        error_code:
+          description: |
+            Machine-readable reason the application failed. Null until it does.
+            Branch on this rather than on `error_message`, whose wording changes
+            without notice. An unknown code means an unexpected internal error;
+            treat it like `TRD_R9999`.
+          type:
+            - string
+            - 'null'
 
         error_message:
           type:
@@ -1325,6 +1347,7 @@ components:
         - id
         - db
         - status
+        - error_code
         - error_message
         - created_at
         - closed_at
@@ -1343,6 +1366,16 @@ components:
 
         status:
           $ref: '#/components/schemas/SubmissionOperationStatus'
+
+        error_code:
+          description: |
+            Machine-readable reason the application failed. Null until it does.
+            Branch on this rather than on `error_message`, whose wording changes
+            without notice. An unknown code means an unexpected internal error;
+            treat it like `TRD_R9999`.
+          type:
+            - string
+            - 'null'
 
         error_message:
           type:

--- a/test/integration/statuses_test.rb
+++ b/test/integration/statuses_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+# クライアントがバリデーションと適用の完了を待つ間、繰り返し叩くのがここ。
+# 契約が守られていることを担保するテストが無かった。
+class StatusesTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:alice)
+
+    default_headers['Authorization'] = "Bearer #{@user.api_key}"
+  end
+
+  test 'show reports a request that has not failed' do
+    get submission_request_status_path(submission_requests(:st26))
+
+    assert_conform_schema 200
+
+    body = response.parsed_body
+
+    assert_nil body['error_code']
+    assert_nil body['error_message']
+  end
+
+  # 失敗の理由は、文言ではなくコードで分岐できる形で出る。
+  test 'show reports the code of a failed application' do
+    # フィクスチャは ddbj_record を持たないので、モデルのバリデーションは通さない。
+    submission_requests(:st26).update_columns(
+      status:        SubmissionRequest.statuses.fetch('application_failed'),
+      error_code:    'TRD_R0012',
+      error_message: 'jpo_na: no numbers left after QX (wanted 3 more)'
+    )
+
+    get submission_request_status_path(submission_requests(:st26))
+
+    assert_conform_schema 200
+
+    body = response.parsed_body
+
+    assert_equal 'application_failed', body['status']
+    assert_equal 'TRD_R0012',          body['error_code']
+    assert_not body['processing']
+  end
+
+  # status は current_user のスコープで引く。他人の request は 404。
+  test 'show does not reach another user' do
+    get submission_request_status_path(submission_requests(:st26)),
+        headers: {'Authorization' => "Bearer #{users(:bob).api_key}"}
+
+    assert_response :not_found
+  end
+end

--- a/test/jobs/apply_submission_request_job_test.rb
+++ b/test/jobs/apply_submission_request_job_test.rb
@@ -51,8 +51,66 @@ class ApplySubmissionRequestJobTest < ActiveSupport::TestCase
     request.reload
 
     assert request.application_failed?
+    assert_equal 'TRD_R9999', request.error_code
     assert_equal 'stack level too deep', request.error_message
     assert_not request.processing?
+  end
+
+  # 採番が尽きたことは、クライアントがランを打ち切るかどうかの判断に使う。
+  # 文言ではなくコードで分岐できるようにしておく。
+  test 'records TRD_R0012 when the accession numbers run out' do
+    request = SubmissionRequest.new(user: users(:alice), db: 'st26')
+
+    request.ddbj_record.attach(
+      io:           file_fixture('ddbj_record/example.json').open,
+      filename:     'example.json',
+      content_type: 'application/json'
+    )
+
+    request.save!
+
+    Sequence.ensure_records!
+    Sequence.find_by!(scope: 'jpo_na').update!(
+      prefix: Sequence.config.fetch(:jpo_na).last[:prefix],
+      next:   1000000
+    )
+
+    ApplySubmissionRequestJob.perform_now request
+
+    request.reload
+
+    assert request.application_failed?
+    assert_equal 'TRD_R0012', request.error_code
+    assert_match(/no numbers left/, request.error_message)
+
+    # 尽きたときは 1 件も消費しないので、prefix を足せばそのまま適用できる。
+    assert_nil request.submission
+  end
+
+  # 前回の失敗の痕跡が残っていると、成功しているのに「今まさに失敗している」と読まれる。
+  test 'clears the previous failure before applying' do
+    request = SubmissionRequest.new(
+      user:          users(:alice),
+      db:            'st26',
+      error_code:    'TRD_R0012',
+      error_message: 'jpo_na: no numbers left after QX (wanted 3 more)'
+    )
+
+    request.ddbj_record.attach(
+      io:           file_fixture('ddbj_record/example.json').open,
+      filename:     'example.json',
+      content_type: 'application/json'
+    )
+
+    request.save!
+
+    ApplySubmissionRequestJob.perform_now request
+
+    request.reload
+
+    assert request.applied?
+    assert_nil request.error_code
+    assert_nil request.error_message
   end
 
   test 'refuses v3 records, transitions request to application_failed cleanly' do

--- a/web/tests/acceptance/closure-test.gts
+++ b/web/tests/acceptance/closure-test.gts
@@ -21,6 +21,7 @@ function failedRequest(attrs: Partial<SubmissionRequest> = {}): SubmissionReques
     id: 42,
     db: 'st26',
     status: 'validation_failed',
+    error_code: null,
     error_message: null,
     created_at: now,
     closed_at: null,

--- a/web/tests/acceptance/reviewer-access-test.gts
+++ b/web/tests/acceptance/reviewer-access-test.gts
@@ -16,6 +16,7 @@ const request: SubmissionRequest = {
   id: 42,
   db: 'bioproject',
   status: 'applied',
+  error_code: null,
   error_message: null,
   created_at: now,
   closed_at: null,

--- a/web/tests/acceptance/submission-messages-test.gts
+++ b/web/tests/acceptance/submission-messages-test.gts
@@ -18,6 +18,7 @@ const request: components['schemas']['SubmissionRequest'] = {
   id: 1,
   db: 'st26',
   status: 'applied',
+  error_code: null,
   error_message: null,
   created_at: now,
   closed_at: null,

--- a/web/tests/acceptance/submission-request-test.gts
+++ b/web/tests/acceptance/submission-request-test.gts
@@ -41,6 +41,7 @@ module('Acceptance | submission request', function (hooks) {
       id: 42,
       db: 'st26',
       status: 'waiting_validation',
+      error_code: null,
       error_message: null,
       created_at: now,
       closed_at: null,

--- a/web/tests/acceptance/validation-report-test.gts
+++ b/web/tests/acceptance/validation-report-test.gts
@@ -22,6 +22,7 @@ function requestWith(details: Detail[]): SubmissionRequest {
     id: 42,
     db: 'biosample',
     status: 'validation_failed',
+    error_code: null,
     error_message: null,
     created_at: now,
     closed_at: null,


### PR DESCRIPTION
エラーコード整備の第一歩です。`submission_requests` のみ、分類は 1 件だけ。

## 背景

バリデーション段階は `validation_details.code`（TRD_R0001–0011 + TRD_R9999）でコード体系を持っていますが、**適用（apply）段階だけが素通し**でした。`ApplySubmissionRequestJob` の `rescue` が `e.message` を `error_message` に入れるだけです。

読み手は 3 つあります。

1. submission-bulk-st26 — `/no numbers left/` の文字列一致で「採番が尽きた」を判断し、ランを打ち切る
2. `web/app/utils/request-state.ts:69` — 登録者の画面にそのまま表示
3. `CurationState#next_action` — キュレータにそのまま表示

実際 #1976 で `Sequence::Exhausted` にスコープ名を足したとき、1 の検出が静かに壊れました（submission-bulk-st26 #85 で追随）。

## 変更

- `submission_requests.error_code`（string, nullable）を追加
- `ApplySubmissionRequestJob::ERROR_CODES` が例外を分類。**`Sequence::Exhausted` → `TRD_R0012` の 1 件だけ**で、残りは catch-all の `TRD_R9999`
- `/submission_requests/{id}/status` と `/submission_requests/{id}` に載せる（OpenAPI 更新済み。reviewer 向けにも出るが、`error_message` が既に出ているので新たな開示はない）
- README の表を「Result Codes」に改め、Phase 列を足した

コード体系は番号帯に意味を持たせず、`TRD_R` の単純な続き（次は 0012）。`9999` だけがどちらの段階でも catch-all です。

### 前回の失敗を消す

`error_code` は機械的な判断に使われるので、古い値が残っていると「今まさに失敗している」と読まれます。適用に入るところで `error_code` / `error_message` の両方を消すようにしました。非 StandardError で job がリトライされる経路が実際にあります。

### 追加は常に additive

クライアントは知らないコードを catch-all と同じに扱えばよい、と README と OpenAPI の両方に書きました。以降 `ERROR_CODES` に 1 行足して表に書くだけで増やせます。

## テスト

- `TRD_R0012` が載り、かつ **1 件も採番を消費していない**（`submission` が作られない）こと
- 分類外は `TRD_R9999`
- 適用に入るときに前回の痕跡が消えること
- `/status` の契約テストを新設（`test/integration/statuses_test.rb`）

`/status` には**契約を担保するテストが 1 本も無く**、クライアントが完了を待つ間ずっと叩く先なのでこの機会に足しました。実際、view から `error_code` を抜くと落ちることを確認しています。

913 runs / 2976 assertions / 0 failures。マイグレーションの可逆性も `db:migrate:redo:primary` で確認済み。

## デプロイと後続

追加のみなので単独で先に出せます。その間クライアントは今の文字列一致で動き続けるため、窓はできません。デプロイ後に submission-bulk-st26 を `error_code == 'TRD_R0012'` に切り替えます。

既存の `application_failed` 行は `error_code` が NULL のままです（バックフィルなし）。クライアントはファイルごとに新しい request を作るので実害はありません。

今後の候補:
- `V3NotImplementedError` など、出てきたものから分類を足す
- `accession_issuances.error_message`（`IssueAccessionsJob` / `MailDeliveryJob`）も同じ形にする
- 分類が揃ったら、web は code ごとの定型文を出して生の文言はキュレータにだけ見せる

🤖 Generated with [Claude Code](https://claude.com/claude-code)