### PR TITLE
LOCUS date の出所を 1 つにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,38 @@ For small files, the same code path works — `sc_parse` handles both minified a
 - `Flatfile::StreamingRenderer` — entry-by-entry renderer for large files, reuses the same ERB template
 - `Flatfile::TaxIdCache` — lazy-loading taxonomy cache for streaming
 
+#### The LOCUS date
+
+One date, three places that must agree, and one person who owns it.
+
+**`locus_date` is the date printed on the LOCUS line.** It is chosen by whoever
+performs the publication — for ST.26 that is DDBJ's own operator running
+`submission-bulk-st26 --date`, not the submitter and not this server, which is
+why neither the JPO XML nor an apply-time clock can supply it.
+
+It lives in three places, and they hold the same value by construction:
+
+| Place | Role |
+|---|---|
+| the record's `sequences.entries[].locus_date` | how it arrives, and what the archived record states |
+| `entries.locus_date` | the queryable copy — API, admin, and per-entry edits |
+| the flatfile's LOCUS line | rendered from the record field the renderer is handed |
+
+`ApplySubmissionRequestJob` takes the date from the record and writes both,
+falling back to the apply date only when the record names none.
+`RegenerateSubmissionFlatfilesJob` renders from the column, so a per-entry date
+change is made by writing the column and regenerating.
+
+This was three different dates until 2026-08: the column held the apply date,
+the record field was called `last_updated` and held the operator's date, and the
+flatfile printed the record's. Regeneration renders from the column, so any
+regeneration silently pulled published LOCUS dates back to the apply date —
+which is what happened to 62 entries while fixing PATENT-386. Records written
+before the rename still say `last_updated`, and `Builders` reads both keys.
+
+The Regenerate screen's date option writes the column for **every entry of the
+submission**, so it is the wrong tool for redating some of them.
+
 ### Submission Pipeline (`ApplySubmissionRequestJob`)
 
 Two-pass streaming:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,10 +126,14 @@ It lives in three places, and they hold the same value by construction:
 
 `ApplySubmissionRequestJob` takes the date from the record and writes both,
 falling back to the apply date only when the record names none.
-`RegenerateSubmissionFlatfilesJob` renders from the column, so redating an entry
-means writing the column and regenerating. There is no screen for that yet: the
-Regenerate form's date option writes **every entry of the submission**
-(`update_all`), so it is the wrong tool for redating some of them.
+`RegenerateSubmissionFlatfilesJob` renders from the column and writes the date to
+the entries the run names — so redating some entries of a submission is what the
+Regenerate screen's accession list is for. The file is the submission's, so the
+whole of it is rewritten either way; the list decides only whose date moves.
+
+A run that names no date renders every entry from the column and **refuses** if
+the column and the record disagree, rather than publishing the column's value.
+That is the guard the 62-entry incident cost.
 
 This was three different dates until 2026-08: the column held the apply date,
 the record field was called `last_updated` and held the operator's date, and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,10 @@ Two consequences of that history, both one-off:
 - Submissions applied before the change still have the apply date in the column.
   `rake locus_date:backfill` reads each request's record — the upload, which no
   regeneration rewrites — and puts the column back. **It has to have been run
-  before any bulk regeneration**, or that regeneration prints the apply date.
+  before any bulk regeneration**, and the guard above is what makes that
+  unskippable rather than remembered. It only touches entries that still carry
+  the apply stamp (`locus_date == created_at.to_date`), so a date somebody set on
+  purpose is left where it is.
 - The key rename makes a re-serialised legacy record differ from its stored
   blob, so `changed?` is true for every one of them. The first regeneration after
   this deploy therefore rewrites the record and reports nothing skipped; that is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,13 +121,15 @@ It lives in three places, and they hold the same value by construction:
 | Place | Role |
 |---|---|
 | the record's `sequences.entries[].locus_date` | how it arrives, and what the archived record states |
-| `entries.locus_date` | the queryable copy — API, admin, and per-entry edits |
+| `entries.locus_date` | the queryable copy — API, admin, and where a redate is written |
 | the flatfile's LOCUS line | rendered from the record field the renderer is handed |
 
 `ApplySubmissionRequestJob` takes the date from the record and writes both,
 falling back to the apply date only when the record names none.
-`RegenerateSubmissionFlatfilesJob` renders from the column, so a per-entry date
-change is made by writing the column and regenerating.
+`RegenerateSubmissionFlatfilesJob` renders from the column, so redating an entry
+means writing the column and regenerating. There is no screen for that yet: the
+Regenerate form's date option writes **every entry of the submission**
+(`update_all`), so it is the wrong tool for redating some of them.
 
 This was three different dates until 2026-08: the column held the apply date,
 the record field was called `last_updated` and held the operator's date, and the
@@ -136,8 +138,16 @@ regeneration silently pulled published LOCUS dates back to the apply date —
 which is what happened to 62 entries while fixing PATENT-386. Records written
 before the rename still say `last_updated`, and `Builders` reads both keys.
 
-The Regenerate screen's date option writes the column for **every entry of the
-submission**, so it is the wrong tool for redating some of them.
+Two consequences of that history, both one-off:
+
+- Submissions applied before the change still have the apply date in the column.
+  `rake locus_date:backfill` reads each request's record — the upload, which no
+  regeneration rewrites — and puts the column back. **It has to have been run
+  before any bulk regeneration**, or that regeneration prints the apply date.
+- The key rename makes a re-serialised legacy record differ from its stored
+  blob, so `changed?` is true for every one of them. The first regeneration after
+  this deploy therefore rewrites the record and reports nothing skipped; that is
+  the rename passing through, not a substantive change.
 
 ### Submission Pipeline (`ApplySubmissionRequestJob`)
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ added as failures are classified, so the set grows.
 | TRD_R0011 | validation | warning | ApplicationNumberText is not in the expected format of yyyy-nnnnnn |
 | TRD_R0012 | application | error | No accession numbers left in the scope; extend its prefix list in `config/sequence.yml`. Nothing was consumed — no accession was burned and no submission created — so once it is extended the file can be submitted afresh |
 | TRD_R0013 | validation | error | The uploaded record could not be parsed: malformed JSON, or a node whose container type is wrong for the schema (`"sequences": []` where an object belongs). The message is the parser's |
+| TRD_R0014 | application | error | The record's `locus_date` is not written as `YYYY-MM-DD`. Refused rather than guessed: `Date.parse` reads `8/13` as this year's 13 August, and the value is printed on the LOCUS line of a published flatfile. Nothing was consumed — no accession was allocated |
 | TRD_R9999 | both | error | Unexpected internal error |
 
 ## Tech Stack

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ erDiagram
         string accession UK "e.g. LC000001"
         string entry_id
         integer version "default: 1"
-        date locus_date
+        date locus_date "date printed on the LOCUS line"
         integer status "Lifecycleable, default: 5300"
         datetime created_at
         datetime updated_at

--- a/app/jobs/apply_submission_request_job.rb
+++ b/app/jobs/apply_submission_request_job.rb
@@ -16,13 +16,10 @@ class ApplySubmissionRequestJob < ApplicationJob
 
   UNEXPECTED_ERROR_CODE = 'TRD_R9999'
 
-  # `YYYY-MM-DD` and nothing else. `String#to_date` is `Date.parse`, which
-  # guesses: `8/13` becomes the 13th of August *of whichever year the job ran
-  # in*, `Aug 2026` becomes the 1st, `2026-225` an ordinal day. This date is
-  # printed on the LOCUS line of a published flatfile, so a guess is worse than
-  # a refusal — and refusing here costs nothing, because pass 1 runs before any
-  # accession is allocated.
-  LOCUS_DATE_FORMAT = /\A\d{4}-\d{2}-\d{2}\z/
+  # Refusing costs nothing here: pass 1 runs before any accession is allocated.
+  # The format itself is DDBJRecord::LOCUS_DATE_FORMAT, shared with the
+  # Regenerate form and the backfill so one rule covers every way a LOCUS date
+  # can be set.
 
   def perform(request)
     # 前回の失敗の痕跡を残さない。コードは機械的な判断に使われるので、古い値が
@@ -60,7 +57,7 @@ class ApplySubmissionRequestJob < ApplicationJob
 
     # `to_s`, so a JSON number (`"locus_date": 20260813`) is refused with this
     # code rather than raising NoMethodError into the TRD_R9999 catch-all.
-    raise MalformedLocusDate, %(#{entry.id}: locus_date "#{given}" is not written as YYYY-MM-DD) unless given.to_s.match?(LOCUS_DATE_FORMAT)
+    raise MalformedLocusDate, %(#{entry.id}: locus_date "#{given}" is not written as YYYY-MM-DD) unless given.to_s.match?(DDBJRecord::LOCUS_DATE_FORMAT)
 
     begin
       Date.iso8601(given)

--- a/app/jobs/apply_submission_request_job.rb
+++ b/app/jobs/apply_submission_request_job.rb
@@ -16,10 +16,6 @@ class ApplySubmissionRequestJob < ApplicationJob
 
   UNEXPECTED_ERROR_CODE = 'TRD_R9999'
 
-  # Refusing costs nothing here: pass 1 runs before any accession is allocated.
-  # The format itself is DDBJRecord::LOCUS_DATE_FORMAT, shared with the
-  # Regenerate form and the backfill so one rule covers every way a LOCUS date
-  # can be set.
 
   def perform(request)
     # 前回の失敗の痕跡を残さない。コードは機械的な判断に使われるので、古い値が
@@ -51,7 +47,12 @@ class ApplySubmissionRequestJob < ApplicationJob
   private
 
   # The date the publication operator put on this entry, or `fallback` when the
-  # record names none. Refused rather than guessed — see LOCUS_DATE_FORMAT.
+  # record names none.
+  #
+  # Refused rather than guessed, against DDBJRecord::LOCUS_DATE_FORMAT — the rule
+  # the Regenerate form and the backfill are held to as well, so one format
+  # covers every way a LOCUS date can be set. Refusing costs nothing here: pass 1
+  # runs before any accession is allocated.
   def locus_date_for(entry, fallback)
     given = entry.locus_date.presence or return fallback
 

--- a/app/jobs/apply_submission_request_job.rb
+++ b/app/jobs/apply_submission_request_job.rb
@@ -65,9 +65,26 @@ class ApplySubmissionRequestJob < ApplicationJob
       features_by_seq_id = parser.features_by_sequence_id
       all_features       = features_by_seq_id.values.flatten
 
-      # Pass 1: Collect entry IDs and types (sequences are discarded by GC)
+      now   = Time.current
+      today = now.to_date
+      ts    = now.utc.iso8601(6)
+
+      # Pass 1: Collect entry IDs, types and LOCUS dates (sequences are
+      # discarded by GC)
+      #
+      # `today` is only a stand-in for a record that names no date. It used to be
+      # written unconditionally into `entries.locus_date` while the flatfile
+      # printed the record's own date, so the column and the flatfile disagreed
+      # from the moment a submission was applied — and any later regeneration,
+      # which renders from the column, pulled the printed date back to the apply
+      # date. The date belongs to whoever performed the publication, so the
+      # record is where it comes from.
+      #
+      # Normalised to a Date once, so the column and the record cannot spell the
+      # same day two ways. An unparseable value raises here instead of further
+      # down in `format_date`, which is where it used to surface.
       entry_metas = parser.each_entry.map {|entry|
-        {id: entry.id, is_aa: aa?(entry)}
+        {id: entry.id, is_aa: aa?(entry), locus_date: entry.locus_date.presence&.to_date || today}
       }
 
       na_count = entry_metas.count { !it[:is_aa] }
@@ -81,10 +98,8 @@ class ApplySubmissionRequestJob < ApplicationJob
         ]
       }
 
-      now              = Time.current
-      today            = now.to_date
-      ts               = now.utc.iso8601(6)
       entry_accessions = {}
+      entry_dates      = {}
       conn             = ActiveRecord::Base.connection.raw_connection
 
       conn.copy_data('COPY entries (accession, entry_id, submission_id, version, locus_date, created_at, updated_at) FROM STDIN') do
@@ -92,8 +107,9 @@ class ApplySubmissionRequestJob < ApplicationJob
           number = (meta[:is_aa] ? aa_nums : na_nums).shift
 
           entry_accessions[meta[:id]] = number
