### PR TITLE
バックフィルの UPDATE をまとめる (9.8M entry)

### DIFF
--- a/lib/locus_date_backfill.rb
+++ b/lib/locus_date_backfill.rb
@@ -140,14 +140,21 @@ module LocusDateBackfill
   # Checked per statement rather than per submission: a total lets one group's
   # over-write cancel another's under-write.
   def apply!(changes)
+    # Unprepared: every distinct slice size is a distinct statement, so an
+    # archive-wide run would PREPARE up to BATCH variants — past the adapter's
+    # 1,000 statement limit it starts DEALLOCATEing them again, and the plans it
+    # keeps carry up to BATCH parameters each. These are one-off writes; there is
+    # nothing for a cached plan to pay back.
     Entry.transaction do
-      changes.group_by { [it.from, it.to] }.each do |(from, to), group|
-        # Sliced so one enormous submission cannot build an IN list of tens of
-        # thousands of ids.
-        group.each_slice(BATCH) do |slice|
-          hit = Entry.where(id: slice.map { it.entry.id }, locus_date: from).update_all(locus_date: to, updated_at: Time.current)
+      Entry.connection.unprepared_statement do
+        changes.group_by { [it.from, it.to] }.each do |(from, to), group|
+          # Sliced so one enormous submission cannot build an IN list of tens of
+          # thousands of ids.
+          group.each_slice(BATCH) do |slice|
+            hit = Entry.where(id: slice.map { it.entry.id }, locus_date: from).update_all(locus_date: to, updated_at: Time.current)
 
-          raise "submission ##{slice.first.entry.submission_id}: #{slice.size} #{'entry'.pluralize(slice.size)} to move off #{from}, #{hit} moved — the dates changed since they were read" unless hit == slice.size
+            raise "submission ##{slice.first.entry.submission_id}: #{slice.size} #{'entry'.pluralize(slice.size)} to move off #{from}, #{hit} moved — the dates changed since they were read" unless hit == slice.size
+          end
         end
       end
     end

--- a/lib/locus_date_backfill.rb
+++ b/lib/locus_date_backfill.rb
@@ -42,6 +42,11 @@ module LocusDateBackfill
   ALREADY_REGENERATED = 'already regenerated: its record and its published flatfile carry the apply date, so redate it ' \
                         'with `Regenerate flatfiles` naming the date — this cannot fix it'.freeze
 
+  # How many ids go into one UPDATE's WHERE. Big enough that a 550-entry
+  # submission is one statement, small enough that the 27,000-entry ones are a
+  # handful rather than one enormous string.
+  BATCH = 2_000
+
   Change = Data.define(:entry, :from, :to)
 
   # One submission's worth of work, and everything about it a person has to see.
@@ -114,22 +119,40 @@ module LocusDateBackfill
     Outcome.new(submission:, changes:, unexamined: nil, unreadable:, deliberate:)
   end
 
-  # Per submission, so a long run can be stopped and resumed, and each entry is
-  # written with its expected current value in the WHERE clause: the read and the
-  # write are separate, and a date that moved in between is one this no longer
-  # knows the truth about.
+  # Per submission, so a long run can be stopped and resumed, and always with the
+  # expected current date in the WHERE clause: the read and the write are
+  # separate, and a date that moved in between is one this no longer knows the
+  # truth about.
+  #
+  # One statement per date, and the ids of the entries it read in the WHERE. The
+  # archive is 9.8 million entries over 17,999 submissions — 550 apiece, not the
+  # handful the first cut assumed — so a statement each would be nine million
+  # round trips.
+  #
+  # The ids are what make that safe. Naming the submission and the date instead,
+  # and checking the row count matched, was identity by proxy: between the read
+  # and the write one member can move off that date while a held-back entry
+  # moves onto it, the count still matches, and the held-back one is overwritten
+  # — the destruction this exists to prevent, reported as success. With the ids
+  # in the WHERE, a row that was not read cannot be touched however the table
+  # moves underneath.
+  #
+  # Checked per statement rather than per submission: a total lets one group's
+  # over-write cancel another's under-write.
   def apply!(changes)
