### PR TITLE
spec pin のずれを検出し、壊れた cross-lang gate を skip で通さない

### DIFF
--- a/test/models/ddbj_record/canon/cross_lang_jcs_test.rb
+++ b/test/models/ddbj_record/canon/cross_lang_jcs_test.rb
@@ -42,6 +42,17 @@ class DDBJRecord::Canon::CrossLangJcsTest < ActiveSupport::TestCase
     false
   end
 
+  # Whether an unusable interpreter is a skip or a failure depends on where
+  # it came from. A developer without the venv is expected: DEFAULT_PYTHON is
+  # a convenience, and skipping keeps `bin/rails test` usable for them.
+  # `DDBJ_CANON_PY` being set is a claim that this gate is meant to run here —
+  # canon.yml sets it — so an interpreter that cannot import rfc8785 means a
+  # broken gate rather than an absent one, and a broken gate that reports
+  # itself as skipped is indistinguishable in CI from one that passed.
+  def self.python_pinned?
+    ENV.key?('DDBJ_CANON_PY')
+  end
+
   SKIP_REASON = 'rfc8785 not available — install rfc8785==0.1.4 in a venv ' \
                 '(set DDBJ_CANON_PY or use tmp/data-migration/spike-0-3/.venv)'.freeze
 
@@ -49,7 +60,16 @@ class DDBJRecord::Canon::CrossLangJcsTest < ActiveSupport::TestCase
     name = File.basename(path, '.json')
 
     define_method("test_jcs_byte_identity_#{name}") do
-      skip SKIP_REASON unless self.class.rfc8785_available?
+      unless self.class.rfc8785_available?
+        flunk <<~MESSAGE.squish if self.class.python_pinned?
+          DDBJ_CANON_PY is set to #{self.class.python_bin.inspect} but
+          `import rfc8785` failed there, so the cross-language gate cannot run.
+          Install rfc8785==0.1.4 into that interpreter, or unset DDBJ_CANON_PY
+          to skip.
+        MESSAGE
+
+        skip SKIP_REASON
+      end
 
       raw    = File.read(path, encoding: Encoding::UTF_8)
       parsed = JSON.parse(raw)

--- a/test/models/ddbj_record/canon/spec_pin_test.rb
+++ b/test/models/ddbj_record/canon/spec_pin_test.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+require 'open3'
+
+module DDBJRecord::Canon; end
+
+# `schema/canon/v3-fields.yml` is derived by hand from the vendored spec, and
+# `canon:fields_check` only compares it against the V3 Data classes. So the
+# manifest and the classes can agree with each other while both have drifted
+# from the spec they claim to describe — which is what happens when the
+# submodule is moved with `git submodule update --remote` and the manifest is
+# not regenerated, or regenerated without updating `SPEC_SHA`.
+#
+# This pins the three places that name a spec revision to the gitlink actually
+# recorded for the submodule. Read from the index rather than the checked-out
+# submodule so the check holds without `git submodule update --init` — the
+# gitlink is what every other checkout resolves to anyway.
+class DDBJRecord::Canon::SpecPinTest < ActiveSupport::TestCase
+  SUBMODULE = 'vendor/ddbj-record-specifications'.freeze
+
+  # `# Derived from ddbj-record-specifications @ bdcdb8d8 (2026-04-13)`
+  CITATION = /ddbj-record-specifications @ (?<sha>[0-9a-f]{7,40})/
+
+  CITING_FILES = %w[
+    schema/canon/v3-fields.yml
+    schema/canon/array-modes.yml
+  ].freeze
+
+  # The gitlink staged for the submodule, or nil when git cannot answer —
+  # a tarball export, or a checkout without the entry.
+  def self.pinned_sha
+    out, _err, status = Open3.capture3(
+      'git', 'ls-files', '--stage', '--', SUBMODULE,
+      chdir: Rails.root.to_s
+    )
+
+    return nil unless status.success?
+
+    mode, sha, = out.split
+
+    # 160000 is the gitlink mode; anything else means the path stopped being
+    # a submodule and this test is asserting about the wrong thing.
+    sha if mode == '160000'
+  rescue StandardError
+    nil
+  end
+
+  setup do
+    @pinned = self.class.pinned_sha
+
+    skip "cannot read the #{SUBMODULE} gitlink from git" unless @pinned
+  end
+
+  test 'SPEC_SHA matches the pinned submodule revision' do
+    assert_equal @pinned, DDBJRecord::V3::SPEC_SHA,
+                 'DDBJRecord::V3::SPEC_SHA disagrees with the gitlink — either the submodule ' \
+                 'moved without updating the constant, or the constant was bumped without ' \
+                 'moving the submodule. Regenerate schema/canon/v3-fields.yml either way.'
+  end
+
+  CITING_FILES.each do |path|
+    test "#{path} cites the pinned submodule revision" do
+      cited = Rails.root.join(path).read[CITATION, :sha]
+
+      assert cited, "#{path} no longer cites a spec revision — the header comment is the only " \
+                    'record of which spec the registry was derived from'
+
+      assert @pinned.start_with?(cited),
+             "#{path} cites spec #{cited} but the submodule is pinned to #{@pinned}"
+    end
+  end
+end