+          entry_dates[meta[:id]]      = meta[:locus_date]
 
-          conn.put_copy_data "#{number}\t#{meta[:id]}\t#{submission.id}\t1\t#{today}\t#{ts}\t#{ts}\n"
+          conn.put_copy_data "#{number}\t#{meta[:id]}\t#{submission.id}\t1\t#{meta[:locus_date]}\t#{ts}\t#{ts}\n"
         end
       end
 
@@ -111,11 +127,14 @@ class ApplySubmissionRequestJob < ApplicationJob
       entries = parser.each_entry.lazy.map {|entry|
         accession = entry_accessions.fetch(entry.id)
 
+        # The same date that went into the column, not the record's own string:
+        # one value, normalised once, so the flatfile and `entries.locus_date`
+        # cannot come apart.
         entry.with(
           accession:,
-          locus:        accession,
-          version:      1,
-          last_updated: entry.last_updated || today.to_s
+          locus:      accession,
+          version:    1,
+          locus_date: entry_dates.fetch(entry.id).to_s
         )
       }
 

--- a/app/jobs/apply_submission_request_job.rb
+++ b/app/jobs/apply_submission_request_job.rb
@@ -58,7 +58,9 @@ class ApplySubmissionRequestJob < ApplicationJob
   def locus_date_for(entry, fallback)
     given = entry.locus_date.presence or return fallback
 
-    raise MalformedLocusDate, %(#{entry.id}: locus_date "#{given}" is not written as YYYY-MM-DD) unless given.match?(LOCUS_DATE_FORMAT)
+    # `to_s`, so a JSON number (`"locus_date": 20260813`) is refused with this
+    # code rather than raising NoMethodError into the TRD_R9999 catch-all.
+    raise MalformedLocusDate, %(#{entry.id}: locus_date "#{given}" is not written as YYYY-MM-DD) unless given.to_s.match?(LOCUS_DATE_FORMAT)
 
     begin
       Date.iso8601(given)

--- a/app/jobs/apply_submission_request_job.rb
+++ b/app/jobs/apply_submission_request_job.rb
@@ -7,11 +7,22 @@ class ApplySubmissionRequestJob < ApplicationJob
   #
   # error_message の方は人間向けで、文言は予告なく変わる。**機械的な判断はコードで
   # 行うこと。**
+  class MalformedLocusDate < StandardError; end
+
   ERROR_CODES = {
-    Sequence::Exhausted => 'TRD_R0012'
+    Sequence::Exhausted => 'TRD_R0012',
+    MalformedLocusDate  => 'TRD_R0014'
   }.freeze
 
   UNEXPECTED_ERROR_CODE = 'TRD_R9999'
+
+  # `YYYY-MM-DD` and nothing else. `String#to_date` is `Date.parse`, which
+  # guesses: `8/13` becomes the 13th of August *of whichever year the job ran
+  # in*, `Aug 2026` becomes the 1st, `2026-225` an ordinal day. This date is
+  # printed on the LOCUS line of a published flatfile, so a guess is worse than
+  # a refusal — and refusing here costs nothing, because pass 1 runs before any
+  # accession is allocated.
+  LOCUS_DATE_FORMAT = /\A\d{4}-\d{2}-\d{2}\z/
 
   def perform(request)
     # 前回の失敗の痕跡を残さない。コードは機械的な判断に使われるので、古い値が
@@ -41,6 +52,20 @@ class ApplySubmissionRequestJob < ApplicationJob
   end
 
   private
+
+  # The date the publication operator put on this entry, or `fallback` when the
+  # record names none. Refused rather than guessed — see LOCUS_DATE_FORMAT.
+  def locus_date_for(entry, fallback)
+    given = entry.locus_date.presence or return fallback
+
+    raise MalformedLocusDate, %(#{entry.id}: locus_date "#{given}" is not written as YYYY-MM-DD) unless given.match?(LOCUS_DATE_FORMAT)
+
+    begin
+      Date.iso8601(given)
+    rescue Date::Error
+      raise MalformedLocusDate, %(#{entry.id}: locus_date "#{given}" is not a real date)
+    end
+  end
 
   def error_code_for(error)
     _, code = ERROR_CODES.find {|klass, _| error.is_a?(klass) }
@@ -81,10 +106,9 @@ class ApplySubmissionRequestJob < ApplicationJob
       # record is where it comes from.
       #
       # Normalised to a Date once, so the column and the record cannot spell the
-      # same day two ways. An unparseable value raises here instead of further
-      # down in `format_date`, which is where it used to surface.
+      # same day two ways.
       entry_metas = parser.each_entry.map {|entry|
-        {id: entry.id, is_aa: aa?(entry), locus_date: entry.locus_date.presence&.to_date || today}
+        {id: entry.id, is_aa: aa?(entry), locus_date: locus_date_for(entry, today)}
       }
 
       na_count = entry_metas.count { !it[:is_aa] }

--- a/app/jobs/regenerate_submission_flatfiles_job.rb
+++ b/app/jobs/regenerate_submission_flatfiles_job.rb
@@ -179,14 +179,17 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
       acc = rows_by_entry_id.fetch(entry.id)
 
       entry.with(
-        accession:    acc.accession,
-        locus:        acc.accession,
-        version:      acc.version,
-        # From the column, which is the queryable copy of what the record
-        # already says — equal by construction since the apply job started
-        # taking the date from the record. Where they are not equal, the column
-        # wins: it is what a curator's per-entry edit and this run's own date
-        # option write to.
+        accession:  acc.accession,
+        locus:      acc.accession,
+        version:    acc.version,
+        # From the column: it is what this run's date option writes, and what a
+        # per-entry redate would write.
+        #
+        # For submissions applied before the apply job started taking the date
+        # from the record, the column holds the apply date while the record
+        # holds the operator's — so regenerating one of those moves its printed
+        # LOCUS date. `rake locus_date:backfill` settles that per entry, and has
+        # to have been run before any bulk regeneration.
         locus_date: acc.locus_date.to_s
       )
     }

--- a/app/jobs/regenerate_submission_flatfiles_job.rb
+++ b/app/jobs/regenerate_submission_flatfiles_job.rb
@@ -182,7 +182,12 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
         accession:    acc.accession,
         locus:        acc.accession,
         version:      acc.version,
-        last_updated: acc.locus_date.to_s
+        # From the column, which is the queryable copy of what the record
+        # already says — equal by construction since the apply job started
+        # taking the date from the record. Where they are not equal, the column
+        # wins: it is what a curator's per-entry edit and this run's own date
+        # option write to.
+        locus_date: acc.locus_date.to_s
       )
     }
   end

--- a/app/jobs/regenerate_submission_flatfiles_job.rb
+++ b/app/jobs/regenerate_submission_flatfiles_job.rb
@@ -5,6 +5,11 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
   # and what went wrong, in words a curator can act on. Re-raised so the
   # queue still records a failed job and Sentry still sees it — the run
   # screen is where the failure is read, not where it is reported.
+  # Not a bare RuntimeError: a pre-backfill run over the archive would otherwise
+  # produce thousands of failure rows indistinguishable from a bug, and this one
+  # means "not ready" rather than "broken".
+  class LocusDateDisagreement < StandardError; end
+
   rescue_from StandardError do |error|
     run, submission, label = failed_target
 
@@ -192,9 +197,12 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
       # run reports exactly which submissions are not ready and rewrites none of
       # them.
       unless dated.include?(acc) || entry.locus_date.blank? || entry.locus_date == acc.locus_date.to_s
-        raise "Submission ##{acc.submission_id}: #{entry.id} has LOCUS date #{entry.locus_date} in its record and " \
+        raise LocusDateDisagreement,
+              "Submission ##{acc.submission_id}: #{entry.id} has LOCUS date #{entry.locus_date} in its record and " \
               "#{acc.locus_date} in entries.locus_date. Regenerating would publish the latter. " \
-              'Run `rake locus_date:backfill` first, or name it in a run that sets a date.'
+              'If the column is the date you meant, name it in this run and it will be written to both. ' \
+              'If you have not touched it, the submission predates the apply job reading the date from the ' \
+              'record: run `rake locus_date:backfill` first.'
       end
 
       entry.with(

--- a/app/jobs/regenerate_submission_flatfiles_job.rb
+++ b/app/jobs/regenerate_submission_flatfiles_job.rb
@@ -38,7 +38,7 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
     # accessions is for.
     redated.each { it.locus_date = date }
 
-    entries             = build_entries(record, rows)
+    entries             = build_entries(record, rows, redated:)
     record_with_entries = record.with(sequences: record.sequences.with(entries:))
 
     regenerated = false
@@ -172,24 +172,35 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
   # `changed?` notice and regenerate rather than skip.
   def retracted_entry_ids(rows) = rows.select(&:retracted?).map(&:entry_id).to_set
 
-  def build_entries(record, rows)
+  def build_entries(record, rows, redated: [])
     rows_by_entry_id = rows.index_by(&:entry_id)
+    dated            = redated.to_set
 
     record.sequences.entries.map {|entry|
       acc = rows_by_entry_id.fetch(entry.id)
+
+      # An entry this run is dating takes the run's date; the rest are rendered
+      # from the column, and for those the column has to already agree with the
+      # record. It does not on any submission applied before the apply job
+      # started taking the date from the record: those hold the operator's date
+      # in the record and the apply date in the column, so rendering from the
+      # column moves the printed date. That is how 62 entries lost their
+      # published dates while PATENT-386 was being fixed, and a comment saying
+      # "run the backfill first" is not what stops it happening again.
+      #
+      # Refused per submission. `rescue_from` turns it into a failure row, so a
+      # run reports exactly which submissions are not ready and rewrites none of
+      # them.
+      unless dated.include?(acc) || entry.locus_date.blank? || entry.locus_date == acc.locus_date.to_s
+        raise "Submission ##{acc.submission_id}: #{entry.id} has LOCUS date #{entry.locus_date} in its record and " \
+              "#{acc.locus_date} in entries.locus_date. Regenerating would publish the latter. " \
+              'Run `rake locus_date:backfill` first, or name it in a run that sets a date.'
+      end
 
       entry.with(
         accession:  acc.accession,
         locus:      acc.accession,
         version:    acc.version,
-        # From the column: it is what this run's date option writes, and what a
-        # per-entry redate would write.
-        #
-        # For submissions applied before the apply job started taking the date
-        # from the record, the column holds the apply date while the record
-        # holds the operator's — so regenerating one of those moves its printed
-        # LOCUS date. `rake locus_date:backfill` settles that per entry, and has
-        # to have been run before any bulk regeneration.
         locus_date: acc.locus_date.to_s
       )
     }

--- a/app/models/ddbj_record.rb
+++ b/app/models/ddbj_record.rb
@@ -5,6 +5,13 @@ module DDBJRecord
   # leaving progress counters stuck and request rows wedged in :applying).
   class V3NotImplementedError < StandardError; end
 
+  # The one way a LOCUS date may be written, wherever it comes from — the
+  # record, the Regenerate form, or a rake option. `Date.parse` would take
+  # `8/13` and fill in whichever year it ran in, `Aug 2026` as the 1st, and
+  # `2026-225` as an ordinal day; this value is printed on the LOCUS line of a
+  # published flatfile, so a guess is worse than a refusal.
+  LOCUS_DATE_FORMAT = /\A\d{4}-\d{2}-\d{2}\z/
+
   Qualifier = Data.define(
     :id,
     :value

--- a/app/models/ddbj_record.rb
+++ b/app/models/ddbj_record.rb
@@ -170,7 +170,16 @@ module DDBJRecord
     :accession,
     :locus,
     :version,
-    :last_updated
+
+    # The date printed on the LOCUS line. Chosen by whoever performs the
+    # publication (submission-bulk-st26's `--date`), so neither the submitted
+    # XML nor this server can derive it; it arrives with the record and is
+    # mirrored into `entries.locus_date`, which is the queryable copy.
+    #
+    # Named `last_updated` until 2026-08: that name said nothing about what the
+    # value was for, and the column, the record and the flatfile drifted into
+    # three different dates as a result.
+    :locus_date
   )
 
   Feature = Data.define(

--- a/app/models/ddbj_record/builders.rb
+++ b/app/models/ddbj_record/builders.rb
@@ -191,7 +191,12 @@ module DDBJRecord
         accession:       h['accession'],
         locus:           h['locus'],
         version:         h['version'],
-        last_updated:    h['last_updated']
+
+        # `last_updated` is what this field was called before 2026-08. Records
+        # written under that name are the whole archive as it stands, so the old
+        # key is still read — dropping it would render every stored record with
+        # a blank LOCUS date.
+        locus_date:      h['locus_date'] || h['last_updated']
       )
     end
 

--- a/app/models/ddbj_record/builders.rb
+++ b/app/models/ddbj_record/builders.rb
@@ -192,11 +192,16 @@ module DDBJRecord
         locus:           h['locus'],
         version:         h['version'],
 
-        # `last_updated` is what this field was called before 2026-08. Records
-        # written under that name are the whole archive as it stands, so the old
-        # key is still read — dropping it would render every stored record with
-        # a blank LOCUS date.
-        locus_date:      h['locus_date'] || h['last_updated']
+        # `last_updated` is what this field was called before 2026-08, and
+        # reading it is not only about the archive: submission-bulk-st26 still
+        # writes that key (`lib/st26/submission.rb`), so it is a live ingest
+        # path. Dropping it before the client is updated would blank the LOCUS
+        # date on every *new* submission as well as every stored one.
+        #
+        # `.presence`, because `''` is truthy: a record carrying an empty
+        # `locus_date` beside a real `last_updated` would otherwise lose the date
+        # to the empty one and fall back to the apply date.
+        locus_date:      h['locus_date'].presence || h['last_updated']
       )
     end
 

--- a/app/models/flatfile/template.erb
+++ b/app/models/flatfile/template.erb
@@ -1,8 +1,8 @@
 <%- entries.each do |entry| -%>
 <%- if entry.na? -%>
-LOCUS       <%= entry.locus.to_s.ljust(16) %> <%= entry.length.to_s.rjust(11) %> bp    <%= mol_type_label(entry.mol_type).ljust(6) %>  <%= entry.topology.ljust(8) %> <%= record.submission.division %> <%= format_date(entry.last_updated) %>
+LOCUS       <%= entry.locus.to_s.ljust(16) %> <%= entry.length.to_s.rjust(11) %> bp    <%= mol_type_label(entry.mol_type).ljust(6) %>  <%= entry.topology.ljust(8) %> <%= record.submission.division %> <%= format_date(entry.locus_date) %>
 <%- else -%>
-LOCUS       <%= entry.locus.to_s.ljust(16) %> <%= entry.length.to_s.rjust(11) %> aa    <%= 'PRT'.ljust(7) %>          <%= record.submission.division %> <%= format_date(entry.last_updated) %>
+LOCUS       <%= entry.locus.to_s.ljust(16) %> <%= entry.length.to_s.rjust(11) %> aa    <%= 'PRT'.ljust(7) %>          <%= record.submission.division %> <%= format_date(entry.locus_date) %>
 <%- end -%>
 DEFINITION  <%= entry.definition %>
 ACCESSION   <%= entry.accession %>

--- a/app/services/regeneration_scope.rb
+++ b/app/services/regeneration_scope.rb
@@ -125,12 +125,22 @@ class RegenerationScope
   # every-submission option is chosen is not a problem, it is a draft.
   def problems
     [
-      ('Pick a LOCUS date, or keep the existing ones.' if setting_date? && locus_date.nil?),
+      date_problem,
       *(numbers_problems if accessions_target?)
     ].compact
   end
 
   def ready? = total.positive? && !(setting_date? && locus_date.nil?)
+
+  # Telling "you have not picked one" from "the one you typed is not a date this
+  # will guess at" — the second used to be reported as the first, which sends a
+  # curator looking for an empty field they had already filled in.
+  def date_problem
+    return nil unless setting_date? && locus_date.nil?
+    return 'Pick a LOCUS date, or keep the existing ones.' if date_input.blank?
+
+    "Write the LOCUS date as YYYY-MM-DD: #{date_input} is not one this will guess at."
+  end
 
   def source_label
     case target

--- a/app/services/regeneration_scope.rb
+++ b/app/services/regeneration_scope.rb
@@ -94,8 +94,12 @@ class RegenerationScope
   def locus_date
     return nil unless setting_date?
 
+    # The same rule the record and the rake options are held to: `Date.parse`
+    # would read `8/13` as this year's 13 August, and the form writes this value
+    # onto published flatfiles. The field is a date picker, so a browser sends
+    # `YYYY-MM-DD` anyway — this is about everything that is not one.
     @locus_date ||= begin
-      Date.parse(date_input)
+      Date.iso8601(date_input) if date_input.match?(DDBJRecord::LOCUS_DATE_FORMAT)
     rescue Date::Error
       nil
     end

--- a/db/migrate/20260810101709_drop_locus_date_default.rb
+++ b/db/migrate/20260810101709_drop_locus_date_default.rb
@@ -1,0 +1,11 @@
+class DropLocusDateDefault < ActiveRecord::Migration[8.1]
+  # The LOCUS date is chosen by whoever performs the publication, so a clock is
+  # never the right answer for it. `ApplySubmissionRequestJob` always supplies
+  # one now; leaving the default in place meant any other insert path stamped
+  # today's date onto a value that gets printed on a published flatfile, with
+  # nothing to say where it came from. Without the default such a path fails
+  # loudly instead.
+  def change
+    change_column_default :entries, :locus_date, from: -> { 'CURRENT_TIMESTAMP' }, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_020933) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_101709) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -105,7 +105,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_020933) do
     t.string "accession", null: false
     t.datetime "created_at", null: false
     t.string "entry_id", null: false