-    written = 0
-
     Entry.transaction do
-      changes.each do |c|
-        written += Entry.where(id: c.entry.id, locus_date: c.from).update_all(locus_date: c.to, updated_at: Time.current)
-      end
+      changes.group_by { [it.from, it.to] }.each do |(from, to), group|
+        # Sliced so one enormous submission cannot build an IN list of tens of
+        # thousands of ids.
+        group.each_slice(BATCH) do |slice|
+          hit = Entry.where(id: slice.map { it.entry.id }, locus_date: from).update_all(locus_date: to, updated_at: Time.current)
 
-      raise "submission ##{changes.first.entry.submission_id}: expected to redate #{changes.size} #{'entry'.pluralize(changes.size)}, redated #{written} — the dates moved since they were read" unless written == changes.size
+          raise "submission ##{slice.first.entry.submission_id}: #{slice.size} #{'entry'.pluralize(slice.size)} to move off #{from}, #{hit} moved — the dates changed since they were read" unless hit == slice.size
+        end
+      end
     end
 
-    written
+    changes.size
   end
 
   def describe(outcome)

--- a/test/lib/locus_date_backfill_test.rb
+++ b/test/lib/locus_date_backfill_test.rb
@@ -29,6 +29,61 @@ class LocusDateBackfillTest < ActiveSupport::TestCase
     assert_equal [Date.new(2026, 7, 11)], @submission.entries.reload.distinct.pluck(:locus_date)
   end
 
+  # 9.8M entries means a statement each is nine million round trips. Written in
+  # one go when the group is every entry of the submission carrying that date.
+  test 'a whole submission is redated in one statement' do
+    changes = outcome.changes
+
+    assert_equal 2, changes.size
+
+    queries = []
+    sub     = ->(_, _, _, _, payload) { queries << payload[:sql] if payload[:sql].start_with?('UPDATE') }
+
+    ActiveSupport::Notifications.subscribed(sub, 'sql.active_record') do
+      LocusDateBackfill.apply! changes
+    end
+
+    assert_equal 1, queries.size, "expected one UPDATE, got #{queries.size}"
+    assert_equal [Date.new(2026, 7, 11)], @submission.entries.reload.distinct.pluck(:locus_date)
+  end
+
+  # The dangerous shape: an entry held back for a reason that has nothing to do
+  # with its date, so it still carries the apply stamp and shares it with the
+  # entries being moved. Naming the submission and the date in the WHERE — and
+  # trusting a row count to prove identity — would sweep it in. The ids are what
+  # make that impossible.
+  test 'a held-back entry sharing the same date is not swept into the batch' do
+    @request.ddbj_record.purge
+    attach_record @request, ['2026-07-11', '2026-8-13'] # the second cannot be read
+
+    held    = @submission.entries.order(:accession).last
+    changes = outcome.changes
+
+    assert_equal 1, changes.size
+    assert_equal held.locus_date, changes.sole.from, 'the held-back entry shares the date being moved off'
+
+    LocusDateBackfill.apply! changes
+
+    assert_equal Date.new(2026, 7, 11), @submission.entries.order(:accession).first.reload.locus_date
+    assert_equal held.locus_date,       held.reload.locus_date, 'the held-back entry was overwritten'
+  end
+
+  # And the same, one layer down: whatever moves under it between the read and
+  # the write, only the rows that were read can be touched.
+  test 'a row that moved onto the date since it was read is left alone' do
+    changes = outcome.changes
+    moved   = @submission.entries.order(:accession).last
+
+    # The audit read both; take one out of the change set, and move it away and
+    # back so the count would still match a submission-and-date WHERE.
+    changes = changes.reject { it.entry.id == moved.id }
+
+    LocusDateBackfill.apply! changes
+
+    assert_equal Date.new(2026, 7, 11), @submission.entries.order(:accession).first.reload.locus_date
+    assert_equal changes.sole.from,     moved.reload.locus_date, 'a row outside the change set was written'
+  end
+
   # An entry whose date was set on purpose no longer carries the apply stamp, and
   # restoring "what the request asked for" over it would undo that decision —
   # PATENT-386's five, redated to 2026-08-13, are why this matters. No list of
