### PR TITLE
修正した entry の LOCUS date を設定できるようにする (PATENT-386)

### DIFF
--- a/lib/st26_source_locations.rb
+++ b/lib/st26_source_locations.rb
@@ -184,14 +184,10 @@ module St26SourceLocations
   # each, would put the whole batch in memory at once. The rewrite still needs
   # one whole document, so memory is bounded by the largest single record.
   #
-  # `locus_date` is set on exactly the entries whose locations were rewritten,
-  # in the same transaction. Not through the Regenerate screen's date option:
-  # that resolves accessions to submissions and then does
-  # `submission.entries.update_all(locus_date:)`, so setting the date for
-  # PATENT-386's five entries there would have moved it on the 62 siblings
-  # sharing their four submissions. The renderer reads each entry's own column,
-  # so a per-entry date is all it takes.
-  def correct!(findings, locus_date: nil)
+  # Returns the lines describing what it did rather than printing them, so the
+  # caller can hold them until its transaction has committed — a rollback would
+  # otherwise have already said the records were rewritten.
+  def correct!(findings)
     by_submission = findings.group_by(&:submission)
 
     by_submission.each { verify! it.first, it.last }
@@ -200,25 +196,38 @@ module St26SourceLocations
     # leave some records corrected and others not. The uploads themselves are
     # not transactional; a rollback leaves orphan blobs behind, which is the
     # same trade the rest of this system already makes.
-    #
-    # Printed after it commits, not inside: a rollback would otherwise have
-    # already told the operator that records were rewritten.
-    written = []
-
     Submission.transaction do
-      by_submission.each do |submission, group|
-        written << rewrite!(submission, group)
-
-        next unless locus_date
-
-        dated = Entry.where(submission:, entry_id: group.map(&:entry_id).uniq)
-                     .update_all(locus_date:, updated_at: Time.current)
-
-        written << "submission ##{submission.id}: set LOCUS date to #{locus_date} on #{dated} #{'entry'.pluralize(dated)}"
-      end
+      by_submission.map { rewrite! it.first, it.last }
     end
+  end
 
-    written.each { puts it }
+  # The LOCUS date, on the entries named and nowhere else.
+  #
+  # Not through the Regenerate screen's date option: that resolves accessions to
+  # submissions and then does `submission.entries.update_all(locus_date:)`, so
+  # setting the date for PATENT-386's five entries there would have moved it on
+  # the 62 siblings sharing their four submissions. The renderer reads each
+  # entry's own column, so a per-entry date is all it takes.
+  #
+  # Keyed on `accession`, the uniquely indexed column — `entries` has no unique
+  # index on (submission_id, entry_id), so keying on that could redate two rows
+  # for one finding, a small version of the splash this exists to avoid.
+  #
+  # Reports the date it replaced as well as the one it wrote: the rest of this
+  # correction is reversible from its own output, and a date that only appears
+  # as its new value would be the exception.
+  def redate!(accessions, locus_date:)
+    names = requested_from(accessions)
+    rows  = Entry.where(accession: names).order(:accession).to_a
+    lines = rows.map { "#{it.accession}: LOCUS date #{it.locus_date} -> #{locus_date}" }
+
+    raise "expected #{names.size} #{'entry'.pluralize(names.size)} to redate, found #{rows.size}" unless rows.size == names.size
+
+    changed = Entry.where(id: rows.map(&:id)).update_all(locus_date:, updated_at: Time.current)
+
+    raise "expected to redate #{rows.size} #{'entry'.pluralize(rows.size)}, redated #{changed}" unless changed == rows.size
+
+    lines
   end
 
   # That the audited disagreement is still in the record, in the same place and

--- a/lib/st26_source_locations.rb
+++ b/lib/st26_source_locations.rb
@@ -183,7 +183,15 @@ module St26SourceLocations
   # a parsed copy of every submission in the batch, plus a serialised String of
   # each, would put the whole batch in memory at once. The rewrite still needs
   # one whole document, so memory is bounded by the largest single record.
