### PR TITLE
ER 図に error_code を足す

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ erDiagram
         bigint user_id FK
         bigint submission_id FK "nullable"
         integer status "enum: waiting_validation..no_change"
+        string error_code "nullable, see Result Codes"
         string error_message "nullable"
         datetime created_at
         datetime updated_at


### PR DESCRIPTION
#1978 で `submission_requests.error_code` を追加したときに、README の ER 図を更新し忘れていました。図だけ見ると列が無いように読めます。

コメントに Result Codes への参照を入れてあります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)