@@ -154,10 +209,12 @@ class LocusDateBackfillTest < ActiveSupport::TestCase
     end
   end
 
+  # `locus_date` may be one value for every entry, or one per entry in order.
   def attach_record(request, locus_date)
     record = JSON.parse(file_fixture('ddbj_record/example.json').read)
+    dates  = Array(locus_date)
 
-    record['sequences']['entries'].each { it['locus_date'] = locus_date }
+    record['sequences']['entries'].each_with_index {|entry, i| entry['locus_date'] = dates[i] || dates.first }
 
     request.ddbj_record.attach(
       io:           StringIO.new(JSON.generate(record)),

--- a/test/lib/locus_date_backfill_test.rb
+++ b/test/lib/locus_date_backfill_test.rb
@@ -36,52 +36,75 @@ class LocusDateBackfillTest < ActiveSupport::TestCase
 
     assert_equal 2, changes.size
 
-    queries = []
-    sub     = ->(_, _, _, _, payload) { queries << payload[:sql] if payload[:sql].start_with?('UPDATE') }
+    updates = []
 
-    ActiveSupport::Notifications.subscribed(sub, 'sql.active_record') do
-      LocusDateBackfill.apply! changes
-    end
+    capture_updates(updates) { LocusDateBackfill.apply! changes }
 
-    assert_equal 1, queries.size, "expected one UPDATE, got #{queries.size}"
+    assert_equal 1, updates.size, "expected one UPDATE, got #{updates.size}"
     assert_equal [Date.new(2026, 7, 11)], @submission.entries.reload.distinct.pluck(:locus_date)
   end
 
-  # The dangerous shape: an entry held back for a reason that has nothing to do
-  # with its date, so it still carries the apply stamp and shares it with the
-  # entries being moved. Naming the submission and the date in the WHERE — and
-  # trusting a row count to prove identity — would sweep it in. The ids are what
-  # make that impossible.
-  test 'a held-back entry sharing the same date is not swept into the batch' do
-    @request.ddbj_record.purge
-    attach_record @request, ['2026-07-11', '2026-8-13'] # the second cannot be read
+  # The shape the ids exist for. Three entries sharing the apply stamp: A and B
+  # are to be moved, C is held back because its request names no date at all. A
+  # then moves off that date before the write.
+  #
+  # Naming the submission and the date in the WHERE, and trusting a row count to
+  # prove identity, would find two rows on the date — B and C — count them equal
+  # to the two it meant to write, and overwrite C. Silently, and reported as
+  # success. With the ids in the WHERE only B is hit, the count no longer matches,
+  # and nothing is written.
+  test 'a change set that no longer matches the rows writes none of them' do
+    submission = seed_submission(['2026-07-11', '2026-07-11', nil])
+    a, b, c    = submission.entries.order(:accession).to_a
+    stamp      = a.locus_date
+    changes    = outcome(submission).changes
 
-    held    = @submission.entries.order(:accession).last
-    changes = outcome.changes
+    assert_equal [a.id, b.id], changes.map { it.entry.id }
+    assert_equal stamp, c.locus_date, 'C has to share the date being moved off for this to be the real case'
 
-    assert_equal 1, changes.size
-    assert_equal held.locus_date, changes.sole.from, 'the held-back entry shares the date being moved off'
+    a.update! locus_date: Date.new(2026, 9, 1)
 
-    LocusDateBackfill.apply! changes
+    assert_raises RuntimeError do
+      LocusDateBackfill.apply! changes
+    end
 
-    assert_equal Date.new(2026, 7, 11), @submission.entries.order(:accession).first.reload.locus_date
-    assert_equal held.locus_date,       held.reload.locus_date, 'the held-back entry was overwritten'
+    assert_equal Date.new(2026, 9, 1), a.reload.locus_date
+    assert_equal stamp,                b.reload.locus_date, 'B was written although the change set no longer held'
+    assert_equal stamp,                c.reload.locus_date, 'C was swept in by the batch'
   end
 
-  # And the same, one layer down: whatever moves under it between the read and
-  # the write, only the rows that were read can be touched.
-  test 'a row that moved onto the date since it was read is left alone' do
-    changes = outcome.changes
-    moved   = @submission.entries.order(:accession).last
+  # An entry held back for a reason that has nothing to do with its date still
+  # carries the apply stamp and shares it with the ones being moved.
+  test 'a held-back entry sharing the same date is not written' do
+    submission = seed_submission(['2026-07-11', nil])
+    moved, held = submission.entries.order(:accession).to_a
+    stamp       = held.locus_date
+    changes     = outcome(submission).changes
 
-    # The audit read both; take one out of the change set, and move it away and
-    # back so the count would still match a submission-and-date WHERE.
-    changes = changes.reject { it.entry.id == moved.id }
+    assert_equal [moved.id], changes.map { it.entry.id }
+    assert_equal stamp, changes.sole.from
 
     LocusDateBackfill.apply! changes
 
-    assert_equal Date.new(2026, 7, 11), @submission.entries.order(:accession).first.reload.locus_date
-    assert_equal changes.sole.from,     moved.reload.locus_date, 'a row outside the change set was written'
+    assert_equal Date.new(2026, 7, 11), moved.reload.locus_date
+    assert_equal stamp,                 held.reload.locus_date, 'the held-back entry was written'
+  end
+
+  # BATCH is 2,000 and a fixture has a handful of entries, so nothing would
+  # otherwise cross a slice boundary.
+  test 'a change set larger than one slice is written in several statements' do
+    changes = outcome.changes
+
+    assert_equal 2, changes.size
+
+    updates = []
+
+    with_batch 1 do
+      capture_updates(updates) { LocusDateBackfill.apply! changes }
+    end
+
+    assert_equal 2, updates.size, 'expected one statement per slice'
+    assert_equal [Date.new(2026, 7, 11)], @submission.entries.reload.distinct.pluck(:locus_date)
   end
 
   # An entry whose date was set on purpose no longer carries the apply stamp, and
@@ -200,7 +223,45 @@ class LocusDateBackfillTest < ActiveSupport::TestCase
   # the "still bears the apply stamp" test has to compare against created_at.
   def apply_date = @submission.entries.first.created_at.to_date
 
-  def outcome(**) = LocusDateBackfill.each_submission(**).find { it.submission == @submission }
+  def outcome(submission = @submission, **) = LocusDateBackfill.each_submission(**).find { it.submission == submission }
+
+  # A submission whose request names one date per entry (nil for "no date"),
+  # applied and then put into the legacy shape: the column carrying the apply
+  # date, which is what the job wrote before it read the record.
+  def seed_submission(dates)
+    request = SubmissionRequest.new(user: users(:alice), db: 'st26')
+    record  = JSON.parse(file_fixture('ddbj_record/example.json').read)
+    entry   = record['sequences']['entries'].first
+
+    record['sequences']['entries'] = dates.each_with_index.map {|date, i|
+      entry.merge('id' => "SEQ|JP|2026123456|B|#{i + 1}", 'locus_date' => date)
+    }
+
+    request.ddbj_record.attach(io: StringIO.new(JSON.generate(record)), filename: 'example.json', content_type: 'application/json')
+    request.save!
+
+    ApplySubmissionRequestJob.perform_now request
+
+    request.reload.submission.tap {|s| s.entries.update_all(locus_date: s.entries.first.created_at.to_date) }
+  end
+
+  def capture_updates(into, &)
+    listener = ->(_, _, _, _, payload) { into << payload[:sql] if payload[:sql].start_with?('UPDATE') }
+
+    ActiveSupport::Notifications.subscribed(listener, 'sql.active_record', &)
+  end
+
+  def with_batch(size)
+    original = LocusDateBackfill::BATCH
+
+    LocusDateBackfill.send :remove_const, :BATCH
+    LocusDateBackfill.const_set :BATCH, size
+
+    yield
+  ensure
+    LocusDateBackfill.send :remove_const, :BATCH
+    LocusDateBackfill.const_set :BATCH, original
+  end
 
   def build_request(locus_date)
     SubmissionRequest.new(user: users(:alice), db: 'st26').tap do |request|


### PR DESCRIPTION
`rake locus_date:backfill` (#1994) を production で流しはじめて、**規模の見積もりが桁違いだった**ことが分かりました。

| | |
|---|---|
| entry 総数 | **9,856,160** |
| submission 総数 | 17,999 |
| 1 submission あたり | **約 550** |

私は約 10 と見積もっていました (dev の 181,754 / 975 から類推)。最初の 200 submission を流した時点で 61,198 entry が動き、**1 entry 1 statement では 975 万回の往復**になることが判明したので、いったん止めて実装を変えます。

## 変更

日付ごとにまとめ、**読んだ entry の id を WHERE に入れます。**

```ruby
Entry.where(id: slice.map { it.entry.id }, locus_date: from).update_all(locus_date: to, updated_at: Time.current)
```

id リストは 2,000 件で切ります (550 件の submission は 1 statement、27,000 件のものも数回)。

### なぜ id を WHERE に入れるのか

最初は「submission と日付を指定し、行数が一致すれば同じ集合だろう」という形にしましたが、これは**同一性の代用**でした。読みと書きの間に、対象の 1 件がその日付から外れ、保留していた 1 件がその日付に入ると、**行数は一致したまま保留分が上書きされます** — このタスクが防ぐべき破壊が、成功として報告されます。

id を WHERE に置けば、下でテーブルがどう動いても読んでいない行には触れません。条件分岐も `COUNT` も要らなくなります。

**この race をテストで固定しました。** 3 entry が必要です (A・B を移動対象、C を保留、書き込み前に A が日付から外れる)。素朴な実装は C を書き換えて成功と報告し、この実装は B しか当たらないので件数が合わず何も書きません。

### そのほか

- 検証を **statement 単位**に。合計では、ある group の過剰書き込みが別の group の不足を打ち消します
- `unprepared_statement` で発行。スライス長ごとに別の statement になるため、全件 run では最大 2,000 通りを PREPARE し、adapter の `statement_limit` 1000 を超えると DEALLOCATE が回ります。一度しか使わない書き込みなので plan を作る意味がありません
- `each_slice` を実際に通るテストを追加 (BATCH=2000 に対し fixture は 2 entry なので、それまで 1 度も通っていませんでした)

## 検証

`bin/rails test:all` — 1175 runs, 0 failures / `bin/rubocop` — 505 files clean。`/code-review` を 2 巡通し、production の変更は「意味的に旧実装の論理積であり、書かれる行が増えることはない」と確認されています。

## 既に流した分

**submission 200 件 (id 343〜542、61,198 entry) は完了・検証済み**で、この変更の影響を受けません (`locus_date=2026-05-16`、`created_at=2026-05-12` を確認)。`AFTER=542` から続けられます。

## merge 後

1. `AFTER=542` から `LIMIT` で刻んで流す。最初のバッチで所要時間を測って報告します
2. 全件 dry run で `Nothing to redate` を確認
3. 別枠: 既に Regenerate された 175 submission は**公開済み FF が apply 日を印字している**ので、日付を指定した Regenerate が必要です。公開物を書き換える操作なので、対象と影響を整理して運用側に相談する材料を作ります

🤖 Generated with [Claude Code](https://claude.com/claude-code)