### PR DESCRIPTION
Canon workflow の穴 2 つを埋めます。#1980 とはファイルが重複しないので独立にマージできます。

## 1. spec pin のずれが無検査だった

`canon:fields_check` が突き合わせるのは `schema/canon/v3-fields.yml` と `DDBJRecord::V3` の Data クラスだけです。したがって両者が互いに一致したまま、揃って由来元の spec から乖離しうる状態でした。具体的には次の 2 経路が無検査です。

- `git submodule update --remote` で submodule を進め、manifest の再生成を忘れる
- manifest を再生成したが `SPEC_SHA` を据え置く

`spec_pin_test.rb` で、spec の revision を名指ししている 3 箇所を submodule の gitlink に固定します。

| 場所 | 内容 |
|---|---|
| `DDBJRecord::V3::SPEC_SHA` | 完全一致 |
| `schema/canon/v3-fields.yml` ヘッダ | 短縮 SHA が prefix であること |
| `schema/canon/array-modes.yml` ヘッダ | 同上 |

gitlink は checked-out の submodule ではなく **index から** 読みます。`git submodule update --init` していなくても成立するので `api.yml` の `test:all` でも走り、かつ他の checkout が実際に解決する値そのものです。git が答えられない環境 (tarball export 等) では skip します。

なお現状 `vendor/` の中身を読むコードは無いため、`canon.yml` の `submodules: recursive` は依然 load-bearing ではありません。本当に効かせるなら spec から `v3-fields.yml` を生成して diff する形 (openapi.d.ts の Schema job と同じ) になりますが、in-tree に generator が無いので別件とします。

## 2. 壊れた cross-lang gate が skip として通っていた

`cross_lang_jcs_test.rb` は `import rfc8785` に失敗すると skip していました。`DDBJ_CANON_PY` が設定されているとき (`canon.yml` がそうします) の skip は「gate が無い」ではなく「gate が壊れている」で、CI のサマリ上は通ったのと区別できません。環境変数が設定されている場合に限り `flunk` にします。

未設定なら従来どおり skip します。venv を持たない開発者にとって `bin/rails test` が通ることは維持したいので、`DEFAULT_PYTHON` はあくまで利便性の既定値という扱いです。副産物として `DDBJ_CANON_PY=$(which python)` が空文字になる類の設定ミスもここで落ちます。

## 検証

- `bin/rails test test/models/ddbj_record/canon/` — 62 runs, 0 failures, **0 skips**
- ドリフト時に落ちることを確認: `SPEC_SHA` と `array-modes.yml` のヘッダをそれぞれ別 SHA に書き換えて 2 failures (メッセージが原因を名指しすること含む)
- `DDBJ_CANON_PY=/usr/bin/python3` (rfc8785 なし) で 19 failures / 0 skips、メッセージは対処方法を提示
- `bin/rubocop` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)