### PR TITLE
LOCUS date を accession 単位で書き換える

### DIFF
--- a/app/controllers/admin/regenerate_flatfiles_controller.rb
+++ b/app/controllers/admin/regenerate_flatfiles_controller.rb
@@ -88,14 +88,16 @@ module Admin
     end
 
     def start(scope)
-      # The numbers are recorded for the retry to read back, so they are
-      # kept for a retry too — and left off the every-submission scope,
-      # where a list in the box is a draft rather than a scope, and
-      # storing it would have the retry date only those.
+      # The numbers are recorded for a retry to read back, so the rule
+      # for which runs have any is the scope's — a list left in the box
+      # under the every-submission option is a draft, and storing it
+      # would have the retry date only those. Stored as the parsed list
+      # rather than the paste, so the run and the form that made it count
+      # the same numbers.
       run = RegenerateFlatfilesRun.create!(
         actor:      current_actor,
         target:     scope.target,
-        numbers:    (scope.numbers_text.presence unless scope.all_target?),
+        numbers:    (scope.numbers.join("\n") if scope.naming_accessions?),
         locus_date: scope.locus_date,
         total:      scope.total,
         started_at: Time.current,
@@ -107,7 +109,9 @@ module Admin
       # kind of allocation that only shows up on the day someone uses it.
       enqueued = 0
 
-      scope.submissions.find_in_batches(batch_size: 500) do |submissions|
+      # Only the id is ever read — the job carries a GlobalID — and the
+      # every-submission scope is the whole table.
+      scope.submissions.select(:id).find_in_batches(batch_size: 500) do |submissions|
         ActiveJob.perform_all_later submissions.map {|submission|
           RegenerateSubmissionFlatfilesJob.new(submission, current_user, run, scope.locus_date,
                                                accessions: scope.accessions_for(submission))

--- a/app/controllers/admin/regenerate_flatfiles_controller.rb
+++ b/app/controllers/admin/regenerate_flatfiles_controller.rb
@@ -88,12 +88,15 @@ module Admin
     end
 
     def start(scope)
+      # The numbers are recorded for the retry to read back, so they are
+      # kept for a retry too — and left off the every-submission scope,
+      # where a list in the box is a draft rather than a scope, and
+      # storing it would have the retry date only those.
       run = RegenerateFlatfilesRun.create!(
         actor:      current_actor,
         target:     scope.target,
-        numbers:    (scope.numbers_text if scope.accessions_target?),
+        numbers:    (scope.numbers_text.presence unless scope.all_target?),
         locus_date: scope.locus_date,
-        force:      scope.force,
         total:      scope.total,
         started_at: Time.current,
         retry_of:   scope.retry_of
@@ -106,7 +109,8 @@ module Admin
 
       scope.submissions.find_in_batches(batch_size: 500) do |submissions|
         ActiveJob.perform_all_later submissions.map {|submission|
-          RegenerateSubmissionFlatfilesJob.new(submission, current_user, run, scope.locus_date, force: scope.force)
+          RegenerateSubmissionFlatfilesJob.new(submission, current_user, run, scope.locus_date,
+                                               accessions: scope.accessions_for(submission))
         }
 
         enqueued += submissions.size

--- a/app/jobs/regenerate_submission_flatfiles_job.rb
+++ b/app/jobs/regenerate_submission_flatfiles_job.rb
@@ -13,12 +13,80 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
     raise error
   end
 
-  def perform(submission, user, run, date, force: false)
-    # Detect v3 BEFORE parsing — v3 ddbj_records can be multi-GB and
-    # V3::Parser is full-document (Oj.load on the whole blob). Eating
-    # that allocation just to raise V3NotImplementedError would burn RAM
-    # and IO with no value. The detector peeks 64KB of head bytes.
-    record = submission.ddbj_record.open do |file|
+  # `accessions` names the entries `date` is written to; nil writes it to
+  # every entry of the submission.
+  #
+  # The file is the submission's — naming one accession still rewrites
+  # the whole of the file that holds it — so the list decides only whose
+  # date moves. A curator who lists numbers has already decided which
+  # ones they are, and dating the rest of the file along with them would
+  # move dates on records that merely share a submission.
+  def perform(submission, user, run, date, accessions: nil)
+    record = read_record(submission)
+
+    # `reload`, because the caller may have loaded the association before
+    # handing the submission over — a second run in the same process
+    # otherwise reads the statuses and dates left by the first.
+    rows    = submission.entries.reload.to_a
+    redated = date ? rows.select { accessions.nil? || accessions.include?(it.accession) } : []
+
+    entries             = build_entries(record, rows, date:, redated: redated.map(&:entry_id).to_set)
+    record_with_entries = record.with(sequences: record.sequences.with(entries:))
+
+    regenerated = false
+
+    generate_outputs record_with_entries, entries, **{
+      filename:       submission.ddbj_record.filename,
+      content_type:   submission.ddbj_record.content_type,
+      flatfile_omits: retracted_entry_ids(rows)
+    } do |updates|
+      # Written once, from the outputs the comparison was made against.
+      # Generating a second time to write what was just compared doubled
+      # the cost of every submission a run actually changed — which, on
+      # the runs this tool exists for, is all of them.
+      next unless changed?(submission, updates)
+
+      # The dates and the files that print them, together. Written apart,
+      # a job that died between them left a flatfile saying one date and
+      # the row behind it saying another — and the next run would read
+      # the file as already correct, generate the same bytes, and skip,
+      # so the two would never be brought back together.
+      ActiveRecord::Base.transaction do
+        Entry.where(id: redated.map(&:id)).update_all(locus_date: date) if redated.any?
+
+        submission.update! updates
+
+        # Every entry of the submission, not only the redated ones: the
+        # action is the rewrite of the file, and the file is theirs too.
+        # Which dates moved is recorded on the run.
+        EntryHistory.insert_all! rows.map {
+          {
+            entry_id: it.id,
+            user_id:  user.id,
+            action:   'regenerate'
+          }
+        }
+      end
+
+      regenerated = true
+    end
+
+    # Counted apart, because the two outcomes answer different questions:
+    # a run that skipped everything did nothing, and a run that
+    # regenerated everything rewrote the lot. The old single `processed`
+    # counter could not tell them apart, so a run that changed nothing
+    # produced a result nobody could read.
+    run.count! (regenerated ? :regenerated : :skipped), submission
+  end
+
+  private
+
+  # Detect v3 BEFORE parsing — v3 ddbj_records can be multi-GB and
+  # V3::Parser is full-document (Oj.load on the whole blob). Eating that
+  # allocation just to raise V3NotImplementedError would burn RAM and IO
+  # with no value. The detector peeks 64KB of head bytes.
+  def read_record(submission)
+    submission.ddbj_record.open do |file|
       major, = DDBJRecord::SchemaVersionDetector.detect(file)
       file.rewind
 
@@ -29,42 +97,7 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
 
       DDBJRecord.parse(file)
     end
-
-    regenerating = force || changed?(submission, record)
-
-    if regenerating
-      submission.entries.update_all(locus_date: date) if date
-
-      rows                = submission.entries.reload.to_a
-      entries             = build_entries(record, rows)
-      record_with_entries = record.with(sequences: record.sequences.with(entries:))
-
-      generate_outputs record_with_entries, entries, **{
-        filename:       submission.ddbj_record.filename,
-        content_type:   submission.ddbj_record.content_type,
-        flatfile_omits: retracted_entry_ids(rows)
-      } do |updates|
-        submission.update! updates
-      end
-
-      EntryHistory.insert_all! submission.entries.ids.map {|id|
-        {
-          entry_id: id,
-          user_id:      user.id,
-          action:       'regenerate'
-        }
-      }
-    end
-
-    # Counted apart, because the two outcomes answer different questions:
-    # a run that skipped everything did nothing, and a run that
-    # regenerated everything rewrote the lot. The old single `processed`
-    # counter could not tell them apart, so turning the rewrite option
-    # off produced a result nobody could read.
-    run.count! (regenerating ? :regenerated : :skipped), submission
   end
-
-  private
 
   # Which run to report to, and which submission the report is about.
   #
@@ -105,36 +138,25 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
     gid ? "#{klass.name.underscore.humanize} ##{gid.split('/').last}" : 'unknown submission'
   end
 
-  def changed?(submission, record)
-    # `reload`, because the caller may have loaded the association before
-    # handing the submission over — a second run in the same process
-    # otherwise compares against the statuses of the first, and a
-    # retraction that changed the flatfile is reported as no change.
-    rows                = submission.entries.reload.to_a
-    entries             = build_entries(record, rows)
-    record_with_entries = record.with(sequences: record.sequences.with(entries:))
-
-    result = false
-
-    generate_outputs record_with_entries, entries, **{
-      filename:       submission.ddbj_record.filename,
-      content_type:   submission.ddbj_record.content_type,
-      flatfile_omits: retracted_entry_ids(rows)
-    } do |updates|
-      result =
-        attachment_changed?(submission.ddbj_record, updates[:ddbj_record]) ||
-        attachment_changed?(submission.flatfile_na, updates[:flatfile_na]) ||
-        attachment_changed?(submission.flatfile_aa, updates[:flatfile_aa])
-    end
-
-    result
+  # Whether writing these outputs would change anything. A run with
+  # nothing to say about a submission leaves its blobs, and its history,
+  # alone — a new date is a change like any other, and reaches here as
+  # one, because the outputs were built with it already applied.
+  def changed?(submission, updates)
+    attachment_changed?(submission.ddbj_record, updates[:ddbj_record]) ||
+      attachment_changed?(submission.flatfile_na, updates[:flatfile_na]) ||
+      attachment_changed?(submission.flatfile_aa, updates[:flatfile_aa])
   end
 
   # Retracting an entry changes the flatfile, so this is also what makes
   # `changed?` notice and regenerate rather than skip.
   def retracted_entry_ids(rows) = rows.select(&:retracted?).map(&:entry_id).to_set
 
-  def build_entries(record, rows)
+  # `redated` is the entry ids taking `date`; the rest keep the date they
+  # have. Both go into the same file, so one submission's entries can
+  # disagree about their LOCUS date — which is what naming accessions is
+  # for.
+  def build_entries(record, rows, date:, redated:)
     rows_by_entry_id = rows.index_by(&:entry_id)
 
     record.sequences.entries.map {|entry|
@@ -144,7 +166,7 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
         accession:    acc.accession,
         locus:        acc.accession,
         version:      acc.version,
-        last_updated: acc.locus_date.to_s
+        last_updated: (redated.include?(entry.id) ? date : acc.locus_date).to_s
       )
     }
   end

--- a/app/jobs/regenerate_submission_flatfiles_job.rb
+++ b/app/jobs/regenerate_submission_flatfiles_job.rb
@@ -28,9 +28,17 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
     # handing the submission over — a second run in the same process
     # otherwise reads the statuses and dates left by the first.
     rows    = submission.entries.reload.to_a
-    redated = date ? rows.select { accessions.nil? || accessions.include?(it.accession) } : []
+    named   = accessions&.to_set
+    redated = date ? rows.select { named.nil? || named.include?(it.accession) } : []
 
-    entries             = build_entries(record, rows, date:, redated: redated.map(&:entry_id).to_set)
+    # Dated in memory first, so there is one account of what this run
+    # means to write: the file is rendered from these rows and the UPDATE
+    # below is made from the same ones. Entries left out keep the date
+    # they have, so one file can carry two — which is what naming
+    # accessions is for.
+    redated.each { it.locus_date = date }
+
+    entries             = build_entries(record, rows)
     record_with_entries = record.with(sequences: record.sequences.with(entries:))
 
     regenerated = false
@@ -46,13 +54,25 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
       # the runs this tool exists for, is all of them.
       next unless changed?(submission, updates)
 
-      # The dates and the files that print them, together. Written apart,
-      # a job that died between them left a flatfile saying one date and
-      # the row behind it saying another — and the next run would read
-      # the file as already correct, generate the same bytes, and skip,
-      # so the two would never be brought back together.
+      # The dates, the attachments that print them, and the history, in
+      # one commit. Written apart, a job that died between them left a
+      # flatfile saying one date and the row behind it saying another —
+      # and the next run would read the file as already correct, generate
+      # the same bytes, and skip, so the two would never be brought back
+      # together.
+      #
+      # The bytes are not in it: Active Storage defers the upload to
+      # after_commit, so a storage failure still leaves rows pointing at
+      # blobs that were never written — and the checksum on the row makes
+      # the next run skip them. Submission#prime_cache! is the shape that
+      # closes that (upload first, swap the pointer under the lock);
+      # ApplySubmissionRequestJob writes its outputs the same way this
+      # does, so it belongs in SubmissionOutputWriter rather than here.
       ActiveRecord::Base.transaction do
-        Entry.where(id: redated.map(&:id)).update_all(locus_date: date) if redated.any?
+        # By id when the run named accessions, and by submission when it
+        # did not — the whole-submission case would otherwise send every
+        # entry id back as an IN list.
+        (accessions ? Entry.where(id: redated.map(&:id)) : submission.entries).update_all(locus_date: date) if date
 
         submission.update! updates
 
@@ -152,11 +172,7 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
   # `changed?` notice and regenerate rather than skip.
   def retracted_entry_ids(rows) = rows.select(&:retracted?).map(&:entry_id).to_set
 
-  # `redated` is the entry ids taking `date`; the rest keep the date they
-  # have. Both go into the same file, so one submission's entries can
-  # disagree about their LOCUS date — which is what naming accessions is
-  # for.
-  def build_entries(record, rows, date:, redated:)
+  def build_entries(record, rows)
     rows_by_entry_id = rows.index_by(&:entry_id)
 
     record.sequences.entries.map {|entry|
@@ -166,7 +182,7 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
         accession:    acc.accession,
         locus:        acc.accession,
         version:      acc.version,
-        last_updated: (redated.include?(entry.id) ? date : acc.locus_date).to_s
+        last_updated: acc.locus_date.to_s
       )
     }
   end

--- a/app/models/regenerate_flatfiles_run.rb
+++ b/app/models/regenerate_flatfiles_run.rb
@@ -11,12 +11,15 @@ class RegenerateFlatfilesRun < ApplicationRecord
   # last time" — it cannot be re-derived from a list of numbers.
   TARGETS = %w[accessions all retry].freeze
 
-  # `force` is history, not an option. Runs made before dates were
-  # written by accession could be told to rewrite files whose content had
-  # not changed, because the date was applied only to what the comparison
-  # had already called changed — so setting a date without it did
-  # nothing. Nothing reads the column now; it stays so those rows still
-  # say what they did.
+  # `force` is a retired option: runs made before dates were written by
+  # accession could be told to rewrite files whose content had not
+  # changed, because a date was applied only to what the comparison had
+  # already called changed — so setting one without it did nothing.
+  #
+  # Nothing reads the column, and nothing ever set it but that option, so
+  # it is only the `true` rows that still say anything. It is kept for
+  # them; the column is a candidate for dropping once they stop being
+  # interesting.
 
   # How long a run may report nothing before it stops being believed.
   #

--- a/app/models/regenerate_flatfiles_run.rb
+++ b/app/models/regenerate_flatfiles_run.rb
@@ -11,6 +11,13 @@ class RegenerateFlatfilesRun < ApplicationRecord
   # last time" — it cannot be re-derived from a list of numbers.
   TARGETS = %w[accessions all retry].freeze
 
+  # `force` is history, not an option. Runs made before dates were
+  # written by accession could be told to rewrite files whose content had
+  # not changed, because the date was applied only to what the comparison
+  # had already called changed — so setting a date without it did
+  # nothing. Nothing reads the column now; it stays so those rows still
+  # say what they did.
+
   # How long a run may report nothing before it stops being believed.
   #
   # It is deliberately not read as "the workers are gone": a run queued

--- a/app/services/regeneration_scope.rb
+++ b/app/services/regeneration_scope.rb
@@ -62,25 +62,31 @@ class RegenerationScope
 
   def total = @total ||= submissions.count
 
-  # The numbers whose LOCUS date the run may rewrite, or nil for "every
-  # entry of every submission covered".
+  # Whether the run has an opinion about which entries take the date.
   #
   # A flatfile belongs to a submission, so any of these runs rewrites
-  # whole files; the date belongs to the entry, and only the run that
-  # named entries has an opinion about which ones. A retry of an
-  # every-submission run has no numbers and lands on nil, which is what
-  # that run did.
-  def named_accessions = all_target? ? nil : numbers.presence
+  # whole files; the date belongs to the entry, and only a run that named
+  # entries knows which ones are meant. A retry of an every-submission
+  # run has no numbers to carry, and dating every entry is what that run
+  # did.
+  def naming_accessions? = !all_target? && numbers.any?
 
   # Which of the named numbers this submission holds — the argument that
-  # tells its job whose dates to move.
-  def accessions_for(submission) = named_accessions && numbers_by_submission[submission.id]
+  # tells its job whose dates to move. Nil is every entry, and only the
+  # scope that named nothing may say it: a submission that holds none of
+  # the named numbers takes an empty list, not a licence to date the lot.
+  # The two cannot diverge on the accessions target, where the
+  # submissions come from these very numbers, but a retry's submissions
+  # come from what failed and nothing keeps the two in step.
+  def accessions_for(submission)
+    numbers_by_submission.fetch(submission.id, []) if naming_accessions?
+  end
 
   # Whose dates move, in the words of the choice that decided it.
   def dated_label
-    named = named_accessions
+    return 'every entry' unless naming_accessions?
 
-    named ? "the #{named.size} #{'accession'.pluralize(named.size)} named" : 'every entry'
+    "the #{numbers.size} #{'accession'.pluralize(numbers.size)} named"
   end
 
   def setting_date? = date_mode == 'set'
@@ -107,7 +113,7 @@ class RegenerationScope
     end
   end
 
-  def unmatched = numbers - matched_numbers - out_of_scope
+  def unmatched = @unmatched ||= numbers - matched_numbers - out_of_scope
 
   # Everything standing between this form and a run, in the order a
   # curator would fix it. The number-shaped ones are silent unless the
@@ -161,7 +167,7 @@ class RegenerationScope
       Entry.where(accession: numbers, submission: self.class.regeneratable)
            .pluck(:submission_id, :accession)
            .group_by(&:first)
-           .transform_values {|rows| rows.map(&:last) }
+           .transform_values { it.map(&:last) }
   end
 
   def matched_numbers = @matched_numbers ||= numbers_by_submission.values.flatten

--- a/app/services/regeneration_scope.rb
+++ b/app/services/regeneration_scope.rb
@@ -10,7 +10,7 @@
 class RegenerationScope
   DATE_MODES = %w[keep set].freeze
 
-  attr_reader :numbers_text, :date_mode, :date_input, :force, :retry_of
+  attr_reader :numbers_text, :date_mode, :date_input, :retry_of
 
   # Flatfiles are rendered from v1/v2 DDBJ Records, and every BioProject
   # and BioSample record in this system is v3 —
@@ -27,8 +27,12 @@ class RegenerationScope
   # it, rather than silently.
   def self.regeneratable = Submission.st26_db.where.associated(:ddbj_record_attachment)
 
+  # The numbers come along too, so a retry dates what the run it is
+  # retrying dated. Without them a retry of a run named by accession
+  # would fall back to "every entry", and quietly move dates the original
+  # had deliberately left alone.
   def self.retrying(run)
-    new({date_mode: run.locus_date ? 'set' : 'keep', date: run.locus_date&.to_s, force: run.force}, retry_of: run)
+    new({date_mode: run.locus_date ? 'set' : 'keep', date: run.locus_date&.to_s, numbers: run.numbers}, retry_of: run)
   end
 
   def initialize(params = {}, retry_of: nil)
@@ -37,14 +41,11 @@ class RegenerationScope
     @numbers_text = params[:numbers].to_s
     @date_mode    = params[:date_mode].to_s.presence_in(DATE_MODES) || 'keep'
     @date_input   = params[:date].to_s
-    @force        = ActiveModel::Type::Boolean.new.cast(params[:force]) || false
   end
 
   def target = retry_of ? 'retry' : @target
 
   def all_target? = target == 'all'
-
-  def retry_target? = target == 'retry'
 
   def accessions_target? = target == 'accessions'
 
@@ -60,6 +61,27 @@ class RegenerationScope
   end
 
   def total = @total ||= submissions.count
+
+  # The numbers whose LOCUS date the run may rewrite, or nil for "every
+  # entry of every submission covered".
+  #
+  # A flatfile belongs to a submission, so any of these runs rewrites
+  # whole files; the date belongs to the entry, and only the run that
+  # named entries has an opinion about which ones. A retry of an
+  # every-submission run has no numbers and lands on nil, which is what
+  # that run did.
+  def named_accessions = all_target? ? nil : numbers.presence
+
+  # Which of the named numbers this submission holds — the argument that
+  # tells its job whose dates to move.
+  def accessions_for(submission) = named_accessions && numbers_by_submission[submission.id]
+
+  # Whose dates move, in the words of the choice that decided it.
+  def dated_label
+    named = named_accessions
+
+    named ? "the #{named.size} #{'accession'.pluralize(named.size)} named" : 'every entry'
+  end
 
   def setting_date? = date_mode == 'set'
 
@@ -116,7 +138,7 @@ class RegenerationScope
   # is a bulk paste of thousands of numbers, and the confirmation is
   # reached by a GET.
   def to_params
-    {target: @target, date_mode:, date: date_input, force: force ? '1' : '0'}.tap {|params|
+    {target: @target, date_mode:, date: date_input}.tap {|params|
       params[:numbers] = numbers_text if accessions_target?
     }
   end
@@ -131,7 +153,16 @@ class RegenerationScope
     ]
   end
 
-  def matched_numbers
-    @matched_numbers ||= Entry.where(accession: numbers, submission: self.class.regeneratable).pluck(:accession)
+  # Which of the named numbers each submission holds. One query for the
+  # whole run, rather than one per job enqueued — a bulk paste is
+  # thousands of numbers, and they arrive as one list.
+  def numbers_by_submission
+    @numbers_by_submission ||=
+      Entry.where(accession: numbers, submission: self.class.regeneratable)
+           .pluck(:submission_id, :accession)
+           .group_by(&:first)
+           .transform_values {|rows| rows.map(&:last) }
   end
+
+  def matched_numbers = @matched_numbers ||= numbers_by_submission.values.flatten
 end

--- a/app/views/admin/regenerate_flatfiles/_summary.html.erb
+++ b/app/views/admin/regenerate_flatfiles/_summary.html.erb
@@ -25,10 +25,15 @@
         <dd class="mb-0"><%= scope.locus_date ? "set to #{scope.locus_date}" : 'unchanged' %></dd>
       </div>
 
-      <div class="d-flex justify-content-between border-top py-1">
-        <dt class="fw-normal text-body-secondary">Identical flatfiles</dt>
-        <dd class="mb-0"><%= scope.force ? 'rewritten' : 'skipped' %></dd>
-      </div>
+      <%# Only when there is a date to place. The file is rewritten %>
+      <%# whole whatever this says — it is the date that lands on some %>
+      <%# entries and not others. %>
+      <% if scope.locus_date %>
+        <div class="d-flex justify-content-between border-top py-1">
+          <dt class="fw-normal text-body-secondary">Written to</dt>
+          <dd class="mb-0"><%= scope.dated_label %></dd>
+        </div>
+      <% end %>
 
       <%# Asked before every heavy action, and answered the same way %>
       <%# each time — a curator should never have to remember which %>

--- a/app/views/admin/regenerate_flatfiles/show.html.erb
+++ b/app/views/admin/regenerate_flatfiles/show.html.erb
@@ -30,8 +30,7 @@
                                                                'aria-label': 'Accession numbers' %>
               <div class="form-text">
                 One per line or comma-separated. The submission that owns each accession is regenerated in
-                full — a flatfile holds all of its entries — but a new LOCUS date goes only to the numbers
-                listed here.
+                full — a flatfile holds all of its entries.
               </div>
             </div>
           </div>
@@ -76,7 +75,8 @@
 
           <div class="form-text">
             Overwrites <code>entries.locus_date</code> on the accessions listed above, or on every entry when
-            the run covers every submission. Entries of the same submission may end up with different dates.
+            the run covers every submission — so entries of the same submission may end up with different
+            dates. The file is rewritten whole either way.
           </div>
         </fieldset>
       </div>

--- a/app/views/admin/regenerate_flatfiles/show.html.erb
+++ b/app/views/admin/regenerate_flatfiles/show.html.erb
@@ -29,7 +29,9 @@
               <%= text_area_tag :numbers, @scope.numbers_text, rows: 4, class: 'form-control font-monospace',
                                                                'aria-label': 'Accession numbers' %>
               <div class="form-text">
-                One per line or comma-separated. The submission that owns each accession is regenerated in full.
+                One per line or comma-separated. The submission that owns each accession is regenerated in
+                full — a flatfile holds all of its entries — but a new LOCUS date goes only to the numbers
+                listed here.
               </div>
             </div>
           </div>
@@ -49,50 +51,34 @@
           </div>
         </fieldset>
 
-        <div class="row g-4">
-          <div class="col-md-6">
-            <fieldset>
-              <legend class="form-label fs-6 fw-semibold">LOCUS date</legend>
+        <%# The only other question there is. Whether an unchanged file %>
+        <%# is rewritten used to be a third one, and it was really this %>
+        <%# one asked badly: it decided whether a date was applied at %>
+        <%# all, so setting a date and leaving it off did nothing. %>
+        <fieldset>
+          <legend class="form-label fs-6 fw-semibold">LOCUS date</legend>
 
-              <div class="form-check">
-                <%= radio_button_tag :date_mode, 'keep', !@scope.setting_date?, class: 'form-check-input' %>
-                <%= label_tag :date_mode_keep, 'Keep existing dates', class: 'form-check-label' %>
-              </div>
-
-              <div class="form-check">
-                <%= radio_button_tag :date_mode, 'set', @scope.setting_date?, class: 'form-check-input',
-                                                                              data: {scope_preview_target: 'setDate'} %>
-                <%= label_tag :date_mode_set, 'Set every regenerated flatfile to', class: 'form-check-label' %>
-
-                <%# Filling this in is choosing to set a date; leaving %>
-                <%# the radio behind would discard it without saying so. %>
-                <%= date_field_tag :date, @scope.date_input, class: 'form-control mt-2', 'aria-label': 'LOCUS date',
-                                                             data: {action: 'input->scope-preview#dateEntered'} %>
-              </div>
-
-              <div class="form-text">
-                Setting a date overwrites <code>entries.locus_date</code> on every regenerated flatfile.
-              </div>
-            </fieldset>
+          <div class="form-check">
+            <%= radio_button_tag :date_mode, 'keep', !@scope.setting_date?, class: 'form-check-input' %>
+            <%= label_tag :date_mode_keep, 'Keep existing dates', class: 'form-check-label' %>
           </div>
 
-          <div class="col-md-6">
-            <fieldset>
-              <legend class="form-label fs-6 fw-semibold">Unchanged content</legend>
+          <div class="form-check">
+            <%= radio_button_tag :date_mode, 'set', @scope.setting_date?, class: 'form-check-input',
+                                                                          data: {scope_preview_target: 'setDate'} %>
+            <%= label_tag :date_mode_set, 'Set to', class: 'form-check-label' %>
 
-              <%# Named by what it does to the records, not by the flag: %>
-              <%# "Force regenerate" says how it is implemented. %>
-              <div class="form-check">
-                <%= check_box_tag :force, '1', @scope.force, class: 'form-check-input' %>
-                <%= label_tag :force, 'Rewrite even if identical', class: 'form-check-label' %>
-              </div>
-
-              <div class="form-text">
-                Off: submissions whose flatfile would not change are skipped.
-              </div>
-            </fieldset>
+            <%# Filling this in is choosing to set a date; leaving %>
+            <%# the radio behind would discard it without saying so. %>
+            <%= date_field_tag :date, @scope.date_input, class: 'form-control mt-2', 'aria-label': 'LOCUS date',
+                                                         data: {action: 'input->scope-preview#dateEntered'} %>
           </div>
-        </div>
+
+          <div class="form-text">
+            Overwrites <code>entries.locus_date</code> on the accessions listed above, or on every entry when
+            the run covers every submission. Entries of the same submission may end up with different dates.
+          </div>
+        </fieldset>
       </div>
     </div>
   </div>

--- a/lib/st26_source_locations.rb
+++ b/lib/st26_source_locations.rb
@@ -203,11 +203,13 @@ module St26SourceLocations
 
   # The LOCUS date, on the entries named and nowhere else.
   #
-  # Not through the Regenerate screen's date option: that resolves accessions to
-  # submissions and then does `submission.entries.update_all(locus_date:)`, so
-  # setting the date for PATENT-386's five entries there would have moved it on
-  # the 62 siblings sharing their four submissions. The renderer reads each
-  # entry's own column, so a per-entry date is all it takes.
+  # Here rather than through the Regenerate screen because this correction is
+  # one act: the locations and the date go into the same run, and the screen
+  # cannot rewrite a location. The screen used to be unable to date one entry
+  # without dating its submission's others too — the reason this was written —
+  # but it now writes a date to the accessions it is given and nothing else, so
+  # a date wanted on its own belongs there. It also regenerates the flatfiles,
+  # which `rewrite!` below does not; see the caveat on the task.
   #
   # Keyed on `accession`, the uniquely indexed column — `entries` has no unique
   # index on (submission_id, entry_id), so keying on that could redate two rows

--- a/lib/tasks/st26.rake
+++ b/lib/tasks/st26.rake
@@ -126,8 +126,13 @@ namespace :st26 do
       # A date is work of its own, so "nothing to correct" no longer ends the run
       # when one was given. The locations may well be right already — this task
       # shipped before the date option existed, so an earlier run having fixed
-      # them is the likely order of events — and there is no other route to a
-      # per-entry date.
+      # them is the likely order of events.
+      #
+      # A date and nothing else is better asked of the Regenerate screen, which
+      # also writes it to the accessions it is given and nothing else, and does
+      # regenerate the flatfiles. This route rewrites the DDBJ Record only, so
+      # the published flatfile goes on printing the old LOCUS date until
+      # something regenerates it.
       if correctable.empty? && locus_date.nil?
         puts 'Nothing to correct.'
         next

--- a/test/integration/admin/regenerate_flatfiles_test.rb
+++ b/test/integration/admin/regenerate_flatfiles_test.rb
@@ -44,7 +44,7 @@ class AdminRegenerateFlatfilesTest < ActionDispatch::IntegrationTest
   # date moves, and the entries beside them in the same submission keep
   # theirs.
   test 'create forwards the accessions each job is to date' do
-    accession = submissions(:st26).entries.first.accession
+    accession = named_accession
 
     post admin_regenerate_flatfiles_path, params: {target: 'accessions', numbers: accession,
                                                    date_mode: 'set', date: '2026-07-01'}
@@ -79,14 +79,8 @@ class AdminRegenerateFlatfilesTest < ActionDispatch::IntegrationTest
   end
 
   test 'a retry covers what failed, with the options that failed' do
-    accession = submissions(:st26).entries.first.accession
-
-    previous = RegenerateFlatfilesRun.create!(
-      actor: 'admin:someone', target: 'accessions', total: 1, numbers: accession,
-      locus_date: Date.new(2026, 7, 1), started_at: 1.hour.ago, finished_at: 1.hour.ago, failed: 1
-    )
-
-    previous.failures.create!(submission: submissions(:st26), label: 'X00001', message: 'boom')
+    accession = named_accession
+    previous  = failed_run(target: 'accessions', numbers: accession, locus_date: Date.new(2026, 7, 1))
 
     post admin_regenerate_flatfiles_path, params: {retry_of: previous.id, date_mode: 'keep', numbers: ''}
 
@@ -109,12 +103,7 @@ class AdminRegenerateFlatfilesTest < ActionDispatch::IntegrationTest
   # A retry of an every-submission run has no list, and dating every
   # entry is what that run did.
   test 'a retry of an every-submission run still dates every entry' do
-    previous = RegenerateFlatfilesRun.create!(
-      actor: 'admin:someone', target: 'all', total: 1,
-      locus_date: Date.new(2026, 7, 1), started_at: 1.hour.ago, finished_at: 1.hour.ago, failed: 1
-    )
-
-    previous.failures.create!(submission: submissions(:st26), label: 'X00001', message: 'boom')
+    previous = failed_run(target: 'all', locus_date: Date.new(2026, 7, 1))
 
     post admin_regenerate_flatfiles_path, params: {retry_of: previous.id}
 
@@ -179,6 +168,18 @@ class AdminRegenerateFlatfilesTest < ActionDispatch::IntegrationTest
   end
 
   private
+
+  def named_accession = submissions(:st26).entries.first.accession
+
+  # A finished run with one failure to retry, so each test shows only the
+  # axis it is about.
+  def failed_run(**attrs)
+    RegenerateFlatfilesRun.create!(
+      actor: 'admin:someone', total: 1, started_at: 1.hour.ago, finished_at: 1.hour.ago, failed: 1, **attrs
+    ).tap {
+      it.failures.create!(submission: submissions(:st26), label: 'X00001', message: 'boom')
+    }
+  end
 
   def enqueued_argument(key)
     job = ActiveJob::Base.queue_adapter.enqueued_jobs.find { it['job_class'] == 'RegenerateSubmissionFlatfilesJob' }

--- a/test/integration/admin/regenerate_flatfiles_test.rb
+++ b/test/integration/admin/regenerate_flatfiles_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 
 # What pressing Regenerate actually starts: one job per submission that
-# can produce a flatfile, carrying the date and the rewrite flag, and a
-# run row recording who asked for it and what they asked for. The screen
-# itself is test/system/tools_test.rb.
+# can produce a flatfile, carrying the date and the accessions it goes
+# to, and a run row recording who asked for it and what they asked for.
+# The screen itself is test/system/tools_test.rb.
 #
 # This is the most destructive action in the admin, and none of what it
 # enqueues is visible from the page it redirects back to.
@@ -33,15 +33,25 @@ class AdminRegenerateFlatfilesTest < ActionDispatch::IntegrationTest
     assert_equal Date.new(2026, 7, 1),  run.locus_date
 
     assert_equal Date.new(2026, 7, 1).to_s, enqueued_argument('value')
-    assert_equal false,                     enqueued_argument('force')
+
+    # Every submission is covered, so every entry takes the date and
+    # there is no list to carry.
+    assert_nil enqueued_argument('accessions')
+    assert_nil RegenerateFlatfilesRun.sole.numbers
   end
 
-  test 'create forwards the rewrite flag' do
-    post admin_regenerate_flatfiles_path, params: {target: 'all', confirm: 'all', force: '1'}
+  # The list is the job's, not just the scope's: it decides whose LOCUS
+  # date moves, and the entries beside them in the same submission keep
+  # theirs.
+  test 'create forwards the accessions each job is to date' do
+    accession = submissions(:st26).entries.first.accession
+
+    post admin_regenerate_flatfiles_path, params: {target: 'accessions', numbers: accession,
+                                                   date_mode: 'set', date: '2026-07-01'}
 
     assert_redirected_to admin_regenerate_flatfiles_path
-    assert_equal true, enqueued_argument('force')
-    assert RegenerateFlatfilesRun.sole.force
+    assert_equal [accession], enqueued_argument('accessions')
+    assert_equal accession,   RegenerateFlatfilesRun.sole.numbers
   end
 
   # The dialog disables a button; a disabled button is a courtesy. The
@@ -69,14 +79,16 @@ class AdminRegenerateFlatfilesTest < ActionDispatch::IntegrationTest
   end
 
   test 'a retry covers what failed, with the options that failed' do
+    accession = submissions(:st26).entries.first.accession
+
     previous = RegenerateFlatfilesRun.create!(
-      actor: 'admin:someone', target: 'all', total: 1, force: true,
+      actor: 'admin:someone', target: 'accessions', total: 1, numbers: accession,
       locus_date: Date.new(2026, 7, 1), started_at: 1.hour.ago, finished_at: 1.hour.ago, failed: 1
     )
 
     previous.failures.create!(submission: submissions(:st26), label: 'X00001', message: 'boom')
 
-    post admin_regenerate_flatfiles_path, params: {retry_of: previous.id, force: '0'}
+    post admin_regenerate_flatfiles_path, params: {retry_of: previous.id, date_mode: 'keep', numbers: ''}
 
     run = RegenerateFlatfilesRun.recent.first
 
@@ -84,11 +96,30 @@ class AdminRegenerateFlatfilesTest < ActionDispatch::IntegrationTest
     assert_equal previous, run.retry_of
     assert_equal 1,        run.total
 
-    # The form said force off; the run it is retrying said on. What
-    # failed is re-run as it was, not as the page happened to look.
-    assert_equal true,                      run.force
-    assert_equal true,                      enqueued_argument('force')
+    # The form had been cleared; the run it is retrying named a date and
+    # an accession. What failed is re-run as it was, not as the page
+    # happened to look — a retry that dated every entry of the submission
+    # would move dates the original deliberately left alone.
+    assert_equal Date.new(2026, 7, 1),      run.locus_date
+    assert_equal accession,                 run.numbers
     assert_equal Date.new(2026, 7, 1).to_s, enqueued_argument('value')
+    assert_equal [accession],               enqueued_argument('accessions')
+  end
+
+  # A retry of an every-submission run has no list, and dating every
+  # entry is what that run did.
+  test 'a retry of an every-submission run still dates every entry' do
+    previous = RegenerateFlatfilesRun.create!(
+      actor: 'admin:someone', target: 'all', total: 1,
+      locus_date: Date.new(2026, 7, 1), started_at: 1.hour.ago, finished_at: 1.hour.ago, failed: 1
+    )
+
+    previous.failures.create!(submission: submissions(:st26), label: 'X00001', message: 'boom')
+
+    post admin_regenerate_flatfiles_path, params: {retry_of: previous.id}
+
+    assert_nil enqueued_argument('accessions')
+    assert_nil RegenerateFlatfilesRun.recent.first.numbers
   end
 
   # Two runs over one submission would have two workers rewriting one

--- a/test/jobs/regenerate_submission_flatfiles_job_test.rb
+++ b/test/jobs/regenerate_submission_flatfiles_job_test.rb
@@ -116,31 +116,23 @@ class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
     assert_equal 0, run.regenerated
   end
 
-  test 'regenerates flatfiles with new locus date when content changed' do
+  # The comparison is against what is attached, so a file that is not
+  # there is a difference like any other — and the one the tool is
+  # reached for when a flatfile has gone missing rather than stale.
+  test 'a missing flatfile is a change' do
     @submission.flatfile_na.purge
     @submission.flatfile_aa.purge if @submission.flatfile_aa.attached?
 
     run = new_run
 
-    RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, run, Date.new(2026, 7, 1)
+    RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, run, nil
 
-    @submission.reload
-
-    assert @submission.flatfile_na.attached?
-    assert_match /01-JUL-2026/, @submission.flatfile_na.download
-
-    @submission.entries.each do |acc|
-      assert_equal Date.new(2026, 7, 1), acc.locus_date
-    end
+    assert_equal 1, run.reload.regenerated
+    assert @submission.reload.flatfile_na.attached?
   end
 
-  test 'records accession history when content changed' do
-    @submission.flatfile_na.purge
-    @submission.flatfile_aa.purge if @submission.flatfile_aa.attached?
-
-    run = new_run
-
-    RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, run, Date.new(2026, 7, 1)
+  test 'the history names the user who asked for the run' do
+    RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, new_run, Date.new(2026, 7, 1)
 
     histories = EntryHistory.where(entry: @submission.entries, action: 'regenerate')
 

--- a/test/jobs/regenerate_submission_flatfiles_job_test.rb
+++ b/test/jobs/regenerate_submission_flatfiles_job_test.rb
@@ -30,7 +30,7 @@ class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
     # AND re-raises: the queue still records a failed job, and the run
     # still reaches a result instead of hanging at loading?.
     assert_raises DDBJRecord::V3NotImplementedError do
-      RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, run, Date.new(2026, 7, 1), force: true
+      RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, run, Date.new(2026, 7, 1)
     end
 
     run.reload
@@ -48,16 +48,45 @@ class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
     assert_match(/not yet implemented for v3/,        failure.message)
   end
 
-  test 'force: true regenerates even when flatfiles would be identical' do
+  # A date is a change like any other. It used to be applied only to
+  # submissions the comparison had already called changed — which the
+  # date itself could not make them — so asking for one and nothing else
+  # rewrote nothing.
+  test 'a new date is a change, and reaches the file that had no other' do
     run = new_run
 
     assert_difference 'EntryHistory.where(action: "regenerate").count', @submission.entries.count do
-      RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, run, Date.new(2026, 7, 1), force: true
+      RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, run, Date.new(2026, 7, 1)
     end
+
+    assert_equal 1, run.reload.regenerated
 
     @submission.entries.each do |acc|
       assert_equal Date.new(2026, 7, 1), acc.reload.locus_date
     end
+
+    assert_match /01-JUL-2026/, @submission.reload.flatfile_na.download
+  end
+
+  # Naming accessions is naming whose dates move. The rest of the
+  # submission is in the same file and is rewritten with it, but keeps
+  # the date it had — so one file can carry two.
+  test 'only the named accessions take the new date' do
+    named, untouched = @submission.entries.order(:id).first(2)
+    before           = untouched.locus_date
+
+    RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, new_run, Date.new(2026, 7, 1),
+                                                accessions: [named.accession]
+
+    assert_equal Date.new(2026, 7, 1), named.reload.locus_date
+    assert_equal before,               untouched.reload.locus_date
+
+    # Both entries are still in the file the run rewrote — the list
+    # chooses dates, not what gets written.
+    flatfile = @submission.reload.flatfile_na.download
+
+    assert_includes flatfile, named.accession
+    assert_includes flatfile, untouched.accession
   end
 
   test 'does nothing when flatfiles would be identical' do
@@ -66,8 +95,9 @@ class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
 
     run = new_run
 
+    # The date they already have: asked for, and still nothing to do.
     assert_no_difference 'EntryHistory.count' do
-      RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, run, Date.new(2099, 1, 1)
+      RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, run, @submission.entries.first.locus_date
     end
 
     @submission.reload
@@ -79,7 +109,7 @@ class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
     end
 
     # Skipped, not regenerated. The distinction is the whole reading of a
-    # run made with the rewrite option off.
+    # run that found nothing to do.
     run.reload
 
     assert_equal 1, run.skipped
@@ -149,7 +179,7 @@ class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
   test 'counts what it did, and closes the run when the last job lands' do
     run = new_run
 
-    RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, run, Date.new(2026, 7, 1), force: true
+    RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, run, Date.new(2026, 7, 1)
 
     run.reload
 

--- a/test/system/tools_test.rb
+++ b/test/system/tools_test.rb
@@ -273,10 +273,27 @@ class RegenerateFlatfilesSystemTest < ApplicationSystemTestCase
       assert_text '1 submission'
       assert_text 'every ST.26 submission with a stored record'
       assert_text 'LOCUS dates unchanged'
-      assert_text 'Identical flatfiles skipped'
       assert_text 'Submitters notified no'
 
       assert_link 'Regenerate 1 submission…'
+    end
+  end
+
+  # Whose dates a date moves is the difference between the two scopes,
+  # and it is not readable from the count — both say "1 submission".
+  test 'the summary says whose LOCUS dates a date would move' do
+    visit admin_regenerate_flatfiles_path(target: 'all', date_mode: 'set', date: '2026-07-01')
+
+    within '[data-test-scope-summary]' do
+      assert_text 'LOCUS dates set to 2026-07-01'
+      assert_text 'Written to every entry'
+    end
+
+    visit admin_regenerate_flatfiles_path(numbers: submissions(:st26).entries.first.accession,
+                                          date_mode: 'set', date: '2026-07-01')
+
+    within '[data-test-scope-summary]' do
+      assert_text 'Written to the 1 accession named'
     end
   end
 


### PR DESCRIPTION
再生成は書き出しルールが変わったときにファイルを作り直すためのもので、選ぶべきことは「ルールだけか、LOCUS date も揃えるか」の一つでした。そこに **"Rewrite even if identical" という三つめの問い**が混ざっていました。

これは実装の都合が表に出たもので、しかも二つが噛み合っていませんでした。`changed?` が更新前の `locus_date` で組み立てた出力と比較していたため、**これから入れる日付は比較に入りません**。結果、日付を指定して force を外すと日付が黙って捨てられていました — 「ルールは変わらないが日付だけ揃えたい」という用途そのものが動きませんでした。

curator は対象の accession をあらかじめリストアップするので、システムに変更検知させる必要はありません。**日付は指定された accession にだけ書き、force は落とします。**

## 変更点

- **日付を適用した状態で出力を組み立ててから比較する。** 日付は他の変更と同じ扱いになり、skip は選択肢ではなく結論になる
- **accession 指定時は指定された entry だけ日付が動く。** 同じ submission の他の entry は日付を保つので、1 ファイル内で日付が混在しうる。ファイルは submission 単位なので書き直し自体は全体に及ぶ
- **日付の書き込みを添付・履歴と同一トランザクションへ移す。** 以前は生成の前にあり、途中で落ちると DB の日付だけ進んだ。しかも次回の再生成はファイルを正しいと読んで skip するので、ずれが戻らなかった
- **生成を 1 回に。** `changed?` がフル生成して捨て、`perform` で作り直していたため、実際に変わるレコードは毎回 2 回レンダリングしていた
- **retry は元のランの numbers を引き継ぐ。** 引き継がないと accession 指定の retry が全 entry の日付を動かす
- `EntryHistory` は従来どおり submission の全 entry に記録する。action はファイルの書き直しを表すため

`runs.force` は過去のランの記録として残置 (読み手はもういない)。未使用だった `RegenerationScope#retry_target?` を削除。

## review 指摘への対応 (2 commit 目)

- **`accessions_for` が「名指しなし」と「この submission は 1 件も持たない」をどちらも nil で返していた。** job は nil を「全 entry」と読むので、後者が最も広い書き換えに化ける。retry は submissions が failures 由来・numbers が元ランの控え由来で両者が独立に決まるため、実際にずれうる。`naming_accessions?` を立て、取りこぼしは `fetch(id, [])` で空配列にする
- 日付は rows に先に載せ、`build_entries` は `locus_date` をそのまま読む。`date:`/`redated:` の 2 引数と Set/id 配列の派生を持ち回らなくて済む
- 全 entry を対象にするときは id の IN リストではなく `submission.entries` を引く
- **トランザクションのコメントが嘘だった。** Active Storage は upload を `after_commit` に回すので、バイト列はコミットに含まれない。保証している範囲と、残っているギャップ (`prime_cache!` の形、`ApplySubmissionRequestJob` にも同じ穴がある) を書く
- 控えに残す numbers はパース済みのリストに。ラン側 `number_list` は uniq しないので、貼り付けたまま持つと画面と件数が食い違う
- 判断の規則が controller と scope に二重にあったのを scope へ寄せる
- `unmatched` をメモ化 (`numbers_problems` が 4 回呼ぶ)、enqueue は id だけ引く、`accessions` は Set にしてから select する
- 日付が撃ち込まれる経路のテストが 3 つ重複していたので整理し、retry の下ごしらえをヘルパへ

## 検証

`bin/rails test:all` — 1154 runs, 0 failures / `bin/rubocop` — 501 files clean

## 後続

この上に `fix/locus-date-single-source` (LOCUS date の出所を 1 つにする + バックフィル) が乗っています。あちらは `entries.locus_date` と record と FF の 3 者を一致させ、食い違ったまま再生成しようとする run を拒否するガードを入れるもので、このブランチの `redated` をそのまま使っています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)