-    t.date "locus_date", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.date "locus_date", null: false
     t.integer "status", default: 5300, null: false
     t.bigint "submission_id", null: false
     t.datetime "updated_at", null: false

--- a/lib/locus_date_backfill.rb
+++ b/lib/locus_date_backfill.rb
@@ -19,7 +19,9 @@
 #   longer carries the apply stamp, so somebody set it on purpose — PATENT-386's
 #   five, redated to 2026-08-13, are why this matters — and restoring "what the
 #   request asked for" over that would undo their work. No list of exceptions to
-#   remember.
+#   remember. (Reported only when it also differs from the request's date: after
+#   the apply job started reading the record, a correctly dated new submission
+#   has a column that differs from its `created_at` too.)
 # - A submission that has already been regenerated. Its record was rewritten with
 #   the column's apply date, so the two agree today, and moving only the column
 #   would put them into the disagreement the guard refuses — leaving the
@@ -92,7 +94,17 @@ module LocusDateBackfill
 
       was = wanted[entry.entry_id]
 
-      next deliberate << entry.accession unless entry.locus_date == entry.created_at.to_date
+      unless entry.locus_date == entry.created_at.to_date
+        # Named only when it is also not the date the request asked for. After
+        # this deploy every correctly dated new submission has a column that
+        # differs from its `created_at` — the operator dates a batch days ahead —
+        # so naming all of those would bury the ones somebody really did redate
+        # (PATENT-386's five) in routine data.
+        next deliberate << entry.accession if was.is_a?(Date) && was != entry.locus_date
+
+        next
+      end
+
       next unreadable << entry.accession if was == :unreadable
       next if was.nil? || was == entry.locus_date
 
@@ -127,7 +139,7 @@ module LocusDateBackfill
 
     outcome.changes.map { format('%-12s submission #%-6d LOCUS date %s -> %s', it.entry.accession, id, it.from, it.to) } +
       outcome.unreadable.map { format('%-12s submission #%-6d its request spells the date in a way this will not guess at', it, id) } +
-      outcome.deliberate.map { format('%-12s submission #%-6d left alone: dated by hand since it was applied', it, id) }
+      outcome.deliberate.map { format('%-12s submission #%-6d left alone: its date was set after it was applied, and is not the one its request asked for', it, id) }
   end
 
   # Which of the named accessions the run never saw. A typo, the wrong case, or a

--- a/lib/locus_date_backfill.rb
+++ b/lib/locus_date_backfill.rb
@@ -1,0 +1,127 @@
+# Puts `entries.locus_date` back to the date the publication operator chose.
+#
+# Until 2026-08 the apply job wrote the apply date into the column while the
+# flatfile printed the date carried in the record, so the two disagree on every
+# submission applied before that — and regeneration renders from the column, so
+# regenerating one of them moves its published LOCUS date. See CLAUDE.md, "The
+# LOCUS date".
+#
+# The original is read from the **request's** record, the file as the operator
+# uploaded it. The submission's own record is rewritten by every regeneration,
+# so for a submission that has been regenerated it already holds the apply date
+# and cannot say what was meant; the request's copy is never rewritten.
+#
+# A one-off, like the PATENT-386 repair before it: delete it once the archive has
+# been walked. Unlike that one it commits per submission rather than in a single
+# transaction — 18,000 submissions cannot be one — so it is written to be
+# re-runnable and to report exactly what it changed.
+module LocusDateBackfill
+  Change = Data.define(:entry, :from, :to)
+
+  Unexamined = Data.define(:submission, :why)
+
+  Result = Data.define(:changes, :unexamined, :scanned) do
+    def submissions = changes.map { it.entry.submission_id }.uniq
+  end
+
+  module_function
+
+  # `except` names entries to leave alone: an entry whose date was deliberately
+  # set to something other than the operator's original — PATENT-386's five —
+  # would otherwise be pulled back to what the request said.
+  def audit(limit: nil, after: nil, accessions: nil, except: nil)
+    keep    = split(except).to_set
+    named   = split(accessions)
+    changes = []
+    unex    = []
+    scanned = 0
+
+    scope = Submission.st26_db.order(:id)
+    scope = scope.where(id: Entry.where(accession: named).select(:submission_id)) if named.any?
+    scope = scope.where(id: after.to_i..)                                        if after.present?
+    scope = scope.limit(limit.to_i)                                              if limit.present?
+
+    scope.each do |submission|
+      scanned += 1
+
+      wanted = original_dates(submission)
+
+      next unex << Unexamined.new(submission:, why: wanted) if wanted.is_a?(String)
+
+      submission.entries.order(:accession).each do |entry|
+        next if keep.include?(entry.accession)
+
+        was = wanted[entry.entry_id]
+
+        next if was.blank? || was == entry.locus_date
+
+        changes << Change.new(entry:, from: entry.locus_date, to: was)
+      end
+    end
+
+    Result.new(changes:, unexamined: unex, scanned:)
+  end
+
+  def report(result)
+    result.changes.each do |c|
+      puts format('%-12s submission #%-6d LOCUS date %s -> %s', c.entry.accession, c.entry.submission_id, c.from, c.to)
+    end
+
+    result.unexamined.each do |u|
+      puts format('%-12s submission #%-6d not examined: %s', '(skipped)', u.submission.id, u.why)
+    end
+  end
+
+  # Per submission, so a long run can be stopped and resumed. Each entry is
+  # written by id with its expected current value in the WHERE clause: the audit
+  # and the write are separate reads, and a date that moved in between is one
+  # this run no longer knows the truth about.
+  def apply!(changes)
+    changes.group_by { it.entry.submission_id }.map do |submission_id, group|
+      written = 0
+
+      Entry.transaction do
+        group.each do |c|
+          written += Entry.where(id: c.entry.id, locus_date: c.from).update_all(locus_date: c.to, updated_at: Time.current)
+        end
+
+        raise "submission ##{submission_id}: expected to redate #{group.size} #{'entry'.pluralize(group.size)}, redated #{written} — the dates moved since the audit" unless written == group.size
+      end
+
+      "submission ##{submission_id}: redated #{written} #{'entry'.pluralize(written)}"
+    end
+  end
+
+  # entry_id => Date from the request's record, or a string saying why not.
+  def original_dates(submission)
+    request = SubmissionRequest.find_by(submission_id: submission.id)
+
+    return 'no submission request' unless request
+    return 'request has no record' unless request.ddbj_record.attached?
+
+    request.ddbj_record.open do |file|
+      major, = DDBJRecord::SchemaVersionDetector.detect(file)
+      file.rewind
+
+      next 'v3 record' if major == '3'
+
+      DDBJRecord::StreamingParser.new(file.path).each_entry.to_h { [it.id, parse(it.locus_date)] }
+    end
+  rescue StandardError => e
+    "#{e.class}: #{e.message}"
+  end
+
+  # Only `YYYY-MM-DD`, for the reason ApplySubmissionRequestJob refuses anything
+  # else: `Date.parse` would guess, and the guess lands on a published flatfile.
+  # A date this cannot read leaves the entry alone rather than moving it
+  # somewhere invented.
+  def parse(value)
+    return nil unless value.to_s.match?(ApplySubmissionRequestJob::LOCUS_DATE_FORMAT)
+
+    Date.iso8601(value)
+  rescue Date::Error
+    nil
+  end
+
+  def split(value) = value.to_s.split(/[\s,]+/).reject(&:blank?).uniq
+end