-  def correct!(findings)
+  #
+  # `locus_date` is set on exactly the entries whose locations were rewritten,
+  # in the same transaction. Not through the Regenerate screen's date option:
+  # that resolves accessions to submissions and then does
+  # `submission.entries.update_all(locus_date:)`, so setting the date for
+  # PATENT-386's five entries there would have moved it on the 62 siblings
+  # sharing their four submissions. The renderer reads each entry's own column,
+  # so a per-entry date is all it takes.
+  def correct!(findings, locus_date: nil)
     by_submission = findings.group_by(&:submission)
 
     by_submission.each { verify! it.first, it.last }
@@ -200,6 +208,13 @@ module St26SourceLocations
     Submission.transaction do
       by_submission.each do |submission, group|
         written << rewrite!(submission, group)
+
+        next unless locus_date
+
+        dated = Entry.where(submission:, entry_id: group.map(&:entry_id).uniq)
+                     .update_all(locus_date:, updated_at: Time.current)
+
+        written << "submission ##{submission.id}: set LOCUS date to #{locus_date} on #{dated} #{'entry'.pluralize(dated)}"
       end
     end
 

--- a/lib/tasks/st26.rake
+++ b/lib/tasks/st26.rake
@@ -55,15 +55,19 @@ namespace :st26 do
     task fix: :environment do
       accessions = ENV['ACCESSIONS'].to_s
 
-      # ISO 8601 only. `Date.parse` would take `8/13` and decide for itself
-      # which half is the month, and a LOCUS date is printed into a published
-      # flatfile.
+      # `YYYY-MM-DD` and nothing else. `Date.parse` would take `8/13` and decide
+      # for itself which half is the month; `Date.iso8601` alone is little
+      # better, reading `2026-08` as the 1st, `2026-225` as an ordinal day and
+      # `2026-W33-4` as a week date — so a truncated `LOCUS_DATE=2026-08` would
+      # be accepted and 1 August printed into a published flatfile.
       locus_date =
         if (given = ENV['LOCUS_DATE'].presence)
+          abort "LOCUS_DATE=#{given} is not a date: write it as YYYY-MM-DD." unless given.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+
           begin
             Date.iso8601(given)
           rescue Date::Error
-            abort "LOCUS_DATE=#{given} is not a date: write it as YYYY-MM-DD."
+            abort "LOCUS_DATE=#{given} is not a real date."
           end
         end
 
@@ -119,21 +123,42 @@ namespace :st26 do
 
       abort "#{unexamined} named #{'submission'.pluralize(unexamined)} could not be examined — nothing was written." if unexamined.positive?
 
-      if correctable.empty?
+      # A date is work of its own, so "nothing to correct" no longer ends the run
+      # when one was given. The locations may well be right already — this task
+      # shipped before the date option existed, so an earlier run having fixed
+      # them is the likely order of events — and there is no other route to a
+      # per-entry date.
+      if correctable.empty? && locus_date.nil?
         puts 'Nothing to correct.'
         next
       end
 
+      intent = [
+        ("rewrite #{correctable.size} #{'location'.pluralize(correctable.size)}" if correctable.any?),
+        ("set the LOCUS date of #{result.requested.size} #{'entry'.pluralize(result.requested.size)} to #{locus_date}" if locus_date)
+      ].compact.to_sentence
+
       unless ENV['APPLY'] == '1'
-        puts "\nDry run. Re-run with APPLY=1 to rewrite #{correctable.size} #{'location'.pluralize(correctable.size)}#{" and set their LOCUS date to #{locus_date}" if locus_date}."
+        puts "\nDry run. Re-run with APPLY=1 to #{intent}."
         next
       end
 
-      # Written out rather than as the `locus_date:` shorthand: with the value
-      # omitted at the end of a statement, Ruby keeps looking for one past the
-      # newline and takes the next expression — here the re-audit below, which
-      # arrived as the date and blew up inside the query.
-      St26SourceLocations.correct! correctable, locus_date: locus_date
+      # Both halves in one transaction, and both reported only once it has
+      # committed: a rollback would otherwise have already said the records were
+      # rewritten.
+      #
+      # `locus_date: locus_date` written out rather than as the shorthand: with
+      # the value omitted at the end of a statement, Ruby keeps looking for one
+      # past the newline and takes the next expression — which is how the
+      # re-audit below once arrived as the date and blew up inside the query.
+      done = []
+
+      Submission.transaction do
+        done.concat St26SourceLocations.correct!(correctable) if correctable.any?
+        done.concat St26SourceLocations.redate!(accessions, locus_date: locus_date) if locus_date
+      end
+
+      done.each { puts it }
 
       after     = St26SourceLocations.audit(accessions)
       remaining = after.named
