### PR TITLE
不足側の source location も配列長に合わせる (PATENT-386)

### DIFF
--- a/lib/st26_source_locations.rb
+++ b/lib/st26_source_locations.rb
@@ -9,18 +9,18 @@ module St26SourceLocations
   # one entry can share a nil id. Keying the rewrite on that would rewrite both
   # and then trip the count guard — after earlier submissions in the batch had
   # already been written.
-  Finding = Data.define(:submission, :accession, :entry_id, :entry_index, :source_index, :location, :expected, :reason) do
-    # Only an overrun is: see St26SourceLocations.disagreement. Everything
+  Finding = Data.define(:submission, :accession, :entry_id, :entry_index, :source_index, :measured, :location, :expected, :reason) do
+    # Only `:wrong_end` is: see St26SourceLocations.disagreement. Everything
     # else is a question about what was meant, and this task does not get to
-    # answer those — it would be inventing coverage, or discarding what a
-    # location was trying to say.
-    def correctable? = reason == :overrun
+    # answer those — it would be discarding what a location was trying to say,
+    # or deciding which of two lengths a record meant.
+    def correctable? = reason == :wrong_end
   end
 
   # What `fix` says when it will not rewrite something, per reason.
   REFUSALS = {
     unreadable:      ->(n) { "Refusing to rewrite #{n} #{'location'.pluralize(n)} bio-ruby cannot parse: whatever #{n == 1 ? 'it was' : 'they were'} trying to say would be destroyed." },
-    ambiguous:       ->(n) { "Refusing to widen #{n} #{'location'.pluralize(n)} covering less than the whole sequence, or covering it in several pieces: rewriting to the full span would invent coverage nobody declared." },
+    ambiguous:       ->(n) { "Refusing to rewrite #{n} #{'location'.pluralize(n)} that #{n == 1 ? 'is' : 'are'} not a plain forward range from base 1: split, complemented, partial (<1..>N) and cross-referenced locations all say something that setting the full span would throw away." },
     missing:         ->(n) { "Refusing to fill in #{n} absent #{'location'.pluralize(n)}: a source feature with none at all is a different repair from this one." },
     no_sequence:     ->(n) { "Refusing to measure #{n} #{'entry'.pluralize(n)} with no sequence: there is no length for a location to agree with." },
     declared_length: ->(n) { "Refusing to touch #{n} #{'entry'.pluralize(n)} whose declared length disagrees with its sequence: which of the two was meant is not this task's to decide." }
@@ -103,17 +103,23 @@ module St26SourceLocations
     # not coming.
     siblings = result.siblings.to_set
 
+    # The sequence length is on every row, refused ones included. It is the
+    # number the decision turns on — whether a location falls short or runs
+    # past, and by how much — and printing it only against rows that were going
+    # to be rewritten anyway meant looking it up by hand for the ones that
+    # actually needed a judgement.
     result.findings.each do |f|
       puts format(
-        '%-12s submission #%-6d %-40s %-20s -> %s',
+        '%-12s submission #%-6d %-40s %-20s sequence=%-7d %s',
         f.accession || '(no accession)',
         f.submission.id,
         f.entry_id,
         f.location.presence || '(none)',
+        f.measured,
         if siblings.include?(f)
           'NOT REWRITTEN (not named)'
         elsif f.correctable?
-          f.expected
+          "-> #{f.expected}"
         else
           "NOT REWRITTEN (#{f.reason})"
         end
@@ -279,6 +285,7 @@ module St26SourceLocations
             entry_id:    entry.id,
             entry_index: i,
             source_index:,
+            measured:,
             location:,
             expected:    "1..#{measured}",
             reason:
@@ -319,12 +326,18 @@ module St26SourceLocations
   # nil when the location is fine, otherwise why it is not — and only one of
   # those reasons is something this task will rewrite.
   #
-  # `:overrun` is the JPO defect and nothing else: one plain forward range that
-  # starts at 1 and runs past the end, where `1..<length>` is what was plainly
-  # meant. Every other disagreement would have coverage invented for it — a
-  # location covering 1..500 of 1000 bases, or `join(1..4,6..9)` with its gap
-  # at 5, does not become correct by being widened to the whole sequence, it
-  # becomes a different claim.
+  # `:wrong_end` is one plain forward range starting at base 1 that stops
+  # somewhere other than the last base. Both directions: PATENT-386's five
+  # records include three running one base past the end (`1..449` over 448) and
+  # two stopping short (`1..315` over 316). An ST.26 patent source covers the
+  # whole sequence — that is the premise the ticket's own FF spec is built on,
+  # and submission-bulk-st26 pins the location to `1..<length>` in either
+  # direction — so `1..<length>` is what such a range meant.
+  #
+  # Everything else keeps its shape. A split, complemented, partial (`<1..>21`)
+  # or cross-referenced location, or one that does not start at base 1, says
+  # something that setting the full span would throw away, and no premise about
+  # patent sources tells us which part of it was the mistake.
   def disagreement(location, length)
     return :missing if location.blank?
 
@@ -343,10 +356,9 @@ module St26SourceLocations
     plain = only &&
             only.strand == 1 &&
             [only.lt, only.gt, only.xref_id, only.carat].all?(&:nil?) &&
-            only.from == 1 &&
-            only.to.to_i > length
+            only.from == 1
 
-    plain ? :overrun : :ambiguous
+    plain ? :wrong_end : :ambiguous
   rescue StandardError
     :unreadable
   end

--- a/lib/st26_source_locations.rb
+++ b/lib/st26_source_locations.rb
@@ -10,16 +10,18 @@ module St26SourceLocations
   # and then trip the count guard — after earlier submissions in the batch had
   # already been written.
   Finding = Data.define(:submission, :accession, :entry_id, :entry_index, :source_index, :measured, :location, :expected, :reason) do
-    # Only `:wrong_end` is: see St26SourceLocations.disagreement. Everything
-    # else is a question about what was meant, and this task does not get to
-    # answer those — it would be discarding what a location was trying to say,
-    # or deciding which of two lengths a record meant.
-    def correctable? = reason == :wrong_end
+    # Whether `expected` is a value this task could write. Whether it *will* is
+    # the caller's: `:overrun` is repaired by default and `:short` only when the
+    # operator asks for it, because a location stopping short might be a
+    # boundary slip or might be a deliberate partial coverage, and this code
+    # cannot tell a shortfall of two residues from one of five hundred.
+    def repairable? = %i[overrun short].include?(reason)
   end
 
   # What `fix` says when it will not rewrite something, per reason.
   REFUSALS = {
     unreadable:      ->(n) { "Refusing to rewrite #{n} #{'location'.pluralize(n)} bio-ruby cannot parse: whatever #{n == 1 ? 'it was' : 'they were'} trying to say would be destroyed." },
+    short:           ->(n) { "Refusing to lengthen #{n} #{'location'.pluralize(n)} stopping short of the sequence: pass INCLUDE=short to accept that a patent source covers all of it. Read the sequence= column first — this cannot tell a boundary slip from deliberate partial coverage." },
     ambiguous:       ->(n) { "Refusing to rewrite #{n} #{'location'.pluralize(n)} that #{n == 1 ? 'is' : 'are'} not a plain forward range from base 1: split, complemented, partial (<1..>N) and cross-referenced locations all say something that setting the full span would throw away." },
     missing:         ->(n) { "Refusing to fill in #{n} absent #{'location'.pluralize(n)}: a source feature with none at all is a different repair from this one." },
     no_sequence:     ->(n) { "Refusing to measure #{n} #{'entry'.pluralize(n)} with no sequence: there is no length for a location to agree with." },
@@ -46,6 +48,14 @@ module St26SourceLocations
   # demands a scope can refuse an empty one *before* the audit streams every
   # record in the archive out of object storage.
   def requested_from(accessions) = accessions.to_s.split(/[\s,]+/).reject(&:blank?).uniq
+
+  # Reasons `fix` will act on. `:overrun` always — a location cannot name bases
+  # the sequence does not have, whatever the amount. `:short` only when asked
+  # for, because the shortfall might be the boundary slip PATENT-386 found or
+  # might be coverage somebody meant.
+  def actionable_reasons(include_env)
+    %i[overrun] + (include_env.to_s.split(/[\s,]+/).include?('short') ? %i[short] : [])
+  end
 
   def audit(accessions = nil)
     requested = requested_from(accessions)
@@ -118,8 +128,10 @@ module St26SourceLocations
         f.measured,
         if siblings.include?(f)
           'NOT REWRITTEN (not named)'
-        elsif f.correctable?
+        elsif f.reason == :overrun
           "-> #{f.expected}"
+        elsif f.reason == :short
+          "-> #{f.expected} (only with INCLUDE=short)"
         else
           "NOT REWRITTEN (#{f.reason})"
         end
@@ -312,8 +324,10 @@ module St26SourceLocations
           next
         end
 
-        Array(entry.source_features).each_with_index do |sf, j|
-          reason = disagreement(sf.location, measured) or next
+        sources = Array(entry.source_features)
+
+        sources.each_with_index do |sf, j|
+          reason = disagreement(sf.location, measured, sources: sources.size) or next
 
           add.call j, sf.location, reason
         end
@@ -338,27 +352,30 @@ module St26SourceLocations
   # or cross-referenced location, or one that does not start at base 1, says
   # something that setting the full span would throw away, and no premise about
   # patent sources tells us which part of it was the mistake.
-  def disagreement(location, length)
+  def disagreement(location, length, sources: 1)
     return :missing if location.blank?
 
-    locations = Bio::Locations.new(location.to_s)
-    span      = locations.span
+    span = Bio::Locations.new(location.to_s).span
 
     return nil if span == [1, length]
 
-    only = locations.locations.size == 1 ? locations.locations.first : nil
+    # Matched against the text, not against bio-ruby's numbers. It flattens a
+    # fuzzy bound — `1..(5.10)` comes back as from=1/to=10 and `1.5` as 1..1,
+    # both with every marker nil — so a check reading `from` and `to` takes
+    # those for plain ranges and would rewrite the notation away. One regexp
+    # also excludes `<1..>21`, `J00194.1:1..21`, `complement(…)`, `join(…)` and
+    # a bare `1`, each of which says something the full span does not.
+    m = /\A(\d+)\.\.(\d+)\z/.match(location.to_s)
 
-    # Plain means plain: `<1..>21` carries 5'/3' partiality and
-    # `J00194.1:1..21` points into another accession, and both of those would
-    # be thrown away by rewriting the string to `1..<length>`. bio-ruby keeps
-    # them as `lt` / `gt` / `xref_id` / `carat` beside the numbers, so a check
-    # that reads only `from` and `to` cannot see them.
-    plain = only &&
-            only.strand == 1 &&
-            [only.lt, only.gt, only.xref_id, only.carat].all?(&:nil?) &&
-            only.from == 1
+    return :ambiguous unless m && m[1] == '1'
 
-    plain ? :wrong_end : :ambiguous
+    # The premise is that a patent source covers the whole sequence, and that is
+    # a statement about an entry with one source. Where several divide an entry
+    # — which the v2 schema provides for — widening the first would swallow the
+    # next one's span and turn a coherent record into overlapping sources.
+    return :ambiguous unless sources == 1
+
+    m[2].to_i > length ? :overrun : :short
   rescue StandardError
     :unreadable
   end

--- a/lib/st26_source_locations.rb
+++ b/lib/st26_source_locations.rb
@@ -11,21 +11,20 @@ module St26SourceLocations
   # already been written.
   Finding = Data.define(:submission, :accession, :entry_id, :entry_index, :source_index, :measured, :location, :expected, :reason) do
     # Whether `expected` is a value this task could write. Whether it *will* is
-    # the caller's: `:overrun` is repaired by default and `:short` only when the
-    # operator asks for it, because a location stopping short might be a
-    # boundary slip or might be a deliberate partial coverage, and this code
-    # cannot tell a shortfall of two residues from one of five hundred.
+    # the Plan's: `:overrun` always, `:short` only where a person has said so
+    # for that accession.
     def repairable? = %i[overrun short].include?(reason)
   end
 
   # What `fix` says when it will not rewrite something, per reason.
   REFUSALS = {
     unreadable:      ->(n) { "Refusing to rewrite #{n} #{'location'.pluralize(n)} bio-ruby cannot parse: whatever #{n == 1 ? 'it was' : 'they were'} trying to say would be destroyed." },
-    short:           ->(n) { "Refusing to lengthen #{n} #{'location'.pluralize(n)} stopping short of the sequence: pass INCLUDE=short to accept that a patent source covers all of it. Read the sequence= column first — this cannot tell a boundary slip from deliberate partial coverage." },
-    ambiguous:       ->(n) { "Refusing to rewrite #{n} #{'location'.pluralize(n)} that #{n == 1 ? 'is' : 'are'} not a plain forward range from base 1: split, complemented, partial (<1..>N) and cross-referenced locations all say something that setting the full span would throw away." },
-    missing:         ->(n) { "Refusing to fill in #{n} absent #{'location'.pluralize(n)}: a source feature with none at all is a different repair from this one." },
-    no_sequence:     ->(n) { "Refusing to measure #{n} #{'entry'.pluralize(n)} with no sequence: there is no length for a location to agree with." },
-    declared_length: ->(n) { "Refusing to touch #{n} #{'entry'.pluralize(n)} whose declared length disagrees with its sequence: which of the two was meant is not this task's to decide." }
+    short:           ->(n) { "Not lengthening #{n} #{'location'.pluralize(n)} that #{n == 1 ? 'stops' : 'stop'} short of the sequence. Read the sequence= column, decide per record, and name the ones you have confirmed in LENGTHEN — this cannot tell a boundary slip of two residues from a deliberate partial coverage of five hundred." },
+    multiple_sources: ->(n) { "Not lengthening #{n} #{'location'.pluralize(n)} in #{'an entry'.pluralize(n)} carrying more than one source: widening one would swallow the next one's span. Fix #{n == 1 ? 'it' : 'them'} by hand." },
+    ambiguous:       ->(n) { "Refusing to rewrite #{n} #{'location'.pluralize(n)} that #{n == 1 ? 'is' : 'are'} not a plain forward range from base 1: split, complemented, partial (<1..>N), fuzzy (1..(5.10)) and cross-referenced locations all say something that setting the full span would throw away. Fix #{n == 1 ? 'it' : 'them'} by hand." },
+    missing:         ->(n) { "Refusing to fill in #{n} absent #{'location'.pluralize(n)}: a source feature with none at all is a different repair from this one. Fix #{n == 1 ? 'it' : 'them'} by hand." },
+    no_sequence:     ->(n) { "Refusing to measure #{n} #{'entry'.pluralize(n)} with no sequence: there is no length for a location to agree with. Fix #{n == 1 ? 'it' : 'them'} by hand." },
+    declared_length: ->(n) { "Refusing to touch #{n} #{'entry'.pluralize(n)} whose declared length disagrees with its sequence: which of the two was meant is not this task's to decide. Fix #{n == 1 ? 'it' : 'them'} by hand." }
   }.freeze
 
   Unreadable = Data.define(:submission, :error)
@@ -49,13 +48,29 @@ module St26SourceLocations
   # record in the archive out of object storage.
   def requested_from(accessions) = accessions.to_s.split(/[\s,]+/).reject(&:blank?).uniq
 
-  # Reasons `fix` will act on. `:overrun` always — a location cannot name bases
-  # the sequence does not have, whatever the amount. `:short` only when asked
-  # for, because the shortfall might be the boundary slip PATENT-386 found or
-  # might be coverage somebody meant.
-  def actionable_reasons(include_env)
-    %i[overrun] + (include_env.to_s.split(/[\s,]+/).include?('short') ? %i[short] : [])
+  # What a run will act on, shared by `report` and `fix` so the column that says
+  # what will happen and the code that makes it happen cannot disagree.
+  #
+  # An overrun is repaired unconditionally: a location cannot name bases the
+  # sequence does not have, whatever the amount, and setting the full span only
+  # ever shrinks it.
+  #
+  # A shortfall is repaired only for an accession named in `LENGTHEN`. Per
+  # accession and not per run, because the judgement is per record — a slip of
+  # two residues and a deliberate coverage of five hundred look identical here,
+  # and PATENT-386's answer came from a person looking at two specific entries.
+  # A run-wide switch would carry that answer to every short row in the batch.
+  Plan = Data.define(:lengthen) do
+    def actionable?(finding)
+      case finding.reason
+      when :overrun then true
+      when :short   then lengthen.include?(finding.accession)
+      else               false
+      end
+    end
   end
+
+  def plan_from(lengthen) = Plan.new(lengthen: requested_from(lengthen).to_set)
 
   def audit(accessions = nil)
     requested = requested_from(accessions)
@@ -106,11 +121,13 @@ module St26SourceLocations
     Result.new(findings:, unreadable:, skipped:, unmatched: requested - matched, requested: requested.to_set)
   end
 
-  def report(result)
-    # The last column is what will happen to this row, so a sibling has to say
-    # so there rather than in a footnote: it is a disagreement that will be
-    # left alone, and reading `-> 1..20` against it promises a rewrite that is
-    # not coming.
+  def report(result, plan = plan_from(nil))
+    # The last column is what will happen to this row, so it has to be read
+    # against the run that is about to happen: `plan` is what tells a short row
+    # authorised by LENGTHEN from one that is not, and a sibling from a target.
+    # A footnote would not do — reading `-> 1..20` on a row that is going to be
+    # left alone promises a rewrite that is not coming, and the inverse hides
+    # one that is.
     siblings = result.siblings.to_set
 
     # The sequence length is on every row, refused ones included. It is the
@@ -128,10 +145,10 @@ module St26SourceLocations
         f.measured,
         if siblings.include?(f)
           'NOT REWRITTEN (not named)'
-        elsif f.reason == :overrun
+        elsif plan.actionable?(f)
           "-> #{f.expected}"
         elsif f.reason == :short
-          "-> #{f.expected} (only with INCLUDE=short)"
+          "-> #{f.expected} only if you name it in LENGTHEN"
         else
           "NOT REWRITTEN (#{f.reason})"
         end
@@ -194,11 +211,16 @@ module St26SourceLocations
   # so a record that had changed shape since the audit could be rewritten at
   # positions that now meant something else.
   def verify!(submission, group)
-    # `expected` is in the key as well as `location`: it carries the sequence
-    # length the audit measured, so a sequence that changed since then would
-    # otherwise pass this check and be rewritten to a span that no longer fits.
-    present = Array(scan(submission, {})).to_set { [it.entry_index, it.source_index, it.location, it.expected] }
-    wanted  = group.to_set { [it.entry_index, it.source_index, it.location, it.expected] }
+    # `expected` and `reason` are in the key as well as `location`. `expected`
+    # carries the sequence length the audit measured, so a sequence that changed
+    # since then cannot pass. `reason` carries everything else the
+    # classification depends on: an entry that gained a second source feature
+    # between audit and rewrite scores `:multiple_sources` where it scored
+    # `:short`, with position, text and length all unchanged — so without it,
+    # the very case the sources guard exists for would slip through.
+    key     = ->(f) { [f.entry_index, f.source_index, f.location, f.expected, f.reason] }
+    present = Array(scan(submission, {})).to_set(&key)
+    wanted  = group.to_set(&key)
     missing = wanted - present
 
     return if missing.empty?
@@ -337,21 +359,20 @@ module St26SourceLocations
     end
   end
 
-  # nil when the location is fine, otherwise why it is not — and only one of
-  # those reasons is something this task will rewrite.
+  # nil when the location is fine, otherwise why it is not. Two of the reasons
+  # carry a value this task knows how to write (`:overrun`, `:short`); see Plan
+  # for which of those a given run will act on.
   #
-  # `:wrong_end` is one plain forward range starting at base 1 that stops
-  # somewhere other than the last base. Both directions: PATENT-386's five
-  # records include three running one base past the end (`1..449` over 448) and
-  # two stopping short (`1..315` over 316). An ST.26 patent source covers the
-  # whole sequence — that is the premise the ticket's own FF spec is built on,
-  # and submission-bulk-st26 pins the location to `1..<length>` in either
-  # direction — so `1..<length>` is what such a range meant.
+  # PATENT-386's five records disagree in both directions: three run one base
+  # past the end (`1..449` over 448) and two stop short (`1..315` over 316). An
+  # ST.26 patent source covers the whole sequence — the premise the ticket's own
+  # FF spec is built on, and submission-bulk-st26 pins the location to
+  # `1..<length>` either way — so that is what such a range meant.
   #
-  # Everything else keeps its shape. A split, complemented, partial (`<1..>21`)
-  # or cross-referenced location, or one that does not start at base 1, says
-  # something that setting the full span would throw away, and no premise about
-  # patent sources tells us which part of it was the mistake.
+  # Everything else keeps its shape. A split, complemented, partial (`<1..>21`),
+  # fuzzy (`1..(5.10)`) or cross-referenced location, or one that does not start
+  # at base 1, says something that setting the full span would throw away, and
+  # no premise about patent sources tells us which part of it was the mistake.
   def disagreement(location, length, sources: 1)
     return :missing if location.blank?
 
@@ -365,17 +386,23 @@ module St26SourceLocations
     # those for plain ranges and would rewrite the notation away. One regexp
     # also excludes `<1..>21`, `J00194.1:1..21`, `complement(…)`, `join(…)` and
     # a bare `1`, each of which says something the full span does not.
-    m = /\A(\d+)\.\.(\d+)\z/.match(location.to_s)
+    #
+    # Whitespace is tolerated because these strings are lifted verbatim out of
+    # XML, which is where a stray space comes from; `expected` is the normalised
+    # `1..<length>` either way. Refusing them would blame the notation for a
+    # defect that is plainly the numbers.
+    m = /\A\s*(\d+)\s*\.\.\s*(\d+)\s*\z/.match(location.to_s)
 
     return :ambiguous unless m && m[1] == '1'
 
-    # The premise is that a patent source covers the whole sequence, and that is
-    # a statement about an entry with one source. Where several divide an entry
-    # — which the v2 schema provides for — widening the first would swallow the
-    # next one's span and turn a coherent record into overlapping sources.
-    return :ambiguous unless sources == 1
+    return :overrun if m[2].to_i > length
 
-    m[2].to_i > length ? :overrun : :short
+    # Only the widening direction is affected: the premise that a patent source
+    # covers the whole sequence is a statement about an entry with one source,
+    # and where several divide an entry — which the v2 schema provides for —
+    # lengthening the first would swallow the next one's span. Shrinking an
+    # overrun above cannot do that, so it is not gated here.
+    sources == 1 ? :short : :multiple_sources
   rescue StandardError
     :unreadable
   end

--- a/lib/st26_source_locations.rb
+++ b/lib/st26_source_locations.rb
@@ -9,22 +9,20 @@ module St26SourceLocations
   # one entry can share a nil id. Keying the rewrite on that would rewrite both
   # and then trip the count guard — after earlier submissions in the batch had
   # already been written.
-  Finding = Data.define(:submission, :accession, :entry_id, :entry_index, :source_index, :measured, :location, :expected, :reason) do
-    # Whether `expected` is a value this task could write. Whether it *will* is
-    # the Plan's: `:overrun` always, `:short` only where a person has said so
-    # for that accession.
-    def repairable? = %i[overrun short].include?(reason)
-  end
+  # Whether a finding will be acted on is Plan's to say and nothing else's — a
+  # second predicate here would be a second copy of the same classification,
+  # free to drift from it.
+  Finding = Data.define(:submission, :accession, :entry_id, :entry_index, :source_index, :measured, :location, :expected, :reason)
 
   # What `fix` says when it will not rewrite something, per reason.
   REFUSALS = {
-    unreadable:      ->(n) { "Refusing to rewrite #{n} #{'location'.pluralize(n)} bio-ruby cannot parse: whatever #{n == 1 ? 'it was' : 'they were'} trying to say would be destroyed." },
-    short:           ->(n) { "Not lengthening #{n} #{'location'.pluralize(n)} that #{n == 1 ? 'stops' : 'stop'} short of the sequence. Read the sequence= column, decide per record, and name the ones you have confirmed in LENGTHEN — this cannot tell a boundary slip of two residues from a deliberate partial coverage of five hundred." },
-    multiple_sources: ->(n) { "Not lengthening #{n} #{'location'.pluralize(n)} in #{'an entry'.pluralize(n)} carrying more than one source: widening one would swallow the next one's span. Fix #{n == 1 ? 'it' : 'them'} by hand." },
-    ambiguous:       ->(n) { "Refusing to rewrite #{n} #{'location'.pluralize(n)} that #{n == 1 ? 'is' : 'are'} not a plain forward range from base 1: split, complemented, partial (<1..>N), fuzzy (1..(5.10)) and cross-referenced locations all say something that setting the full span would throw away. Fix #{n == 1 ? 'it' : 'them'} by hand." },
-    missing:         ->(n) { "Refusing to fill in #{n} absent #{'location'.pluralize(n)}: a source feature with none at all is a different repair from this one. Fix #{n == 1 ? 'it' : 'them'} by hand." },
-    no_sequence:     ->(n) { "Refusing to measure #{n} #{'entry'.pluralize(n)} with no sequence: there is no length for a location to agree with. Fix #{n == 1 ? 'it' : 'them'} by hand." },
-    declared_length: ->(n) { "Refusing to touch #{n} #{'entry'.pluralize(n)} whose declared length disagrees with its sequence: which of the two was meant is not this task's to decide. Fix #{n == 1 ? 'it' : 'them'} by hand." }
+    unreadable:       ->(n) { "Refusing to rewrite #{n} #{'location'.pluralize(n)} bio-ruby cannot parse: whatever #{n == 1 ? 'it was' : 'they were'} trying to say would be destroyed. Fix #{n == 1 ? 'it' : 'them'} by hand." },
+    short:            ->(n) { "Not lengthening #{n} #{'location'.pluralize(n)} that #{n == 1 ? 'stops' : 'stop'} short of the sequence. Read the sequence= column, decide per record, and name the ones you have confirmed in LENGTHEN — this cannot tell a boundary slip of two residues from a deliberate partial coverage of five hundred." },
+    multiple_sources: ->(n) { "Not lengthening #{n} #{'location'.pluralize(n)} in #{n == 1 ? 'an entry' : 'entries'} carrying more than one source: widening one would swallow the next one's span. Fix #{n == 1 ? 'it' : 'them'} by hand." },
+    ambiguous:        ->(n) { "Refusing to rewrite #{n} #{'location'.pluralize(n)} that #{n == 1 ? 'is' : 'are'} not a plain forward range from base 1: split, complemented, partial (<1..>N), fuzzy (1..(5.10)) and cross-referenced locations all say something that setting the full span would throw away. Fix #{n == 1 ? 'it' : 'them'} by hand." },
+    missing:          ->(n) { "Refusing to fill in #{n} absent #{'location'.pluralize(n)}: a source feature with none at all is a different repair from this one. Fix #{n == 1 ? 'it' : 'them'} by hand." },
+    no_sequence:      ->(n) { "Refusing to measure #{n} #{'entry'.pluralize(n)} with no sequence: there is no length for a location to agree with. Fix #{n == 1 ? 'it' : 'them'} by hand." },
+    declared_length:  ->(n) { "Refusing to touch #{n} #{'entry'.pluralize(n)} whose declared length disagrees with its sequence: which of the two was meant is not this task's to decide. Fix #{n == 1 ? 'it' : 'them'} by hand." }
   }.freeze
 
   Unreadable = Data.define(:submission, :error)
@@ -147,8 +145,10 @@ module St26SourceLocations
           'NOT REWRITTEN (not named)'
         elsif plan.actionable?(f)
           "-> #{f.expected}"
-        elsif f.reason == :short
+        elsif f.reason == :short && f.accession
           "-> #{f.expected} only if you name it in LENGTHEN"
+        elsif f.reason == :short
+          'NOT REWRITTEN (short, and no accession to name it by)'
         else
           "NOT REWRITTEN (#{f.reason})"
         end
@@ -267,6 +267,12 @@ module St26SourceLocations
           finding = wanted[[i, j]] or next
 
           raise "submission ##{submission.id}: #{finding.entry_id} source #{j} now reads #{sf['location'].inspect}, not #{finding.location.inspect}" unless sf['location'] == finding.location
+
+          # `verify!` ran before this lock was taken, so the entry could have
+          # gained a source feature in between — and lengthening one source of
+          # two is what the classification refuses. Counted again here, where
+          # the write actually happens.
+          raise "submission ##{submission.id}: #{finding.entry_id} now carries #{Array(entry['source_features']).size} source features; lengthening one of several would swallow the next one's span" if finding.reason == :short && Array(entry['source_features']).size != 1
 
           sf['location'] = finding.expected
           done          += 1
@@ -393,9 +399,17 @@ module St26SourceLocations
     # defect that is plainly the numbers.
     m = /\A\s*(\d+)\s*\.\.\s*(\d+)\s*\z/.match(location.to_s)
 
-    return :ambiguous unless m && m[1] == '1'
+    return :ambiguous unless m
 
-    return :overrun if m[2].to_i > length
+    from = m[1].to_i
+    to   = m[2].to_i
+
+    # Compared as numbers, so `01..21` is the overrun it plainly is rather than
+    # a notation complaint; and `to >= from`, so `1..0` is not read as a range
+    # that merely stops early.
+    return :ambiguous unless from == 1 && to >= from
+
+    return :overrun if to > length
 
     # Only the widening direction is affected: the premise that a patent source
     # covers the whole sequence is a statement about an entry with one source,

--- a/lib/tasks/st26.rake
+++ b/lib/tasks/st26.rake
@@ -91,6 +91,15 @@ namespace :st26 do
 
       abort "#{result.unmatched.size} #{'accession'.pluralize(result.unmatched.size)} matched no ST.26 entry — nothing was written." if result.unmatched.any?
 
+      # LENGTHEN gets the same treatment as ACCESSIONS. A name that matches no
+      # finding — a typo, the wrong case, an accession outside ACCESSIONS —
+      # would otherwise leave the rows it was meant to authorise untouched while
+      # the run reported success on the others, which is the situation the
+      # unmatched check above exists to prevent.
+      stray = plan.lengthen - result.named.filter_map(&:accession)
+
+      abort "#{stray.size} LENGTHEN #{'accession'.pluralize(stray.size)} matched none of the findings: #{stray.to_a.join(', ')} — nothing was written." if stray.any?
+
       # A named record that could not be read is not a record that needs
       # nothing: its finding never got as far as being one, so without this the
       # task would print "Nothing to correct." over a missing blob.

--- a/lib/tasks/st26.rake
+++ b/lib/tasks/st26.rake
@@ -1,10 +1,12 @@
 namespace :st26 do
   namespace :source_locations do
     # INSDC-3468 / PATENT-386. JPO ST.26 files carried source feature locations
-    # taken verbatim from the XML, which overran the sequence (1..21 over 20
-    # bases). The flatfile prints LOCUS from the length and both the source
-    # location and the REFERENCE span from the location, so those records ship
-    # claiming two different lengths.
+    # taken verbatim from the XML, which disagreed with the sequence in both
+    # directions — three of the five records run one base past the end
+    # (`1..449` over 448) and two stop short (`1..315` over 316). The flatfile
+    # prints LOCUS from the length and both the source location and the
+    # REFERENCE span from the location, so those records ship claiming two
+    # different lengths.
     #
     # submission-bulk-st26 now pins the location to 1..<length> as it builds the
     # record (PAT_R0024), so this is only for the records that landed before it
@@ -47,7 +49,7 @@ namespace :st26 do
       end
     end
 
-    desc 'Set plain source locations to 1..<length> (ACCESSIONS= required, APPLY=1 to write)'
+    desc 'Set plain source locations to 1..<length> (ACCESSIONS= required, INCLUDE=short to also lengthen, APPLY=1 to write)'
     task fix: :environment do
       accessions = ENV['ACCESSIONS'].to_s
 
@@ -68,10 +70,14 @@ namespace :st26 do
 
       St26SourceLocations.report result
 
-      # Only what was named. Resolving accessions reaches whole submissions —
-      # a JPO request can carry sixty entries — so without this, naming one
-      # accession would rewrite every disagreeing sibling alongside it.
-      correctable, rest = result.named.partition(&:correctable?)
+      # Only what was named, and only the reasons this run is allowed to act on.
+      # Resolving accessions reaches whole submissions — a JPO request can carry
+      # sixty entries — so without the first restriction, naming one accession
+      # would rewrite every disagreeing sibling alongside it.
+      allowed = St26SourceLocations.actionable_reasons(ENV['INCLUDE'])
+      act     = ->(f) { allowed.include?(f.reason) }
+
+      correctable, rest = result.named.partition(&act)
 
       # Named by reason. Both are refusals, but they are refusals to answer
       # different questions, and "unreadable" said of a length disagreement
@@ -109,7 +115,7 @@ namespace :st26 do
       # `remaining` empty and this check trivially satisfied — reporting the
       # rewrite as verified on the strength of not having looked. The
       # pre-checks above refuse the same situation for the same reason.
-      unless remaining.none?(&:correctable?) && after.unreadable.empty? && after.skipped.empty?
+      unless remaining.none?(&act) && after.unreadable.empty? && after.skipped.empty?
         St26SourceLocations.report after
 
         abort 'The rewrite could not be confirmed: run the audit again.'

--- a/lib/tasks/st26.rake
+++ b/lib/tasks/st26.rake
@@ -16,11 +16,13 @@ namespace :st26 do
     # cover part of an entry — a qualifier can even lift the expectation that
     # other features sit inside it.
 
-    desc 'Report ST.26 entries whose source location disagrees with the sequence length (ACCESSIONS= to scope)'
+    desc 'Report ST.26 entries whose source location disagrees with the sequence length (ACCESSIONS= to scope, LENGTHEN= to preview)'
     task audit: :environment do
       result = St26SourceLocations.audit(ENV['ACCESSIONS'])
 
-      St26SourceLocations.report result
+      # LENGTHEN is honoured here too, so `audit` can be asked what the `fix`
+      # that follows it would do rather than only what a bare one would.
+      St26SourceLocations.report result, St26SourceLocations.plan_from(ENV['LENGTHEN'])
 
       # An accession that matched nothing counts here too: it is a question
       # this run did not answer, exactly like a record it could not read, and
@@ -49,7 +51,7 @@ namespace :st26 do
       end
     end
 
-    desc 'Set plain source locations to 1..<length> (ACCESSIONS= required, INCLUDE=short to also lengthen, APPLY=1 to write)'
+    desc 'Set plain source locations to 1..<length> (ACCESSIONS= required, LENGTHEN= to also lengthen those, APPLY=1 to write)'
     task fix: :environment do
       accessions = ENV['ACCESSIONS'].to_s
 
@@ -68,22 +70,23 @@ namespace :st26 do
 
       result = St26SourceLocations.audit(accessions)
 
-      St26SourceLocations.report result
-
-      # Only what was named, and only the reasons this run is allowed to act on.
+      # Only what was named, and only what this run is allowed to act on.
       # Resolving accessions reaches whole submissions — a JPO request can carry
       # sixty entries — so without the first restriction, naming one accession
       # would rewrite every disagreeing sibling alongside it.
-      allowed = St26SourceLocations.actionable_reasons(ENV['INCLUDE'])
-      act     = ->(f) { allowed.include?(f.reason) }
+      plan = St26SourceLocations.plan_from(ENV['LENGTHEN'])
 
-      correctable, rest = result.named.partition(&act)
+      St26SourceLocations.report result, plan
+
+      correctable, rest = result.named.partition { plan.actionable?(it) }
 
       # Named by reason. Both are refusals, but they are refusals to answer
       # different questions, and "unreadable" said of a length disagreement
       # sends the reader looking for a malformed location that is not there.
+      # Each refusal says what to do about itself: `:short` has an answer on the
+      # command line, the rest are dead ends where by hand is the only route.
       rest.group_by(&:reason).each do |reason, group|
-        puts "\n#{St26SourceLocations::REFUSALS.fetch(reason).call(group.size)} Fix #{group.size == 1 ? 'it' : 'them'} by hand."
+        puts "\n#{St26SourceLocations::REFUSALS.fetch(reason).call(group.size)}"
       end
 
       abort "#{result.unmatched.size} #{'accession'.pluralize(result.unmatched.size)} matched no ST.26 entry — nothing was written." if result.unmatched.any?
@@ -115,8 +118,8 @@ namespace :st26 do
       # `remaining` empty and this check trivially satisfied — reporting the
       # rewrite as verified on the strength of not having looked. The
       # pre-checks above refuse the same situation for the same reason.
-      unless remaining.none?(&act) && after.unreadable.empty? && after.skipped.empty?
-        St26SourceLocations.report after
+      unless remaining.none? { plan.actionable?(it) } && after.unreadable.empty? && after.skipped.empty?
+        St26SourceLocations.report after, plan
 
         abort 'The rewrite could not be confirmed: run the audit again.'
       end

--- a/lib/tasks/st26.rake
+++ b/lib/tasks/st26.rake
@@ -47,7 +47,7 @@ namespace :st26 do
       end
     end
 
-    desc 'Rewrite disagreeing source locations to 1..<length> (ACCESSIONS= required, APPLY=1 to write)'
+    desc 'Set plain source locations to 1..<length> (ACCESSIONS= required, APPLY=1 to write)'
     task fix: :environment do
       accessions = ENV['ACCESSIONS'].to_s
 

--- a/test/lib/st26_source_locations_test.rb
+++ b/test/lib/st26_source_locations_test.rb
@@ -9,7 +9,7 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
   # Only a plain forward range from base 1 is repairable, and the two directions
   # are told apart: an overrun names bases the sequence does not have, while a
   # shortfall might be the boundary slip PATENT-386 found or might be coverage
-  # somebody meant, so `fix` needs INCLUDE=short for it.
+  # somebody meant, so lengthening has to be asked for per accession.
   #
   # The notation cases are the ones that matter. bio-ruby flattens `1..(5.10)`
   # to from=1/to=10 and `1.5` to 1..1, with none of its markers set, so a check
@@ -19,6 +19,8 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
     '1..20'             => nil,
     'join(1..4,6..20)'  => nil,       # covers the whole sequence, gap and all
     '1..21'             => :overrun,  # names a base that is not there
+    '1..21 '            => :overrun,  # lifted from XML, stray space and all
+    ' 1..21'            => :overrun,
     '1..19'             => :short,    # PATENT-386 has both directions
     '1..5'              => :short,
     '1'                 => :ambiguous, # not a range
@@ -36,7 +38,7 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
     '1..E'              => :unreadable,
     'garbage!!'         => :unreadable
   }.each do |location, expected|
-    test "#{location.presence || '(blank)'} over 20 bases is #{expected.inspect}" do
+    test "#{location.inspect} over 20 bases is #{expected.inspect}" do
       actual = St26SourceLocations.disagreement(location, 20)
 
       expected.nil? ? assert_nil(actual) : assert_equal(expected, actual)
@@ -127,17 +129,40 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
 
     result = St26SourceLocations.audit
 
-    assert_equal %i[ambiguous ambiguous], result.findings.map(&:reason)
-    assert_empty result.findings.select(&:repairable?)
+    # The first is the one that could have been lengthened — it is a plain range
+    # from base 1 stopping short. The second does not start at base 1, so it was
+    # never a candidate.
+    assert_equal %i[multiple_sources ambiguous], result.findings.map(&:reason)
+    assert_empty result.findings.select { St26SourceLocations.plan_from('ACC_000001').actionable?(it) }
   end
 
-  # `:short` is repairable but not acted on by default: the operator says so on
-  # the command line, which is where PATENT-386's answer to that question came
-  # from.
-  test 'only overruns are actionable unless short is asked for' do
-    assert_equal %i[overrun],        St26SourceLocations.actionable_reasons(nil)
-    assert_equal %i[overrun short],  St26SourceLocations.actionable_reasons('short')
-    assert_equal %i[overrun],        St26SourceLocations.actionable_reasons('something-else')
+  # `:short` is repairable but acted on only where a person named the accession.
+  # Per accession and not per run: PATENT-386's answer came from somebody
+  # looking at two specific entries, and a run-wide switch would carry it to
+  # every short row in the batch.
+  test 'lengthening applies only to the accessions named in the plan' do
+    seed '1..21', '1..19'
+
+    findings = St26SourceLocations.audit.findings
+    overrun  = findings.find { it.reason == :overrun }
+    short    = findings.find { it.reason == :short }
+
+    bare    = St26SourceLocations.plan_from(nil)
+    someone = St26SourceLocations.plan_from('ACC_000002')
+    other   = St26SourceLocations.plan_from('ACC_000009')
+
+    assert bare.actionable?(overrun),      'an overrun needs no permission'
+    refute bare.actionable?(short)
+    assert someone.actionable?(short),     'named in LENGTHEN'
+    refute other.actionable?(short),       'a different accession is not permission for this one'
+  end
+
+  # Shrinking an overrun cannot swallow a sibling's span, so the sources guard
+  # applies to lengthening only — and refusing it as `ambiguous` would have
+  # blamed a notation problem that is not there.
+  test 'an overrun is still repaired when another source divides the entry' do
+    assert_equal :overrun, St26SourceLocations.disagreement('1..21', 20, sources: 2)
+    assert_equal :multiple_sources, St26SourceLocations.disagreement('1..19', 20, sources: 2)
   end
 
   test 'a submission with no record is skipped rather than passed over' do

--- a/test/lib/st26_source_locations_test.rb
+++ b/test/lib/st26_source_locations_test.rb
@@ -11,15 +11,15 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
   #
   # `<1..>21` and `J00194.1:1..21` matter most — bio-ruby keeps the partiality
   # markers and the cross-referenced accession beside the numbers, so a check
-  # reading only `from` and `to` calls them overruns and rewriting throws them
-  # away.
+  # reading only `from` and `to` calls them plain ranges and rewriting throws
+  # them away.
   {
     '1..20'             => nil,
-    'join(1..4,6..20)'  => nil,      # covers the whole sequence, gap and all
-    '1..21'             => :overrun, # the JPO defect
-    '1'                 => :ambiguous, # one base of twenty, not a repair to guess at
-    '1..19'             => :ambiguous,
-    '5..21'             => :ambiguous,
+    'join(1..4,6..20)'  => nil,        # covers the whole sequence, gap and all
+    '1..21'             => :wrong_end, # runs one past the end
+    '1..19'             => :wrong_end, # stops one short — PATENT-386 has both
+    '1'                 => :wrong_end,
+    '5..21'             => :ambiguous, # does not start at base 1
     '10..1'             => :ambiguous,
     '<1..>21'           => :ambiguous,
     '<1..21'            => :ambiguous,
@@ -43,14 +43,15 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
     result = St26SourceLocations.audit
 
     assert_equal %w[ACC_000001 ACC_000002], result.findings.map(&:accession)
-    assert_equal %i[overrun ambiguous], result.findings.map(&:reason)
+    assert_equal %i[wrong_end wrong_end], result.findings.map(&:reason)
     assert_empty result.unreadable
     assert_empty result.skipped
     assert_equal submission, result.findings.first.submission
   end
 
-  test 'correct! rewrites the overrun and touches nothing else' do
-    submission = seed('1..21', '1..19', '1..20')
+  # Both directions land on the sequence length, and nothing else moves.
+  test 'correct! sets the wrong-ended locations to the full span' do
+    submission = seed('1..21', '1..19', '1..20', '5..21')
     before     = record_of(submission)
 
     capture_io do
@@ -59,7 +60,7 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
 
     after = record_of(submission)
 
-    assert_equal %w[1..20 1..19 1..20], locations_of(after)
+    assert_equal %w[1..20 1..20 1..20 5..21], locations_of(after)
     assert_equal blind_to_locations(before), blind_to_locations(after),
                  'the correction rewrote something other than a location'
   end
@@ -131,6 +132,17 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
     result = St26SourceLocations.audit('ACC_000001, NOPE_000009')
 
     assert_equal %w[NOPE_000009], result.unmatched
+  end
+
+  # The number the decision turns on. PATENT-386 needed it for two refused
+  # rows and it was not on the line, so it had to be looked up by hand.
+  test 'the report prints the sequence length on refused rows too' do
+    seed 'join(1..4,6..25)'
+
+    out, = capture_io { St26SourceLocations.report St26SourceLocations.audit }
+
+    assert_match(/sequence=20/, out)
+    assert_match(/NOT REWRITTEN \(ambiguous\)/, out)
   end
 
   # Naming one accession must not drag its siblings into the rewrite.

--- a/test/lib/st26_source_locations_test.rb
+++ b/test/lib/st26_source_locations_test.rb
@@ -23,6 +23,8 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
     ' 1..21'            => :overrun,
     '1..19'             => :short,    # PATENT-386 has both directions
     '1..5'              => :short,
+    '01..21'            => :overrun,  # zero-padded, still plainly the overrun
+    '1..0'              => :ambiguous, # not a forward range at all
     '1'                 => :ambiguous, # not a range
     '1.5'               => :ambiguous, # fuzzy bound, flattened by bio-ruby to 1..1
     '1..(5.10)'         => :ambiguous, # fuzzy bound, flattened to 1..10
@@ -62,8 +64,10 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
     submission = seed('1..21', '1..19', '1..20', '5..21')
     before     = record_of(submission)
 
+    plan = St26SourceLocations.plan_from('ACC_000002')
+
     capture_io do
-      St26SourceLocations.correct! St26SourceLocations.audit.findings.select(&:repairable?)
+      St26SourceLocations.correct! St26SourceLocations.audit.findings.select { plan.actionable?(it) }
     end
 
     after = record_of(submission)
@@ -111,7 +115,7 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
     result = St26SourceLocations.audit
 
     assert_equal %i[no_sequence], result.findings.map(&:reason)
-    refute_predicate result.findings.first, :repairable?
+    refute St26SourceLocations.plan_from('ACC_000001').actionable?(result.findings.first)
   end
 
   # "A patent source covers the whole sequence" is a statement about an entry

--- a/test/lib/st26_source_locations_test.rb
+++ b/test/lib/st26_source_locations_test.rb
@@ -6,25 +6,31 @@ require 'test_helper'
 # guard has to fire before anything is written, and a record that was not
 # examined must not be reported as a clean one.
 class St26SourceLocationsTest < ActiveSupport::TestCase
-  # The whole point of the classification: only the JPO defect is repaired
-  # automatically, because only there is `1..<length>` plainly what was meant.
+  # Only a plain forward range from base 1 is repairable, and the two directions
+  # are told apart: an overrun names bases the sequence does not have, while a
+  # shortfall might be the boundary slip PATENT-386 found or might be coverage
+  # somebody meant, so `fix` needs INCLUDE=short for it.
   #
-  # `<1..>21` and `J00194.1:1..21` matter most — bio-ruby keeps the partiality
-  # markers and the cross-referenced accession beside the numbers, so a check
-  # reading only `from` and `to` calls them plain ranges and rewriting throws
-  # them away.
+  # The notation cases are the ones that matter. bio-ruby flattens `1..(5.10)`
+  # to from=1/to=10 and `1.5` to 1..1, with none of its markers set, so a check
+  # reading `from` and `to` calls them plain ranges and the rewrite throws the
+  # notation away — which is why the guard is a regexp over the text.
   {
     '1..20'             => nil,
-    'join(1..4,6..20)'  => nil,        # covers the whole sequence, gap and all
-    '1..21'             => :wrong_end, # runs one past the end
-    '1..19'             => :wrong_end, # stops one short — PATENT-386 has both
-    '1'                 => :wrong_end,
+    'join(1..4,6..20)'  => nil,       # covers the whole sequence, gap and all
+    '1..21'             => :overrun,  # names a base that is not there
+    '1..19'             => :short,    # PATENT-386 has both directions
+    '1..5'              => :short,
+    '1'                 => :ambiguous, # not a range
+    '1.5'               => :ambiguous, # fuzzy bound, flattened by bio-ruby to 1..1
+    '1..(5.10)'         => :ambiguous, # fuzzy bound, flattened to 1..10
     '5..21'             => :ambiguous, # does not start at base 1
     '10..1'             => :ambiguous,
     '<1..>21'           => :ambiguous,
     '<1..21'            => :ambiguous,
     'J00194.1:1..21'    => :ambiguous,
     'complement(1..25)' => :ambiguous,
+    'join(1..25)'       => :ambiguous, # one member, but still not a plain range
     'join(1..4,6..25)'  => :ambiguous,
     ''                  => :missing,
     '1..E'              => :unreadable,
@@ -43,19 +49,19 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
     result = St26SourceLocations.audit
 
     assert_equal %w[ACC_000001 ACC_000002], result.findings.map(&:accession)
-    assert_equal %i[wrong_end wrong_end], result.findings.map(&:reason)
+    assert_equal %i[overrun short], result.findings.map(&:reason)
     assert_empty result.unreadable
     assert_empty result.skipped
     assert_equal submission, result.findings.first.submission
   end
 
   # Both directions land on the sequence length, and nothing else moves.
-  test 'correct! sets the wrong-ended locations to the full span' do
+  test 'correct! sets a repairable location to the full span' do
     submission = seed('1..21', '1..19', '1..20', '5..21')
     before     = record_of(submission)
 
     capture_io do
-      St26SourceLocations.correct! St26SourceLocations.audit.findings.select(&:correctable?)
+      St26SourceLocations.correct! St26SourceLocations.audit.findings.select(&:repairable?)
     end
 
     after = record_of(submission)
@@ -103,7 +109,35 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
     result = St26SourceLocations.audit
 
     assert_equal %i[no_sequence], result.findings.map(&:reason)
-    refute_predicate result.findings.first, :correctable?
+    refute_predicate result.findings.first, :repairable?
+  end
+
+  # "A patent source covers the whole sequence" is a statement about an entry
+  # with one source. Where two divide an entry, widening the first would swallow
+  # the second's span and turn a coherent record into overlapping sources.
+  test 'a source is not lengthened when another one divides the same entry' do
+    seed_entries [
+      {
+        'id'              => 'SEQ|JP|2026123456|A|1',
+        'sequence'        => 'acgt' * 5,
+        'length'          => 20,
+        'source_features' => [{'location' => '1..10'}, {'location' => '11..20'}]
+      }
+    ]
+
+    result = St26SourceLocations.audit
+
+    assert_equal %i[ambiguous ambiguous], result.findings.map(&:reason)
+    assert_empty result.findings.select(&:repairable?)
+  end
+
+  # `:short` is repairable but not acted on by default: the operator says so on
+  # the command line, which is where PATENT-386's answer to that question came
+  # from.
+  test 'only overruns are actionable unless short is asked for' do
+    assert_equal %i[overrun],        St26SourceLocations.actionable_reasons(nil)
+    assert_equal %i[overrun short],  St26SourceLocations.actionable_reasons('short')
+    assert_equal %i[overrun],        St26SourceLocations.actionable_reasons('something-else')
   end
 
   test 'a submission with no record is skipped rather than passed over' do


### PR DESCRIPTION
[PATENT-386](https://ddbj-dev.atlassian.net/browse/PATENT-386) の続きです。#1982 をデプロイして production の 5 件を audit したところ、**食い違いが両方向にありました**。

| accession | submission | entry | 配列長 | 現在の location | 差 |
|---|---|---|---|---|---|
| ZAA0535397 | #3826 | A\|15 | 448 | `1..449` | +1 超過 |
| ZAA0673386 | #4085 | A\|15 | 448 | `1..449` | +1 超過 |
| QW116184 | #25231 | A\|2 | 20 | `1..21` | +1 超過 |
| ZAA4138603 | #22343 | A\|14 | 316 | `1..315` | **1 残基不足** |
| ZAA4138622 | #22343 | A\|33 | 437 | `1..435` | **2 残基不足** |

不足側は `:ambiguous` として拒否していました。「短い location を全長まで広げると宣言されていない範囲をでっち上げる」という一般原則で作ったためです。ST.26 に限ればこの原則は効きません — patent source は全長 1 本で、それは PATENT-386 の FF 仕様策定が前提にしているものであり、submission-bulk-st26 は方向を問わず `1..<length>` に固定します。**同じ XML を今日再投入すれば client は `1..316` / `1..437` を出力します。** 青野さんに確認済みです。

## 分類

| location (20 塩基に対して) | 分類 | 修正 |
|---|---|---|
| `1..21` / `01..21` / `1..21 ` | `overrun` | ✅ 無条件。存在しない塩基を名指すのは量に関わらず誤りで、全長に縮める操作は何も壊さない |
| `1..19` | `short` | ⚠️ **`LENGTHEN=<accession>` で名指したものだけ** |
| `1..10` (同 entry に別 source あり) | `multiple_sources` | ❌ 広げると兄弟の span を飲み込む |
| `5..21` / `1` / `1..0` / `10..1` | `ambiguous` | ❌ 1 から始まる順方向 range でない |
| `<1..>21` / `J00194.1:1..21` / `1..(5.10)` / `1.5` | `ambiguous` | ❌ 部分性・参照・fuzzy bound が失われる |
| `complement(…)` / `join(…)` | `ambiguous` | ❌ |
| `""` / `1..E` / 壊れた文字列 | `missing` / `unreadable` | ❌ |
| 申告 `length` ≠ 実配列長 | `declared_length` | ❌ どちらが正しいか判断できない |

**不足の許可は accession 単位です。** run 単位のスイッチだと 1 残基のずれと 995 残基のでっち上げを 1 回の指定でまとめて通してしまいます。判断はレコードごとであり、今回の答えも特定の 2 entry を見た人から得たものなので、粒度をそれに合わせました。閾値は発明していません。

`LENGTHEN` は `ACCESSIONS` と同じく検証します。綴り誤りや `ACCESSIONS` の外の番号は、authorise したはずの行が触られないまま成功と報告されるのを防ぐため abort します。

## その他の修正 (review 3 巡分)

- **bio-ruby は fuzzy bound を平坦化する** — `1..(5.10)` は `from=1/to=10`、`1.5` は `1..1` で marker はすべて nil。`from`/`to` だけを見る判定はこれらを plain な range と誤認して記法を消していた。判定を本文の regexp に変更
- location の数値比較を整数で行う (`01..21` が誤って拒否されていた)、`to >= from` を要求 (`1..0` を「早く終わる range」と読まない)
- 空白を許容 (`'1..21 '` は XML 由来でありうる形)
- `verify!` の照合キーに `reason` を追加し、lock の中でも source 数を数える — audit 後に entry が 2 本目の source を得ると分類が変わるが位置・文言・長さは変わらないため
- report に配列長 (`sequence=N`) を全行に表示。**判断が必要な行にその数字が無く、production へ別途問い合わせる必要があった**
- report が「この run で何が起きるか」を言えるよう plan を渡す。`LENGTHEN=… APPLY=1` の run で、まさに書き換える行に「LENGTHEN が必要」と表示していた
- `Finding#repairable?` を削除 (Plan と分類を二重に持っていた)、文言の複数形バグ、`REFUSALS` の縦位置

## 検証

- `bin/rails test:all` — 1148 runs, 0 failures (`test/lib/st26_source_locations_test.rb` 36 件)
- `bin/rubocop` — 501 files, clean
- dev に production と同じ形 (+1 / −2) を仕込み、bare / `LENGTHEN` preview / 無関係な accession / 正しく名指し / 綴り誤り (exit 1) の 5 通りを確認
- 書き換え後に全件 audit → `OK` / exit 0

## デプロイ後

```sh
bin/rails st26:source_locations:audit ACCESSIONS=<5件> LENGTHEN=ZAA4138603,ZAA4138622
bin/rails st26:source_locations:fix   ACCESSIONS=<5件> LENGTHEN=ZAA4138603,ZAA4138622 APPLY=1
```

その後 Admin → Regenerate flatfiles に 5 accession、AA 蓄積ファイルの再公開 (ticket 3、運用側)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)