--- a/lib/locus_date_backfill.rb
+++ b/lib/locus_date_backfill.rb
@@ -2,99 +2,111 @@
 #
 # Until 2026-08 the apply job wrote the apply date into the column while the
 # flatfile printed the date carried in the record, so the two disagree on every
-# submission applied before that — and regeneration renders from the column, so
-# regenerating one of them moves its published LOCUS date. See CLAUDE.md, "The
-# LOCUS date".
+# submission applied before that. Regeneration renders from the column, so
+# RegenerateSubmissionFlatfilesJob now refuses a submission whose column and
+# record disagree — which is what makes this a prerequisite rather than a
+# tidy-up. See CLAUDE.md, "The LOCUS date".
 #
 # The original is read from the **request's** record, the file as the operator
 # uploaded it. The submission's own record is rewritten by every regeneration,
-# so for a submission that has been regenerated it already holds the apply date
+# so for a submission that has already been regenerated it holds the apply date
 # and cannot say what was meant; the request's copy is never rewritten.
 #
-# A one-off, like the PATENT-386 repair before it: delete it once the archive has
-# been walked. Unlike that one it commits per submission rather than in a single
-# transaction — 18,000 submissions cannot be one — so it is written to be
-# re-runnable and to report exactly what it changed.
+# An entry is left alone unless it still carries the apply stamp — that is,
+# unless `locus_date` is the date the row was created. Anything else was set by
+# somebody on purpose (PATENT-386's five, redated to 2026-08-13, are the reason
+# this matters), and restoring "the date the request asked for" over a
+# deliberate one would undo their work. No list of exceptions to remember.
+#
+# No EntryHistory row: this changes what the column says, not what the record or
+# the published flatfile says. The date is not moving — it is being recorded
+# where it was already meant to be.
+#
+# A one-off. Delete it once the archive has been walked.
 module LocusDateBackfill
   Change = Data.define(:entry, :from, :to)
 
-  Unexamined = Data.define(:submission, :why)
-
-  Result = Data.define(:changes, :unexamined, :scanned) do
-    def submissions = changes.map { it.entry.submission_id }.uniq
+  # One submission's worth of work, or the reason there is none.
+  Outcome = Data.define(:submission, :changes, :unexamined) do
+    def examined? = unexamined.nil?
   end
 
   module_function
 
-  # `except` names entries to leave alone: an entry whose date was deliberately
-  # set to something other than the operator's original — PATENT-386's five —
-  # would otherwise be pulled back to what the request said.
-  def audit(limit: nil, after: nil, accessions: nil, except: nil)
-    keep    = split(except).to_set
-    named   = split(accessions)
-    changes = []
-    unex    = []
-    scanned = 0
+  # Yields an Outcome per submission and holds nothing: the archive is ~18,000
+  # submissions and every one of them means a blob read, so a pass that
+  # collected first and acted later would carry the whole thing in memory.
+  def each_submission(limit: nil, after: nil, accessions: nil)
+    return enum_for(:each_submission, limit:, after:, accessions:) unless block_given?
 
+    named = split(accessions).to_set
     scope = Submission.st26_db.order(:id)
-    scope = scope.where(id: Entry.where(accession: named).select(:submission_id)) if named.any?
-    scope = scope.where(id: after.to_i..)                                        if after.present?
-    scope = scope.limit(limit.to_i)                                              if limit.present?
+    scope = scope.where(id: Entry.where(accession: named.to_a).select(:submission_id)) if named.any?
+    scope = scope.where(id: integer!(after, 'AFTER')..)                                if after.present?
+    scope = scope.limit(integer!(limit, 'LIMIT'))                                      if limit.present?
 
-    scope.each do |submission|
-      scanned += 1
-
-      wanted = original_dates(submission)
-
-      next unex << Unexamined.new(submission:, why: wanted) if wanted.is_a?(String)
-
-      submission.entries.order(:accession).each do |entry|
-        next if keep.include?(entry.accession)
-
-        was = wanted[entry.entry_id]
-
-        next if was.blank? || was == entry.locus_date
-
-        changes << Change.new(entry:, from: entry.locus_date, to: was)
-      end
-    end
-
-    Result.new(changes:, unexamined: unex, scanned:)
+    scope.find_each { yield examine(it, named) }
   end
 
-  def report(result)
-    result.changes.each do |c|
-      puts format('%-12s submission #%-6d LOCUS date %s -> %s', c.entry.accession, c.entry.submission_id, c.from, c.to)
-    end
+  def examine(submission, named)
+    wanted = original_dates(submission)
 
-    result.unexamined.each do |u|
-      puts format('%-12s submission #%-6d not examined: %s', '(skipped)', u.submission.id, u.why)
-    end
+    return Outcome.new(submission:, changes: [], unexamined: wanted) if wanted.is_a?(String)
+
+    changes = submission.entries.order(:accession).filter_map {|entry|
+      # Named entries only, when any were named. `ACCESSIONS` reaches whole
+      # submissions to find the records, and a submission can hold sixty
+      # entries — restoring the other fifty-nine was not what was asked for.
+      next if named.any? && !named.include?(entry.accession)
+
+      # Still bearing the apply stamp, or somebody set it deliberately.
+      next unless entry.locus_date == entry.created_at.to_date
+
+      was = wanted[entry.entry_id]
+
+      next if was.blank? || was == entry.locus_date
+
+      Change.new(entry:, from: entry.locus_date, to: was)
+    }
+
+    Outcome.new(submission:, changes:, unexamined: nil)
   end
 
-  # Per submission, so a long run can be stopped and resumed. Each entry is
-  # written by id with its expected current value in the WHERE clause: the audit
-  # and the write are separate reads, and a date that moved in between is one
-  # this run no longer knows the truth about.
+  # Per submission, so a long run can be stopped and resumed, and each entry is
+  # written with its expected current value in the WHERE clause: the read and the
+  # write are separate, and a date that moved in between is one this no longer
+  # knows the truth about.
   def apply!(changes)
-    changes.group_by { it.entry.submission_id }.map do |submission_id, group|
-      written = 0
+    written = 0
 
-      Entry.transaction do
-        group.each do |c|
-          written += Entry.where(id: c.entry.id, locus_date: c.from).update_all(locus_date: c.to, updated_at: Time.current)
-        end
-
-        raise "submission ##{submission_id}: expected to redate #{group.size} #{'entry'.pluralize(group.size)}, redated #{written} — the dates moved since the audit" unless written == group.size
+    Entry.transaction do
+      changes.each do |c|
+        written += Entry.where(id: c.entry.id, locus_date: c.from).update_all(locus_date: c.to, updated_at: Time.current)
       end
 
-      "submission ##{submission_id}: redated #{written} #{'entry'.pluralize(written)}"
+      raise "submission ##{changes.first.entry.submission_id}: expected to redate #{changes.size} #{'entry'.pluralize(changes.size)}, redated #{written} — the dates moved since they were read" unless written == changes.size
     end
+
+    written
+  end
+
+  def describe(outcome)
+    return ["#{label(outcome.submission)} not examined: #{outcome.unexamined}"] unless outcome.examined?
+
+    outcome.changes.map do |c|
+      format('%-12s submission #%-6d LOCUS date %s -> %s', c.entry.accession, c.entry.submission_id, c.from, c.to)
+    end
+  end
+
+  # Which of the named accessions the run never saw. A typo, the wrong case, or
+  # a number outside the archive would otherwise read as "nothing to do here".
+  def unmatched(accessions, seen)
+    split(accessions).to_set - seen
   end
 
   # entry_id => Date from the request's record, or a string saying why not.
   def original_dates(submission)
-    request = SubmissionRequest.find_by(submission_id: submission.id)
+    request = submission.request
 
     return 'no submission request' unless request
     return 'request has no record' unless request.ddbj_record.attached?
@@ -123,5 +135,15 @@ module LocusDateBackfill
     nil
   end
 
+  def label(submission) = format('(skipped)    submission #%-6d', submission.id)
+
   def split(value) = value.to_s.split(/[\s,]+/).reject(&:blank?).uniq
+
+  # `AFTER=LC000123` would otherwise be 0 and silently restart a resumed run;
+  # `LIMIT=all` would be `limit(0)`, which scans nothing and reads as clean.
+  def integer!(value, name)
+    Integer(value.to_s, 10)
+  rescue ArgumentError
+    raise ArgumentError, "#{name}=#{value} is not a number."
+  end
 end

--- a/lib/locus_date_backfill.rb
+++ b/lib/locus_date_backfill.rb
@@ -8,68 +8,98 @@
 # tidy-up. See CLAUDE.md, "The LOCUS date".
 #
 # The original is read from the **request's** record, the file as the operator
-# uploaded it. The submission's own record is rewritten by every regeneration,
-# so for a submission that has already been regenerated it holds the apply date
-# and cannot say what was meant; the request's copy is never rewritten.
+# uploaded it. The submission's own record is rewritten by every regeneration, so
+# for a submission that has already been regenerated it holds the apply date and
+# cannot say what was meant; the request's copy is never rewritten.
 #
-# An entry is left alone unless it still carries the apply stamp — that is,
-# unless `locus_date` is the date the row was created. Anything else was set by
-# somebody on purpose (PATENT-386's five, redated to 2026-08-13, are the reason
-# this matters), and restoring "the date the request asked for" over a
-# deliberate one would undo their work. No list of exceptions to remember.
+# Three things are deliberately left alone, each reported rather than passed over
+# in silence:
+#
+# - An entry whose `locus_date` is no longer the date its row was created. It no
+#   longer carries the apply stamp, so somebody set it on purpose — PATENT-386's
+#   five, redated to 2026-08-13, are why this matters — and restoring "what the
+#   request asked for" over that would undo their work. No list of exceptions to
+#   remember.
+# - A submission that has already been regenerated. Its record was rewritten with
+#   the column's apply date, so the two agree today, and moving only the column
+#   would put them into the disagreement the guard refuses — leaving the
+#   submission unregeneratable, with a second pass unable to help because the
+#   stamp is gone. Those are also the submissions whose *published* flatfile
+#   prints the apply date, so the column is not the thing to fix: they need a
+#   regeneration that names the date, which writes the column, the record and the
+#   file together.
+# - An entry whose original date cannot be read (`2026-8-13`). Guessing at a date
+#   is what put a wrong one on a flatfile to begin with.
 #
 # No EntryHistory row: this changes what the column says, not what the record or
-# the published flatfile says. The date is not moving — it is being recorded
-# where it was already meant to be.
+# the published flatfile says. The date is not moving — it is being recorded where
+# it was already meant to be.
 #
 # A one-off. Delete it once the archive has been walked.
 module LocusDateBackfill
+  ALREADY_REGENERATED = 'already regenerated: its record and its published flatfile carry the apply date, so redate it ' \
+                        'with `Regenerate flatfiles` naming the date — this cannot fix it'.freeze
+
   Change = Data.define(:entry, :from, :to)
 
-  # One submission's worth of work, or the reason there is none.
-  Outcome = Data.define(:submission, :changes, :unexamined) do
+  # One submission's worth of work, and everything about it a person has to see.
+  # `unexamined` is a reason the submission was not looked at; `unreadable` names
+  # entries whose original date could not be read; `deliberate` names entries
+  # somebody had already dated.
+  Outcome = Data.define(:submission, :changes, :unexamined, :unreadable, :deliberate) do
     def examined? = unexamined.nil?
+
+    def needs_attention? = !examined? || unreadable.any?
   end
 
   module_function
 
   # Yields an Outcome per submission and holds nothing: the archive is ~18,000