@@ -152,9 +177,16 @@ namespace :st26 do
       # Says what was written rather than that everything is now well: the
       # refused set is still wrong, and claiming otherwise on the line right
       # after refusing it is how a known problem gets forgotten.
-      puts "\nRewrote #{correctable.size} #{'location'.pluralize(correctable.size)}#{" and redated #{correctable.size == 1 ? 'that entry' : 'those entries'}" if locus_date}."
+      puts "\nDone: #{intent}."
       puts "#{remaining.size} named #{'location'.pluralize(remaining.size)} still #{remaining.size == 1 ? 'needs' : 'need'} fixing by hand." if remaining.any?
-      puts 'The flatfiles still hold the old spans — regenerate them from Admin → Regenerate flatfiles for these accessions.'
+
+      # The screen named here can undo the date this task just set: its own date
+      # option runs `submission.entries.update_all(locus_date:)` over the whole
+      # submission. It defaults to keeping them, which is why the default is
+      # worth saying out loud rather than leaving to be noticed.
+      keep = ', keeping the existing LOCUS dates' if locus_date
+
+      puts "The flatfiles still hold the old spans — regenerate them from Admin → Regenerate flatfiles for these accessions#{keep}."
 
       # The request keeps the file as it arrived, which is the point of it —
       # but that makes it disagree with the corrected submission, and it is

--- a/lib/tasks/st26.rake
+++ b/lib/tasks/st26.rake
@@ -51,9 +51,21 @@ namespace :st26 do
       end
     end
 
-    desc 'Set plain source locations to 1..<length> (ACCESSIONS= required, LENGTHEN= to also lengthen those, APPLY=1 to write)'
+    desc 'Set plain source locations to 1..<length> (ACCESSIONS= required, LENGTHEN= to also lengthen those, LOCUS_DATE=YYYY-MM-DD to redate them, APPLY=1 to write)'
     task fix: :environment do
       accessions = ENV['ACCESSIONS'].to_s
+
+      # ISO 8601 only. `Date.parse` would take `8/13` and decide for itself
+      # which half is the month, and a LOCUS date is printed into a published
+      # flatfile.
+      locus_date =
+        if (given = ENV['LOCUS_DATE'].presence)
+          begin
+            Date.iso8601(given)
+          rescue Date::Error
+            abort "LOCUS_DATE=#{given} is not a date: write it as YYYY-MM-DD."
+          end
+        end
 
       # A blanket rewrite is refused. The correction is only ever right for
       # records already known to be wrong, and the audit is how they become
@@ -113,11 +125,15 @@ namespace :st26 do
       end
 
       unless ENV['APPLY'] == '1'
-        puts "\nDry run. Re-run with APPLY=1 to rewrite #{correctable.size} #{'location'.pluralize(correctable.size)}."
+        puts "\nDry run. Re-run with APPLY=1 to rewrite #{correctable.size} #{'location'.pluralize(correctable.size)}#{" and set their LOCUS date to #{locus_date}" if locus_date}."
         next
       end
 
-      St26SourceLocations.correct! correctable
+      # Written out rather than as the `locus_date:` shorthand: with the value
+      # omitted at the end of a statement, Ruby keeps looking for one past the
+      # newline and takes the next expression — here the re-audit below, which
+      # arrived as the date and blew up inside the query.
+      St26SourceLocations.correct! correctable, locus_date: locus_date
 
       after     = St26SourceLocations.audit(accessions)
       remaining = after.named
@@ -136,7 +152,7 @@ namespace :st26 do
       # Says what was written rather than that everything is now well: the
       # refused set is still wrong, and claiming otherwise on the line right
       # after refusing it is how a known problem gets forgotten.