-  # submissions and every one of them means a blob read, so a pass that
-  # collected first and acted later would carry the whole thing in memory.
+  # submissions and every one of them means a blob read, so a pass that collected
+  # first and acted later would carry the whole thing in memory.
   def each_submission(limit: nil, after: nil, accessions: nil)
     return enum_for(:each_submission, limit:, after:, accessions:) unless block_given?
 
     named = split(accessions).to_set
-    scope = Submission.st26_db.order(:id)
+
+    # No `order`: `find_each` batches by id and discards any order of its own.
+    # `AFTER` is exclusive, or resuming would re-read the blob of the submission
+    # the previous run stopped on.
+    scope = Submission.st26_db
     scope = scope.where(id: Entry.where(accession: named.to_a).select(:submission_id)) if named.any?
-    scope = scope.where(id: integer!(after, 'AFTER')..)                                if after.present?
+    scope = scope.where(id: (integer!(after, 'AFTER') + 1)..)                          if after.present?
     scope = scope.limit(integer!(limit, 'LIMIT'))                                      if limit.present?
 
     scope.find_each { yield examine(it, named) }
   end
 
   def examine(submission, named)
+    return unexamined(submission, ALREADY_REGENERATED) if regenerated?(submission)
+
     wanted = original_dates(submission)
 
-    return Outcome.new(submission:, changes: [], unexamined: wanted) if wanted.is_a?(String)
+    return unexamined(submission, wanted) if wanted.is_a?(String)
 
-    changes = submission.entries.order(:accession).filter_map {|entry|
+    changes    = []
+    unreadable = []
+    deliberate = []
+
+    submission.entries.order(:accession).each do |entry|
       # Named entries only, when any were named. `ACCESSIONS` reaches whole
       # submissions to find the records, and a submission can hold sixty
       # entries — restoring the other fifty-nine was not what was asked for.
       next if named.any? && !named.include?(entry.accession)
 
-      # Still bearing the apply stamp, or somebody set it deliberately.
-      next unless entry.locus_date == entry.created_at.to_date
-
       was = wanted[entry.entry_id]
 
-      next if was.blank? || was == entry.locus_date
+      next deliberate << entry.accession unless entry.locus_date == entry.created_at.to_date
+      next unreadable << entry.accession if was == :unreadable
+      next if was.nil? || was == entry.locus_date
 
-      Change.new(entry:, from: entry.locus_date, to: was)
-    }
+      changes << Change.new(entry:, from: entry.locus_date, to: was)
+    end
 
-    Outcome.new(submission:, changes:, unexamined: nil)
+    Outcome.new(submission:, changes:, unexamined: nil, unreadable:, deliberate:)
   end
 
   # Per submission, so a long run can be stopped and resumed, and each entry is
@@ -91,20 +121,28 @@ module LocusDateBackfill
   end
 
   def describe(outcome)
-    return ["#{label(outcome.submission)} not examined: #{outcome.unexamined}"] unless outcome.examined?
+    id = outcome.submission.id
 
-    outcome.changes.map do |c|
-      format('%-12s submission #%-6d LOCUS date %s -> %s', c.entry.accession, c.entry.submission_id, c.from, c.to)
-    end
+    return [format('(skipped)    submission #%-6d %s', id, outcome.unexamined)] unless outcome.examined?
+
+    outcome.changes.map { format('%-12s submission #%-6d LOCUS date %s -> %s', it.entry.accession, id, it.from, it.to) } +
+      outcome.unreadable.map { format('%-12s submission #%-6d its request spells the date in a way this will not guess at', it, id) } +
+      outcome.deliberate.map { format('%-12s submission #%-6d left alone: dated by hand since it was applied', it, id) }
   end
 
-  # Which of the named accessions the run never saw. A typo, the wrong case, or
-  # a number outside the archive would otherwise read as "nothing to do here".
-  def unmatched(accessions, seen)
-    split(accessions).to_set - seen
+  # Which of the named accessions the run never saw. A typo, the wrong case, or a
+  # number outside the archive would otherwise read as "nothing to do here".
+  def unmatched(accessions, seen) = split(accessions).to_set - seen
+
+  # Whether this submission's record has already been rewritten by a
+  # regeneration. Read from the history rather than by comparing the two records,
+  # which would double the blob reads of an archive-wide pass.
+  def regenerated?(submission)
+    EntryHistory.where(action: 'regenerate', entry_id: submission.entries.select(:id)).exists?
   end
 
-  # entry_id => Date from the request's record, or a string saying why not.
+  # entry_id => Date, `:unreadable`, or nil when the request named no date. A
+  # String in place of the Hash is the reason the submission could not be read.
   def original_dates(submission)
     request = submission.request
 
@@ -123,19 +161,18 @@ module LocusDateBackfill
     "#{e.class}: #{e.message}"
   end
 
-  # Only `YYYY-MM-DD`, for the reason ApplySubmissionRequestJob refuses anything
-  # else: `Date.parse` would guess, and the guess lands on a published flatfile.
-  # A date this cannot read leaves the entry alone rather than moving it
-  # somewhere invented.
+  # nil when the record names no date, `:unreadable` when it names one this will
+  # not guess at, otherwise the date.
   def parse(value)
-    return nil unless value.to_s.match?(ApplySubmissionRequestJob::LOCUS_DATE_FORMAT)
+    return nil if value.blank?
+    return :unreadable unless value.to_s.match?(DDBJRecord::LOCUS_DATE_FORMAT)
 
     Date.iso8601(value)
   rescue Date::Error
-    nil
+    :unreadable
   end
 
-  def label(submission) = format('(skipped)    submission #%-6d', submission.id)
+  def unexamined(submission, why) = Outcome.new(submission:, changes: [], unexamined: why, unreadable: [], deliberate: [])
 
   def split(value) = value.to_s.split(/[\s,]+/).reject(&:blank?).uniq
 

--- a/lib/tasks/locus_date.rake
+++ b/lib/tasks/locus_date.rake
@@ -1,0 +1,42 @@
+namespace :locus_date do
+  desc 'Put entries.locus_date back to the date the publication operator chose (LIMIT=/AFTER=/ACCESSIONS=/EXCEPT= to scope, APPLY=1 to write)'
+  task backfill: :environment do
+    # `EXCEPT` is the one option worth reading twice. An entry whose date was
+    # deliberately set to something other than what the operator first asked for
+    # — PATENT-386's five, redated to 2026-08-13 — would otherwise be pulled
+    # back to what its request said. The dry run prints every move, so read it.
+    result = LocusDateBackfill.audit(
+      limit:      ENV['LIMIT'],
+      after:      ENV['AFTER'],
+      accessions: ENV['ACCESSIONS'],
+      except:     ENV['EXCEPT']
+    )
+
+    LocusDateBackfill.report result
+
+    puts "\nscanned #{result.scanned} #{'submission'.pluralize(result.scanned)}."
+
+    if result.changes.empty?
+      puts 'Nothing to redate.'
+    elsif ENV['APPLY'] == '1'
+      LocusDateBackfill.apply!(result.changes).each { puts it }
+
+      puts "\nRedated #{result.changes.size} #{'entry'.pluralize(result.changes.size)} across #{result.submissions.size} #{'submission'.pluralize(result.submissions.size)}."
+
+      # Deliberately not regenerated here. The column is now right; whether the
+      # published flatfiles should be rebuilt — and when — is a publication
+      # decision, and rebuilding one rewrites every entry of its submission.
+      puts 'The flatfiles are untouched: regenerate the ones that need republishing, keeping the existing LOCUS dates.'
+    else
+      puts "\nDry run. Re-run with APPLY=1 to redate #{result.changes.size} #{'entry'.pluralize(result.changes.size)}."
+    end
+
+    # A submission this could not read is not a submission that agrees. Findings
+    # themselves exit 0 — they are the report.
+    next if result.unexamined.empty?
+
+    $stdout.flush
+
+    abort "#{result.unexamined.size} #{'submission'.pluralize(result.unexamined.size)} could not be examined, so this is not a clean bill of health."
+  end
+end

--- a/lib/tasks/locus_date.rake
+++ b/lib/tasks/locus_date.rake
@@ -1,11 +1,11 @@
 namespace :locus_date do
   desc 'Put entries.locus_date back to the date the publication operator chose (LIMIT=/AFTER=/ACCESSIONS= to scope, APPLY=1 to write)'
   task backfill: :environment do
-    applying = ENV['APPLY'] == '1'
-    redated  = 0
-    seen     = Set.new
-    scanned  = 0
-    skipped  = []
+    applying  = ENV['APPLY'] == '1'
+    attention = []
+    redated   = 0
+    scanned   = 0
+    seen      = Set.new
 
     # Reported as each submission is dealt with, and written in the same pass:
     # a run over the archive that collected first would hold every change in
@@ -13,11 +13,14 @@ namespace :locus_date do
     # 300 submissions it had already committed when the 301st raised.
     LocusDateBackfill.each_submission(limit: ENV['LIMIT'], after: ENV['AFTER'], accessions: ENV['ACCESSIONS']) do |outcome|
       scanned += 1
-      seen.merge outcome.submission.entries.pluck(:accession)
+
+      # Only when there is a list to check against: on an archive-wide pass this
+      # would be a query per submission for a set nothing reads.
+      seen.merge outcome.submission.entries.pluck(:accession) if ENV['ACCESSIONS'].present?
 
       LocusDateBackfill.describe(outcome).each { puts it }
 
-      skipped << outcome unless outcome.examined?
+      attention << outcome if outcome.needs_attention?
 
       next unless applying && outcome.changes.any?
 
@@ -29,10 +32,10 @@ namespace :locus_date do
     if applying
       puts "Redated #{redated} #{'entry'.pluralize(redated)}."
 
-      # Deliberately not regenerated. The column is now right, and the published
-      # flatfiles already print these dates — they were only ever wrong in the
-      # column. Regenerating is a publication decision, and it rewrites every
-      # entry of a submission.
+      # Deliberately not regenerated, and nothing needs to be: the published
+      # flatfiles of these submissions already print the operator's date — it was
+      # only ever the column that was wrong. (A submission whose file prints the
+      # apply date has been regenerated, and this refuses those.)
       puts 'The flatfiles are untouched, and now agree with the column.' if redated.positive?
     else
       puts 'Re-run with APPLY=1 to write.'
@@ -42,7 +45,7 @@ namespace :locus_date do
 
     problems = [
       ("#{unmatched.size} #{'accession'.pluralize(unmatched.size)} matched no ST.26 entry: #{unmatched.to_a.join(', ')}" if unmatched.any?),
-      ("#{skipped.size} #{'submission'.pluralize(skipped.size)} could not be examined" if skipped.any?)
+      ("#{attention.size} #{'submission'.pluralize(attention.size)} need attention rather than a backfill" if attention.any?)
     ].compact
 
     next if problems.empty?

--- a/lib/tasks/locus_date.rake
+++ b/lib/tasks/locus_date.rake
@@ -41,7 +41,11 @@ namespace :locus_date do
       puts 'Re-run with APPLY=1 to write.'
     end
 