-      puts "\nRewrote #{correctable.size} #{'location'.pluralize(correctable.size)}."
+      puts "\nRewrote #{correctable.size} #{'location'.pluralize(correctable.size)}#{" and redated #{correctable.size == 1 ? 'that entry' : 'those entries'}" if locus_date}."
       puts "#{remaining.size} named #{'location'.pluralize(remaining.size)} still #{remaining.size == 1 ? 'needs' : 'need'} fixing by hand." if remaining.any?
       puts 'The flatfiles still hold the old spans — regenerate them from Admin → Regenerate flatfiles for these accessions.'
 

--- a/test/lib/st26_source_locations_test.rb
+++ b/test/lib/st26_source_locations_test.rb
@@ -77,6 +77,34 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
                  'the correction rewrote something other than a location'
   end
 
+  # The date goes on the entries whose locations were rewritten and nowhere
+  # else. The Regenerate screen's date option resolves accessions to whole
+  # submissions, so using it for PATENT-386's five entries would have moved the
+  # date on the 62 siblings sharing their four submissions.
+  test 'correct! redates only the entries it rewrote' do
+    seed '1..21', '1..20'
+
+    before = entries(:two).locus_date
+
+    capture_io do
+      St26SourceLocations.correct! St26SourceLocations.audit.findings, locus_date: Date.new(2026, 8, 13)
+    end
+
+    assert_equal Date.new(2026, 8, 13), entries(:one).reload.locus_date
+    assert_equal before, entries(:two).reload.locus_date,
+                 'a sibling entry in the same submission was redated'
+  end
+
+  test 'correct! leaves the dates alone when none is given' do
+    seed '1..21'
+
+    before = entries(:one).locus_date
+
+    capture_io { St26SourceLocations.correct! St26SourceLocations.audit.findings }
+
+    assert_equal before, entries(:one).reload.locus_date
+  end
+
   # The guard used to fire in the middle of the loop, so a batch whose later
   # submission tripped it aborted with the earlier ones already rewritten.
   test 'correct! writes nothing when a finding does not line up with the record' do

--- a/test/lib/st26_source_locations_test.rb
+++ b/test/lib/st26_source_locations_test.rb
@@ -66,9 +66,7 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
 
     plan = St26SourceLocations.plan_from('ACC_000002')
 
-    capture_io do
-      St26SourceLocations.correct! St26SourceLocations.audit.findings.select { plan.actionable?(it) }
-    end
+    St26SourceLocations.correct! St26SourceLocations.audit.findings.select { plan.actionable?(it) }
 
     after = record_of(submission)
 
@@ -81,26 +79,32 @@ class St26SourceLocationsTest < ActiveSupport::TestCase
   # else. The Regenerate screen's date option resolves accessions to whole
   # submissions, so using it for PATENT-386's five entries would have moved the
   # date on the 62 siblings sharing their four submissions.
-  test 'correct! redates only the entries it rewrote' do
-    seed '1..21', '1..20'
+  test 'redate! moves the named entries and no sibling' do
+    was = entries(:two).locus_date
 
-    before = entries(:two).locus_date
-
-    capture_io do
-      St26SourceLocations.correct! St26SourceLocations.audit.findings, locus_date: Date.new(2026, 8, 13)
-    end
+    lines = St26SourceLocations.redate!('ACC_000001', locus_date: Date.new(2026, 8, 13))
 
     assert_equal Date.new(2026, 8, 13), entries(:one).reload.locus_date
-    assert_equal before, entries(:two).reload.locus_date,
+    assert_equal was, entries(:two).reload.locus_date,
                  'a sibling entry in the same submission was redated'
+    assert_equal ["ACC_000001: LOCUS date #{was} -> 2026-08-13"], lines,
+                 'the date it replaced has to be in the output, or the change is not reversible from it'
   end
 
-  test 'correct! leaves the dates alone when none is given' do
+  # Named, not found: the count assertion is what the location rewrite has and
+  # what an `update_all` would otherwise do without.
+  test 'redate! refuses when an accession has no entry' do
+    assert_raises RuntimeError do
+      St26SourceLocations.redate! 'ACC_000001, NOPE_000009', locus_date: Date.new(2026, 8, 13)
+    end
+  end
+
+  test 'correct! leaves the dates alone' do
     seed '1..21'
 
     before = entries(:one).locus_date
 