-    unmatched = LocusDateBackfill.unmatched(ENV['ACCESSIONS'], seen)
+    # Only when the run saw the whole of what was named. Scoped by LIMIT or
+    # resumed from AFTER, an accession the run simply has not reached yet is
+    # indistinguishable from one that does not exist, and reporting it as missing
+    # reads as a typo.
+    unmatched = ENV['LIMIT'].present? || ENV['AFTER'].present? ? Set.new : LocusDateBackfill.unmatched(ENV['ACCESSIONS'], seen)
 
     problems = [
       ("#{unmatched.size} #{'accession'.pluralize(unmatched.size)} matched no ST.26 entry: #{unmatched.to_a.join(', ')}" if unmatched.any?),

--- a/lib/tasks/locus_date.rake
+++ b/lib/tasks/locus_date.rake
@@ -1,42 +1,56 @@
 namespace :locus_date do
-  desc 'Put entries.locus_date back to the date the publication operator chose (LIMIT=/AFTER=/ACCESSIONS=/EXCEPT= to scope, APPLY=1 to write)'
+  desc 'Put entries.locus_date back to the date the publication operator chose (LIMIT=/AFTER=/ACCESSIONS= to scope, APPLY=1 to write)'
   task backfill: :environment do
-    # `EXCEPT` is the one option worth reading twice. An entry whose date was
-    # deliberately set to something other than what the operator first asked for
-    # — PATENT-386's five, redated to 2026-08-13 — would otherwise be pulled
-    # back to what its request said. The dry run prints every move, so read it.
-    result = LocusDateBackfill.audit(
-      limit:      ENV['LIMIT'],
-      after:      ENV['AFTER'],
-      accessions: ENV['ACCESSIONS'],
-      except:     ENV['EXCEPT']
-    )
+    applying = ENV['APPLY'] == '1'
+    redated  = 0
+    seen     = Set.new
+    scanned  = 0
+    skipped  = []
 
-    LocusDateBackfill.report result
+    # Reported as each submission is dealt with, and written in the same pass:
+    # a run over the archive that collected first would hold every change in
+    # memory, and one that printed only at the end would say nothing about the
+    # 300 submissions it had already committed when the 301st raised.
+    LocusDateBackfill.each_submission(limit: ENV['LIMIT'], after: ENV['AFTER'], accessions: ENV['ACCESSIONS']) do |outcome|
+      scanned += 1
+      seen.merge outcome.submission.entries.pluck(:accession)
 
-    puts "\nscanned #{result.scanned} #{'submission'.pluralize(result.scanned)}."
+      LocusDateBackfill.describe(outcome).each { puts it }
 
-    if result.changes.empty?
-      puts 'Nothing to redate.'
-    elsif ENV['APPLY'] == '1'
-      LocusDateBackfill.apply!(result.changes).each { puts it }
+      skipped << outcome unless outcome.examined?
 
-      puts "\nRedated #{result.changes.size} #{'entry'.pluralize(result.changes.size)} across #{result.submissions.size} #{'submission'.pluralize(result.submissions.size)}."
+      next unless applying && outcome.changes.any?
 
-      # Deliberately not regenerated here. The column is now right; whether the
-      # published flatfiles should be rebuilt — and when — is a publication
-      # decision, and rebuilding one rewrites every entry of its submission.
-      puts 'The flatfiles are untouched: regenerate the ones that need republishing, keeping the existing LOCUS dates.'
-    else
-      puts "\nDry run. Re-run with APPLY=1 to redate #{result.changes.size} #{'entry'.pluralize(result.changes.size)}."
+      redated += LocusDateBackfill.apply!(outcome.changes)
     end
 
-    # A submission this could not read is not a submission that agrees. Findings
-    # themselves exit 0 — they are the report.
-    next if result.unexamined.empty?
+    puts "\nscanned #{scanned} #{'submission'.pluralize(scanned)}."
 
+    if applying
+      puts "Redated #{redated} #{'entry'.pluralize(redated)}."
+
+      # Deliberately not regenerated. The column is now right, and the published
+      # flatfiles already print these dates — they were only ever wrong in the
+      # column. Regenerating is a publication decision, and it rewrites every
+      # entry of a submission.
+      puts 'The flatfiles are untouched, and now agree with the column.' if redated.positive?
+    else
+      puts 'Re-run with APPLY=1 to write.'
+    end
+
+    unmatched = LocusDateBackfill.unmatched(ENV['ACCESSIONS'], seen)
+
+    problems = [
+      ("#{unmatched.size} #{'accession'.pluralize(unmatched.size)} matched no ST.26 entry: #{unmatched.to_a.join(', ')}" if unmatched.any?),
+      ("#{skipped.size} #{'submission'.pluralize(skipped.size)} could not be examined" if skipped.any?)
+    ].compact
+
+    next if problems.empty?
+
+    # Neither is a clean bill of health: one is most likely a typo, the other is
+    # a submission this run has said nothing about.
     $stdout.flush
 
-    abort "#{result.unexamined.size} #{'submission'.pluralize(result.unexamined.size)} could not be examined, so this is not a clean bill of health."
+    abort problems.join('. ') << '.'
   end
 end

--- a/lib/tasks/st26.rake
+++ b/lib/tasks/st26.rake
@@ -185,13 +185,15 @@ namespace :st26 do
       puts "\nDone: #{intent}."
       puts "#{remaining.size} named #{'location'.pluralize(remaining.size)} still #{remaining.size == 1 ? 'needs' : 'need'} fixing by hand." if remaining.any?
 
-      # The screen named here can undo the date this task just set: its own date
-      # option runs `submission.entries.update_all(locus_date:)` over the whole
-      # submission. It defaults to keeping them, which is why the default is
-      # worth saying out loud rather than leaving to be noticed.
-      keep = ', keeping the existing LOCUS dates' if locus_date
+      # Naming the date in that run, not leaving it to the column. This task
+      # writes `entries.locus_date` and deliberately leaves the record alone, so
+      # a run that names no date finds the two disagreeing and refuses the
+      # submission — the guard that stops a regeneration publishing a date
+      # nobody chose. Naming it writes the column, the record and the file
+      # together, and for exactly these accessions.
+      there = locus_date ? ", naming #{locus_date} as the LOCUS date there too" : ''
 
-      puts "The flatfiles still hold the old spans — regenerate them from Admin → Regenerate flatfiles for these accessions#{keep}."
+      puts "The flatfiles still hold the old spans — regenerate these accessions from Admin → Regenerate flatfiles#{there}."
 
       # The request keeps the file as it arrived, which is the point of it —
       # but that makes it disagree with the corrected submission, and it is

--- a/test/integration/accessions_test.rb
+++ b/test/integration/accessions_test.rb
@@ -98,7 +98,7 @@ class AccessionsTest < ActionDispatch::IntegrationTest
   test 'the flat list is the caller\'s own entries and nobody else\'s' do
     mine   = submissions(:st26).entries.first
     theirs = Submission.create!(user: users(:carol), db: 'st26')
-                       .entries.create!(accession: 'ACC_CAROL1', entry_id: 'C|1', version: 1)
+                       .entries.create!(accession: 'ACC_CAROL1', entry_id: 'C|1', version: 1, locus_date: Date.new(2026, 1, 15))
 
     get accessions_path
 

--- a/test/integration/reviews_test.rb
+++ b/test/integration/reviews_test.rb
@@ -67,7 +67,7 @@ class ReviewsTest < ActionDispatch::IntegrationTest
   end
 
   test 'GET accessions returns the submission accessions' do
-    @submission_request.submission.entries.create!(accession: 'ACC_REVIEW1', entry_id: 'E|1', version: 1)
+    @submission_request.submission.entries.create!(accession: 'ACC_REVIEW1', entry_id: 'E|1', version: 1, locus_date: Date.new(2026, 1, 15))
 
     get review_accessions_path(@access.token)
 

--- a/test/jobs/apply_submission_request_job_test.rb
+++ b/test/jobs/apply_submission_request_job_test.rb
@@ -2,15 +2,7 @@ require 'test_helper'
 
 class ApplySubmissionRequestJobTest < ActiveSupport::TestCase
   test 'generates NA flatfile for genomic DNA entries' do
-    request = SubmissionRequest.new(user: users(:alice), db: 'st26')
-
-    request.ddbj_record.attach(
-      io:           file_fixture('ddbj_record/example.json').open,
-      filename:     'example.json',
-      content_type: 'application/json'
-    )
-
-    request.save!
+    request = build_request('ddbj_record/example.json')
 
     ApplySubmissionRequestJob.perform_now request
 
@@ -58,6 +50,24 @@ class ApplySubmissionRequestJobTest < ActiveSupport::TestCase
     assert_includes submission.flatfile_na.download, '13-AUG-2026'
   end
 
+  # to_date (= Date.parse) は推測する。"8/13" は「実行した年」の 8 月 13 日に
+  # なり、その値が公開される flatfile の LOCUS 行に印字される。推測より拒否。
+  # pass 1 は採番の前なので、ここで落ちても 1 件も消費しない。
+  test 'refuses a locus_date that is not written as YYYY-MM-DD' do
+    request = build_request('ddbj_record/example.json') {|record|
+      record['sequences']['entries'].each { it['locus_date'] = '8/13' }
+    }
+
+    ApplySubmissionRequestJob.perform_now request
+
+    request.reload
+
+    assert request.application_failed?
+    assert_equal 'TRD_R0014', request.error_code
+    assert_match(/not written as YYYY-MM-DD/, request.error_message)
+    assert_nil request.submission
+  end
+
   # 日付を言わない record のときだけ apply 日が立つ。
   test 'falls back to the apply date when the record names none' do
     request = build_request('ddbj_record/example.json')
@@ -71,16 +81,7 @@ class ApplySubmissionRequestJobTest < ActiveSupport::TestCase
   # request が applying のまま取り残され、クライアントが status を永久に
   # ポーリングし続ける。終端状態 (application_failed) に落ちることを保証する。
   test 'marks the request as application_failed even on a non-StandardError' do
-    request = SubmissionRequest.new(user: users(:alice), db: 'st26')
-
-    request.ddbj_record.attach(
-      io:           file_fixture('ddbj_record/example.json').open,
-      filename:     'example.json',
-      content_type: 'application/json'
-    )
-
-    request.save!
-
+    request = build_request('ddbj_record/example.json')
     boom = ->(*) { raise SystemStackError, 'stack level too deep' }
 
     assert_raises SystemStackError do
@@ -100,15 +101,7 @@ class ApplySubmissionRequestJobTest < ActiveSupport::TestCase
   # 採番が尽きたことは、クライアントがランを打ち切るかどうかの判断に使う。
   # 文言ではなくコードで分岐できるようにしておく。
   test 'records TRD_R0012 when the accession numbers run out' do
-    request = SubmissionRequest.new(user: users(:alice), db: 'st26')
-
-    request.ddbj_record.attach(
-      io:           file_fixture('ddbj_record/example.json').open,
-      filename:     'example.json',
-      content_type: 'application/json'
-    )
-
-    request.save!
+    request = build_request('ddbj_record/example.json')
 
     Sequence.ensure_records!
     Sequence.find_by!(scope: 'jpo_na').update!(
@@ -130,20 +123,12 @@ class ApplySubmissionRequestJobTest < ActiveSupport::TestCase
 
   # 前回の失敗の痕跡が残っていると、成功しているのに「今まさに失敗している」と読まれる。
   test 'clears the previous failure before applying' do
-    request = SubmissionRequest.new(
-      user:          users(:alice),
-      db:            'st26',
+    request = build_request('ddbj_record/example.json')
+
+    request.update!(
       error_code:    'TRD_R0012',
       error_message: 'jpo_na: no numbers left after QX (wanted 3 more)'
     )
-
-    request.ddbj_record.attach(
-      io:           file_fixture('ddbj_record/example.json').open,
-      filename:     'example.json',
-      content_type: 'application/json'
-    )
-
-    request.save!
 
     ApplySubmissionRequestJob.perform_now request
 
@@ -155,15 +140,7 @@ class ApplySubmissionRequestJobTest < ActiveSupport::TestCase
   end
 
   test 'refuses v3 records, transitions request to application_failed cleanly' do
-    request = SubmissionRequest.new(user: users(:alice), db: 'st26')
-
-    request.ddbj_record.attach(
-      io:           file_fixture('ddbj_record/v3_trad_gnm.json').open,
-      filename:     'v3_trad_gnm.json',
-      content_type: 'application/json'
-    )
-
-    request.save!
+    request = build_request('ddbj_record/v3_trad_gnm.json')
 
     # V3NotImplementedError is a StandardError so the job's bareword
     # rescue catches it; request transitions to :application_failed

--- a/test/jobs/apply_submission_request_job_test.rb
+++ b/test/jobs/apply_submission_request_job_test.rb
@@ -26,6 +26,47 @@ class ApplySubmissionRequestJobTest < ActiveSupport::TestCase
     assert histories.all? { it.action == 'create' && it.user == request.user }
   end
 
+  # LOCUS date は公開作業を行う人が決める値で、record に入って届く。列にも
+  # flatfile にも同じ日付が入らなければならない: 列に apply 日を入れて
+  # flatfile には record の日付を印字していたため、apply した瞬間から両者が
+  # 食い違い、後の regenerate が印字済みの日付を apply 日へ引き戻していた。
+  test 'takes the LOCUS date from the record, into both the column and the flatfile' do
+    request = build_request('ddbj_record/example.json') {|record|
+      record['sequences']['entries'].each { it['locus_date'] = '2026-08-13' }
+    }
+
+    ApplySubmissionRequestJob.perform_now request
+
+    submission = request.reload.submission
+
+    assert_equal ['2026-08-13'], submission.entries.distinct.pluck(:locus_date).map(&:to_s)
+    assert_includes submission.flatfile_na.download, '13-AUG-2026'
+  end
+
+  # `last_updated` は 2026-08 までのこのフィールドの名前で、既存の record は
+  # すべてその名前で書かれている。読めなくなると LOCUS 行の日付が全部空になる。
+  test 'still reads the date from a record written under the old name' do
+    request = build_request('ddbj_record/example.json') {|record|
+      record['sequences']['entries'].each { it['last_updated'] = '2026-08-13' }
+    }
+
+    ApplySubmissionRequestJob.perform_now request
+
+    submission = request.reload.submission
+
+    assert_equal ['2026-08-13'], submission.entries.distinct.pluck(:locus_date).map(&:to_s)
+    assert_includes submission.flatfile_na.download, '13-AUG-2026'
+  end
+
+  # 日付を言わない record のときだけ apply 日が立つ。
+  test 'falls back to the apply date when the record names none' do
+    request = build_request('ddbj_record/example.json')
+
+    ApplySubmissionRequestJob.perform_now request
+
+    assert_equal [Date.current], request.reload.submission.entries.distinct.pluck(:locus_date)
+  end
+
   # SystemStackError は StandardError ではないので、rescue を取り違えると
   # request が applying のまま取り残され、クライアントが status を永久に
   # ポーリングし続ける。終端状態 (application_failed) に落ちることを保証する。
@@ -132,5 +173,26 @@ class ApplySubmissionRequestJobTest < ActiveSupport::TestCase
     request.reload
     assert request.application_failed?
     assert_match(/v3 record application not yet implemented/, request.error_message)
+  end
+
+  private
+
+  # A request carrying a fixture record, with the parsed JSON handed to the
+  # block first so a test can say what it needs the record to contain.
+  def build_request(fixture)
+    record = JSON.parse(file_fixture(fixture).read)
+
+    yield record if block_given?
+
+    request = SubmissionRequest.new(user: users(:alice), db: 'st26')
+
+    request.ddbj_record.attach(
+      io:           StringIO.new(JSON.generate(record)),
+      filename:     File.basename(fixture),
+      content_type: 'application/json'
+    )
+
+    request.save!
+    request
   end
 end

--- a/test/jobs/regenerate_submission_flatfiles_job_test.rb
+++ b/test/jobs/regenerate_submission_flatfiles_job_test.rb
@@ -140,7 +140,7 @@ class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
 
     before = @submission.flatfile_na.download
 
-    assert_raises RuntimeError do
+    assert_raises RegenerateSubmissionFlatfilesJob::LocusDateDisagreement do
       RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, new_run, nil
     end
 
@@ -156,7 +156,7 @@ class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
     @submission.entries.update_all(locus_date: Date.new(2026, 8, 13))
 
     # 名指ししなかった kept は依然として食い違っているので、まだ止まる。
-    assert_raises RuntimeError do
+    assert_raises RegenerateSubmissionFlatfilesJob::LocusDateDisagreement do
       RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, new_run, Date.new(2026, 9, 1), accessions: [redated.accession]
     end
 

--- a/test/jobs/regenerate_submission_flatfiles_job_test.rb
+++ b/test/jobs/regenerate_submission_flatfiles_job_test.rb
@@ -131,6 +131,47 @@ class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
     assert @submission.reload.flatfile_na.attached?
   end
 
+  # 列と record が食い違ったまま日付を指定せずに走らせると、列の日付が公開されて
+  # しまう。2026-08-10、これで PATENT-386 の 5 件を直す regenerate が兄弟 62
+  # entry の LOCUS 日付を apply 日へ 4〜10 日巻き戻した。**コメントではなく、
+  # 走らせたら止まることで防ぐ。**
+  test 'refuses to regenerate while the column and the record disagree about the date' do
+    @submission.entries.update_all(locus_date: Date.new(2026, 8, 13))
+
+    before = @submission.flatfile_na.download
+
+    assert_raises RuntimeError do
+      RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, new_run, nil
+    end
+
+    assert_equal before, @submission.reload.flatfile_na.download,
+                 'the flatfile was rewritten despite the refusal'
+  end
+
+  # 日付を入れる entry については列が正なので、食い違っていても進む。名指しの
+  # redate もこの経路を通る。
+  test 'a date settles the disagreement for the entries it is written to' do
+    kept, redated = @submission.entries.order(:accession).to_a
+
+    @submission.entries.update_all(locus_date: Date.new(2026, 8, 13))
+
+    # 名指ししなかった kept は依然として食い違っているので、まだ止まる。
+    assert_raises RuntimeError do
+      RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, new_run, Date.new(2026, 9, 1), accessions: [redated.accession]
+    end
+
+    # 両方に日付を入れれば通り、両方がその日付で印字される。
+    RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, new_run, Date.new(2026, 9, 1),
+                                                accessions: [kept.accession, redated.accession]
+
+    assert_match(/01-SEP-2026/, @submission.reload.flatfile_na.download)
+
+    # 一度通れば record と列が揃うので、以後は日付なしの run でも止まらない。
+    RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, new_run, nil
+
+    assert_match(/01-SEP-2026/, @submission.reload.flatfile_na.download)
+  end
+
   test 'the history names the user who asked for the run' do
     RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, new_run, Date.new(2026, 7, 1)
 

--- a/test/lib/locus_date_backfill_test.rb
+++ b/test/lib/locus_date_backfill_test.rb
@@ -13,39 +13,56 @@ class LocusDateBackfillTest < ActiveSupport::TestCase
     ApplySubmissionRequestJob.perform_now @request
 
     @submission = @request.reload.submission
-    @submission.entries.update_all(locus_date: Date.new(2026, 7, 7))
+
+    # The legacy shape: the column carries the apply date (which is what the job
+    # wrote before it started reading the record), the record carries 2026-07-11.
+    @submission.entries.update_all(locus_date: @submission.entries.first.created_at.to_date)
   end
 
   test 'moves the column back to the date the request asked for' do
-    result = LocusDateBackfill.audit
+    changes = outcome.changes
 
-    assert_equal [[Date.new(2026, 7, 7), Date.new(2026, 7, 11)]], result.changes.map { [it.from, it.to] }.uniq
+    assert_equal [[apply_date, Date.new(2026, 7, 11)]], changes.map { [it.from, it.to] }.uniq
 
-    LocusDateBackfill.apply! result.changes
+    LocusDateBackfill.apply! changes
 
     assert_equal [Date.new(2026, 7, 11)], @submission.entries.reload.distinct.pluck(:locus_date)
   end
 
-  test 'leaves alone an entry named in except' do
+  # An entry whose date was set on purpose no longer carries the apply stamp, and
+  # restoring "what the request asked for" over it would undo that decision —
+  # PATENT-386's five, redated to 2026-08-13, are why this matters. No list of
+  # exceptions to remember.
+  test 'leaves alone an entry whose date was set deliberately' do
     kept = @submission.entries.order(:accession).first
 
-    result = LocusDateBackfill.audit(except: kept.accession)
+    kept.update! locus_date: Date.new(2026, 8, 13)
 
-    refute_includes result.changes.map { it.entry.id }, kept.id
-    assert_equal Date.new(2026, 7, 7), kept.reload.locus_date
+    refute_includes outcome.changes.map { it.entry.id }, kept.id
+  end
+
+  # ACCESSIONS reaches whole submissions to find the records; restoring the
+  # siblings was not what was asked for.
+  test 'only the named accessions are moved' do
+    named, sibling = @submission.entries.order(:accession).to_a
+
+    changes = outcome(accessions: named.accession).changes
+
+    assert_equal [named.id], changes.map { it.entry.id }
+    refute_includes changes.map { it.entry.id }, sibling.id
   end
 
   test 'finds nothing once the column already agrees' do
-    LocusDateBackfill.apply! LocusDateBackfill.audit.changes
+    LocusDateBackfill.apply! outcome.changes
 
-    assert_empty LocusDateBackfill.audit.changes
+    assert_empty outcome.changes
   end
 
   # The audit and the write are separate reads. A date that moved in between is
   # one this no longer knows the truth about, so the run stops rather than
   # overwriting the newer value.
-  test 'refuses to write when the date moved since the audit' do
-    changes = LocusDateBackfill.audit.changes
+  test 'refuses to write when the date moved since it was read' do
+    changes = outcome.changes
 
     @submission.entries.update_all(locus_date: Date.new(2026, 8, 13))
 
@@ -59,12 +76,21 @@ class LocusDateBackfillTest < ActiveSupport::TestCase
   test 'a request with no record is reported rather than passed over' do
     @request.ddbj_record.purge
 
-    result = LocusDateBackfill.audit
-    mine   = result.unexamined.find { it.submission == @submission }
+    mine = outcome
 
-    assert mine, 'the submission whose request lost its record was passed over silently'
-    assert_equal 'request has no record', mine.why
-    assert_empty result.changes
+    refute_predicate mine, :examined?
+    assert_equal 'request has no record', mine.unexamined
+    assert_empty mine.changes
+  end
+
+  test 'LIMIT and AFTER refuse anything that is not a number' do
+    assert_raises ArgumentError do
+      LocusDateBackfill.each_submission(after: 'LC000123').to_a
+    end
+
+    assert_raises ArgumentError do
+      LocusDateBackfill.each_submission(limit: 'all').to_a
+    end
   end
 
   # `Date.parse` would read `8/13` as this year's 13 August. A date the record
@@ -77,6 +103,13 @@ class LocusDateBackfillTest < ActiveSupport::TestCase
   end
 
   private
+
+  # The apply job stamps the column with the apply date when the record names no
+  # date; `setup` then moves it to something else to make the legacy shape, so
+  # the "still bears the apply stamp" test has to compare against created_at.
+  def apply_date = @submission.entries.first.created_at.to_date
+
+  def outcome(**) = LocusDateBackfill.each_submission(**).find { it.submission == @submission }
 
   def build_request(locus_date)
     record = JSON.parse(file_fixture('ddbj_record/example.json').read)

--- a/test/lib/locus_date_backfill_test.rb
+++ b/test/lib/locus_date_backfill_test.rb
@@ -1,0 +1,96 @@
+require 'test_helper'
+
+# The repair behind `rake locus_date:backfill`. Covered because it writes a date
+# that gets printed on published flatfiles, and because the case it must NOT
+# touch — an entry deliberately redated away from what its request asked for —
+# is the one that would undo the PATENT-386 correction.
+class LocusDateBackfillTest < ActiveSupport::TestCase
+  setup do
+    # A request whose record names 2026-07-11, applied while the job still wrote
+    # the apply date into the column: the shape of every legacy submission.
+    @request = build_request('2026-07-11')
+
+    ApplySubmissionRequestJob.perform_now @request
+
+    @submission = @request.reload.submission
+    @submission.entries.update_all(locus_date: Date.new(2026, 7, 7))
+  end
+
+  test 'moves the column back to the date the request asked for' do
+    result = LocusDateBackfill.audit
+
+    assert_equal [[Date.new(2026, 7, 7), Date.new(2026, 7, 11)]], result.changes.map { [it.from, it.to] }.uniq
+
+    LocusDateBackfill.apply! result.changes
+
+    assert_equal [Date.new(2026, 7, 11)], @submission.entries.reload.distinct.pluck(:locus_date)
+  end
+
+  test 'leaves alone an entry named in except' do
+    kept = @submission.entries.order(:accession).first
+
+    result = LocusDateBackfill.audit(except: kept.accession)
+
+    refute_includes result.changes.map { it.entry.id }, kept.id
+    assert_equal Date.new(2026, 7, 7), kept.reload.locus_date
+  end
+
+  test 'finds nothing once the column already agrees' do
+    LocusDateBackfill.apply! LocusDateBackfill.audit.changes
+
+    assert_empty LocusDateBackfill.audit.changes
+  end
+
+  # The audit and the write are separate reads. A date that moved in between is
+  # one this no longer knows the truth about, so the run stops rather than
+  # overwriting the newer value.
+  test 'refuses to write when the date moved since the audit' do
+    changes = LocusDateBackfill.audit.changes
+
+    @submission.entries.update_all(locus_date: Date.new(2026, 8, 13))
+
+    assert_raises RuntimeError do
+      LocusDateBackfill.apply! changes
+    end
+
+    assert_equal [Date.new(2026, 8, 13)], @submission.entries.reload.distinct.pluck(:locus_date)
+  end
+
+  test 'a request with no record is reported rather than passed over' do
+    @request.ddbj_record.purge
+
+    result = LocusDateBackfill.audit
+    mine   = result.unexamined.find { it.submission == @submission }
+
+    assert mine, 'the submission whose request lost its record was passed over silently'
+    assert_equal 'request has no record', mine.why
+    assert_empty result.changes
+  end
+
+  # `Date.parse` would read `8/13` as this year's 13 August. A date the record
+  # spells some other way is left alone rather than guessed at.
+  test 'a date that is not YYYY-MM-DD leaves the entry alone' do
+    assert_nil LocusDateBackfill.parse('8/13')
+    assert_nil LocusDateBackfill.parse('2026-225')
+    assert_nil LocusDateBackfill.parse(nil)
+    assert_equal Date.new(2026, 8, 13), LocusDateBackfill.parse('2026-08-13')
+  end
+
+  private
+
+  def build_request(locus_date)
+    record = JSON.parse(file_fixture('ddbj_record/example.json').read)
+
+    record['sequences']['entries'].each { it['locus_date'] = locus_date }
+
+    SubmissionRequest.new(user: users(:alice), db: 'st26').tap do |request|
+      request.ddbj_record.attach(
+        io:           StringIO.new(JSON.generate(record)),
+        filename:     'example.json',
+        content_type: 'application/json'
+      )
+
+      request.save!
+    end
+  end
+end

--- a/test/lib/locus_date_backfill_test.rb
+++ b/test/lib/locus_date_backfill_test.rb
@@ -94,12 +94,48 @@ class LocusDateBackfillTest < ActiveSupport::TestCase
   end
 
   # `Date.parse` would read `8/13` as this year's 13 August. A date the record
-  # spells some other way is left alone rather than guessed at.
-  test 'a date that is not YYYY-MM-DD leaves the entry alone' do
-    assert_nil LocusDateBackfill.parse('8/13')
-    assert_nil LocusDateBackfill.parse('2026-225')
+  # spells some other way is not guessed at — and is told apart from a record
+  # that names no date at all, which is nothing to report.
+  test 'a date that is not YYYY-MM-DD is unreadable rather than absent' do
+    assert_equal :unreadable, LocusDateBackfill.parse('8/13')
+    assert_equal :unreadable, LocusDateBackfill.parse('2026-225')
     assert_nil LocusDateBackfill.parse(nil)
+    assert_nil LocusDateBackfill.parse('')
     assert_equal Date.new(2026, 8, 13), LocusDateBackfill.parse('2026-08-13')
+  end
+
+  # Left alone, but named: the column stays on the apply date, so the guard will
+  # refuse the submission and somebody has to look at it.
+  test 'an unreadable original date is reported, not skipped in silence' do
+    @request.ddbj_record.purge
+    attach_record @request, '2026-8-13'
+
+    mine = outcome
+
+    assert_empty mine.changes
+    assert_equal @submission.entries.order(:accession).map(&:accession), mine.unreadable
+    assert_predicate mine, :needs_attention?
+  end
+
+  # Its record and its published flatfile already carry the apply date, so moving
+  # only the column would leave it disagreeing with itself — and unregeneratable.
+  test 'a submission that has already been regenerated is refused, not backfilled' do
+    EntryHistory.create! entry: @submission.entries.first, user: users(:alice), action: 'regenerate'
+
+    mine = outcome
+
+    refute_predicate mine, :examined?
+    assert_match(/already regenerated/, mine.unexamined)
+    assert_empty mine.changes
+  end
+
+  # 意図して設定された日付は報告される (黙って飛ばさない)。
+  test 'an entry dated by hand is named in the report' do
+    kept = @submission.entries.order(:accession).first
+
+    kept.update! locus_date: Date.new(2026, 8, 13)
+
+    assert_includes outcome.deliberate, kept.accession
   end
 
   private
@@ -112,18 +148,21 @@ class LocusDateBackfillTest < ActiveSupport::TestCase
   def outcome(**) = LocusDateBackfill.each_submission(**).find { it.submission == @submission }
 
   def build_request(locus_date)
+    SubmissionRequest.new(user: users(:alice), db: 'st26').tap do |request|
+      attach_record request, locus_date
+      request.save!
+    end
+  end
+
+  def attach_record(request, locus_date)
     record = JSON.parse(file_fixture('ddbj_record/example.json').read)
 
     record['sequences']['entries'].each { it['locus_date'] = locus_date }
 
-    SubmissionRequest.new(user: users(:alice), db: 'st26').tap do |request|
-      request.ddbj_record.attach(
-        io:           StringIO.new(JSON.generate(record)),
-        filename:     'example.json',
-        content_type: 'application/json'
-      )
-
-      request.save!
-    end
+    request.ddbj_record.attach(
+      io:           StringIO.new(JSON.generate(record)),
+      filename:     'example.json',
+      content_type: 'application/json'
+    )
   end
 end

--- a/test/models/flatfile/streaming_renderer_test.rb
+++ b/test/models/flatfile/streaming_renderer_test.rb
@@ -13,10 +13,10 @@ class Flatfile::StreamingRendererTest < ActiveSupport::TestCase
 
     entries = record.sequences.entries.map.with_index(1) {|entry, i|
       entry.with(
-        accession:    "AB00000#{i}",
-        locus:        "AB00000#{i}",
-        version:      1,
-        last_updated: '2026-06-01'
+        accession:  "AB00000#{i}",
+        locus:      "AB00000#{i}",
+        version:    1,
+        locus_date: '2026-06-01'
       )
     }
 

--- a/test/models/flatfile_test.rb
+++ b/test/models/flatfile_test.rb
@@ -13,10 +13,10 @@ class FlatfileTest < ActiveSupport::TestCase
 
     entries = record.sequences.entries.map.with_index(1) {|entry, i|
       entry.with(
-        accession:    "AB00000#{i}",
-        locus:        "AB00000#{i}",
-        version:      1,
-        last_updated: '2026-06-01'
+        accession:  "AB00000#{i}",
+        locus:      "AB00000#{i}",
+        version:    1,
+        locus_date: '2026-06-01'
       )
     }
 
@@ -38,10 +38,10 @@ class FlatfileTest < ActiveSupport::TestCase
 
     entries = record.sequences.entries.map.with_index(1) {|entry, i|
       entry.with(
-        accession:    "AB00000#{i}",
-        locus:        "AB00000#{i}",
-        version:      1,
-        last_updated: '2026-06-01'
+        accession:  "AB00000#{i}",
+        locus:      "AB00000#{i}",
+        version:    1,
+        locus_date: '2026-06-01'
       )
     }
 


### PR DESCRIPTION
[PATENT-386](https://ddbj-dev.atlassian.net/browse/PATENT-386) の 5 件を直した後、荒武さんが公開ファイルを refetch して diff を取ったところ、**同 submission の兄弟 62 entry の LOCUS 日付が 4〜10 日過去に戻っていました。**

原因は、同じ役割の値が 3 通りの意味を持っていたことです。

| 場所 | 実際に入っていた値 |
|---|---|
| record の `entries[].last_updated` | 公開作業者が決めた日付 (`submission-bulk-st26 --date`) |
| `entries.locus_date` 列 | **apply した日** |
| FF の LOCUS 行 | record の `last_updated` |
| API `locus_date` / admin | 列 = apply 日 |

**API は LOCUS 行に載っていない日付を `locus_date` として返し続けていました。** そして Regenerate は列から record を上書きするので、**Regenerate するだけで印字済みの日付が apply 日へ後退します**。

実測 (production、未 Regenerate の 20 submission): `last_updated − locus_date` は **+10 日が 18 件**、+9 と +4 が各 1 件。`--date` は日常的に使われており、両者は構造的に一致しません。

| | 件数 |
|---|---|
| ST.26 submission 総数 | 17,999 |
| Regenerate 履歴あり (既に発生済み) | 175 |
| **未 Regenerate (潜在的な対象)** | **17,824** |

## 位置付けを確定させました

**`locus_date` は LOCUS 行に印字される日付で、決めるのは公開作業を行う人**です。提出者のデータでもサーバが算出できる値でもありません (JPO の XML には入っていません)。CLAUDE.md に定義を書きました — **どこにも書かれていなかったことが今回の原因**です。

| 層 | 変更 |
|---|---|
| record のフィールド | `last_updated` → **`locus_date`** (v2/v3 スキーマに無い拡張なので仕様調整なし) |
| `Builders` | **両方の key を読む。** 既存 record も、`submission-bulk-st26` が現に書いている key もこれ |
| apply | **ずれの発生源。** 列に無条件で `today` を入れていたのを、record の日付から取る |
| Regenerate | 列から描画 (列 = 照会用コピー)。日付を入れる entry については列が正 |
| API / admin | 実際に LOCUS 行にある日付を返すようになる (スキーマ変更なし) |

## ガード — コメントではなく実行時の拒否

`RegenerateSubmissionFlatfilesJob` は、**日付を入れない entry について列と record が食い違っていたら拒否します** (`LocusDateDisagreement`)。`rescue_from` が submission 単位の失敗行にするので、全件 run はどれが準備できていないかを報告し、1 件も書き換えません。

**これが 62 entry の事故の代償です。** 「バックフィルを先に走らせる」とコメントに書くだけでは同じことが起きます。

## バックフィル (`rake locus_date:backfill`)

`entries.locus_date` を **request 側の record** (提出時のファイル、Regenerate に書き換えられない) から埋め直します。3 つを意図的に触らず、いずれも黙って飛ばさず報告します。

- **既に Regenerate 済みの submission** — record も列も apply 日なので今は一致しており、列だけ動かすとガードが永久に拒否します (刻印が消えるので 2 回目も no-op)。**公開済み FF 自体が apply 日を印字している**ので、直すべきは「日付を指定した Regenerate」です
- **apply の刻印が消えている entry** — 誰かが意図して設定した日付 (PATENT-386 の 5 件)。除外リストを覚えておく必要がない構造的な判定です
- **読めない日付** (`2026-8-13`) — 推測が今回の原因なので、しません

安全側の作り: submission 単位で走査しながら報告・書き込み (18,000 件を溜めない)、`WHERE locus_date = <読んだ値>` で書いて件数を検証、`ACCESSIONS` は entry 単位に絞り、照合できない accession は非ゼロ終了、`LIMIT`/`AFTER` は整数検証。

## そのほか

- **TRD_R0014** — record の `locus_date` が `YYYY-MM-DD` でなければ拒否。`Date.parse` は `8/13` を**実行した年**の 8 月 13 日と読み、それが公開 FF に印字されます。採番前なので 1 件も消費しません
- `DDBJRecord::LOCUS_DATE_FORMAT` を 1 箇所に。Regenerate 画面の日付だけが推測したままでした
- `entries.locus_date` の `default: CURRENT_TIMESTAMP` を削除 (テスト 2 箇所がこれに依存していたのが露出しました)

## 検証

`bin/rails test:all` — 1171 runs, 0 failures / `bin/rubocop` — 505 files clean。dev でガードの発火 (run に failure 行)、既に Regenerate 済みの submission が弾かれること、綴り誤りの abort を確認。`/code-review` を 4 巡通しています。

## merge 後の手順

**merge した瞬間から、バックフィルが済むまで日付を指定しない Regenerate は失敗します。それが意図です。**

1. deploy
2. `rake locus_date:backfill` を `LIMIT` で刻みながら → 17,824 submission の列を直す (読み取りのみの dry run が既定)
3. 報告された「要対応」を仕分ける — 175 件の既 Regenerate 分は**日付を指定した Regenerate** が必要 (公開済み FF が誤っているため)。これは公開判断なので運用側と相談
4. 兄弟 62 entry は 2 で直り、FF は元から正しい日付を印字しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)