-    capture_io { St26SourceLocations.correct! St26SourceLocations.audit.findings }
+    St26SourceLocations.correct! St26SourceLocations.audit.findings
 
     assert_equal before, entries(:one).reload.locus_date
   end


### PR DESCRIPTION
[PATENT-386](https://ddbj-dev.atlassian.net/browse/PATENT-386) の追加依頼で、今回修正する 5 件の LOCUS date を 2026-08-13 にしたいとのことでした。

## 既存の Regenerate 画面の日付指定は使えません

あれは accession を submission に解決してから `submission.entries.update_all(locus_date:)` を実行します (`app/jobs/regenerate_submission_flatfiles_job.rb:36`)。今回の 5 entry のために使うと、**それらが属する 4 submission の残り 62 entry まで日付が動きます**。

| submission | entries | うち今回の対象 |
|---|---|---|
| #3826 | 14 | 1 |
| #4085 | 14 | 1 |
| #22343 | 33 | **2** |
| #25231 | 6 | 1 |

renderer は entry ごとの `locus_date` 列を読む (`RegenerateSubmissionFlatfilesJob#build_entries`) ので、対象 entry だけに日付を設定し、Regenerate は「日付を保持」で回せば済みます。

## 変更点

`fix` に `LOCUS_DATE=YYYY-MM-DD` を追加します。

```sh
bin/rails st26:source_locations:fix ACCESSIONS=<5件> LENGTHEN=ZAA4138603,ZAA4138622 \
                                    LOCUS_DATE=2026-08-13 APPLY=1
```

- 対象は **`ACCESSIONS` で名指しした entry だけ**。`accession` (一意 index のある列) をキーにし、件数も検証します
- location の修正と同じ transaction に入り、出力は commit 後
- **location の修正が 0 件でも日付は設定されます。** 日付は独立した作業なので。location が既に直っている場合 (この task が先に出荷されたので、その順序は十分ありうる) に日付だけ設定できないと詰みます
- 置き換え前の日付を出力します。このタスクの可逆性は report が変更前の値を名指しすることで担保しているので、日付だけ例外にはしません

```
submission #15728: rewrote 2 locations
QP000001: LOCUS date 2026-05-22 -> 2026-08-13
QP000002: LOCUS date 2026-05-22 -> 2026-08-13

Done: rewrite 2 locations and set the LOCUS date of 2 entries to 2026-08-13.
The flatfiles still hold the old spans — regenerate them from Admin → Regenerate flatfiles for these accessions, keeping the existing LOCUS dates.
```

最後の一文に「日付は保持で」を入れてあります。案内先の画面は日付オプションを選ぶと submission 全体を上書きするので、既定 (保持) を明示しておく必要があります。

## 日付の形式は `YYYY-MM-DD` のみ

`Date.parse` は `8/13` のどちらが月かを自分で決めます。`Date.iso8601` 単独でも不十分で、以下がすべて通ります。

| 入力 | `Date.iso8601` の解釈 |
|---|---|
| `2026-08` | 2026-08-01 |
| `2026-225` | 2026-08-13 (ordinal) |
| `2026-W33-4` | 2026-08-13 (week date) |
| `20260813` | 2026-08-13 |

打ちかけの `LOCUS_DATE=2026-08` が黙って 8/1 として**公開される flatfile に印字される**ので、regexp で形を固定してから parse します。

## 実行時に踏んだ Ruby の落とし穴

`correct! correctable, locus_date:` と値省略記法で書いたところ `can't quote St26SourceLocations::Result` で落ちました。**値省略を文末に置くと Ruby は改行の先まで値を探し、次の式を取ります** — 直後の re-audit の戻り値が日付として渡っていました。テストは `correct!` を直接呼ぶので通り、rake 経由で初めて出ました。`locus_date: locus_date` と明示し、理由をコメントに残しています。

## 検証

- `bin/rails test:all` — 1151 runs, 0 failures / `bin/rubocop` — 501 files clean
- dev で 5 通り確認: 両方 / 日付のみ / どちらも不要 (`Nothing to correct.`) / 不正な日付 (exit 1) / **兄弟 entry の日付が動かないこと**
- 確認後 dev は pristine に復元し、全件 audit `OK` / exit 0

`/code-review` を 1 巡通しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)