### PR TITLE
upload をコミットの前に出す (バイト列のない blob を作らない)

### DIFF
--- a/app/jobs/apply_submission_request_job.rb
+++ b/app/jobs/apply_submission_request_job.rb
@@ -75,15 +75,9 @@ class ApplySubmissionRequestJob < ApplicationJob
 
   def apply(request)
     request.ddbj_record.open do |file|
-      # v3 streaming + apply path is unimplemented — refuse explicitly
-      # to prevent silent NoMethodError downstream when
-      # DDBJRecord::StreamingParser (v2 SAJ-only) hits v3 input.
-      major, = DDBJRecord::SchemaVersionDetector.detect(file)
-      file.rewind
-      if major == '3'
-        raise DDBJRecord::V3NotImplementedError,
-              "SubmissionRequest ##{request.id}: v3 record application not yet implemented (Phase 6+)"
-      end
+      # StreamingParser is v2-shaped (SAJ only) and would fail downstream as a
+      # NoMethodError.
+      DDBJRecord.refuse_v3! file, "SubmissionRequest ##{request.id}"
 
       parser             = DDBJRecord::StreamingParser.new(file.path)
       metadata           = parser.metadata
@@ -165,8 +159,8 @@ class ApplySubmissionRequestJob < ApplicationJob
       generate_outputs record, entries, **{
         filename:     request.ddbj_record.filename,
         content_type: request.ddbj_record.content_type
-      } do |updates|
-        submission.update! updates
+      } do |outputs|
+        write_outputs! submission, outputs
       end
     end
   end

--- a/app/jobs/concerns/submission_output_writer.rb
+++ b/app/jobs/concerns/submission_output_writer.rb
@@ -1,6 +1,39 @@
 module SubmissionOutputWriter
   private
 
+  # The outputs, uploaded, and then the pointers swapped inside the caller's
+  # transaction.
+  #
+  # Handing the payloads to `update!` instead put the upload in an
+  # `after_commit`, so a storage failure left the row pointing at a blob whose
+  # bytes were never written — and because the row carries the checksum of what
+  # *should* be there, the next run generates the same bytes, compares equal, and
+  # skips. The byteless blob is then permanent, and nothing says so: the
+  # LocusDateDisagreement guard reads dates, and here the dates are right.
+  #
+  # Uploading first means a failure there raises before anything is written, and
+  # a failure in the transaction leaves blobs nobody points at — purged, the way
+  # Submission#prime_cache! does it.
+  #
+  # `nil` for an output is preserved: it means "there is no such file", and
+  # assigning nil is what detaches the one that is there (an AA flatfile that no
+  # longer has any AA entries).
+  def write_outputs!(submission, outputs)
+    blobs = outputs.transform_values { it && ActiveStorage::Blob.create_and_upload!(**it) }
+
+    begin
+      ActiveRecord::Base.transaction do
+        yield if block_given?
+
+        submission.update! blobs
+      end
+    rescue StandardError
+      blobs.each_value { it&.purge_later }
+
+      raise
+    end
+  end
+
   # `flatfile_omits` is entry ids the flatfile leaves out — canceled and
   # withdrawn entries. They stay in the DDBJ Record, which is the account
   # of what was submitted; the flatfile is what goes out, and a withdrawn

--- a/app/jobs/concerns/submission_output_writer.rb
+++ b/app/jobs/concerns/submission_output_writer.rb
@@ -11,24 +11,45 @@ module SubmissionOutputWriter
   # skips. The byteless blob is then permanent, and nothing says so: the
   # LocusDateDisagreement guard reads dates, and here the dates are right.
   #
-  # Uploading first means a failure there raises before anything is written, and
-  # a failure in the transaction leaves blobs nobody points at — purged, the way
-  # Submission#prime_cache! does it.
+  # Uploading first means a failure there raises before anything is written.
   #
   # `nil` for an output is preserved: it means "there is no such file", and
   # assigning nil is what detaches the one that is there (an AA flatfile that no
   # longer has any AA entries).
+  #
+  # Two things about the purge, both of which cost bytes rather than risk them:
+  #
+  # - It only runs on a rollback. `transaction` calls `after_commit` callbacks
+  #   after the COMMIT has succeeded but still inside its own call, and re-raises
+  #   anything they throw — Active Storage enqueues an AnalyzeJob there, so a
+  #   blip in the queue's database would arrive here as an exception with the row
+  #   already committed and pointing at these blobs. Purging then would delete
+  #   the bytes of a correct row: the very failure this exists to prevent, from
+  #   the other side. Reasoned rather than tested: transactional fixtures make
+  #   the job's transaction a savepoint, so `after_commit` never runs in a test
+  #   and there is nothing there to raise.
+  # - `committed` is set at the end of the block rather than after COMMIT, so a
+  #   COMMIT that itself fails leaves the blobs behind instead of purging them.
+  #   Orphan bytes are recoverable — PurgeUnattachedUploadsJob collects them —
+  #   and deleting the bytes of a live record is not.
   def write_outputs!(submission, outputs)
-    blobs = outputs.transform_values { it && ActiveStorage::Blob.create_and_upload!(**it) }
+    blobs     = {}
+    committed = false
 
     begin
+      # Accumulated as they go, so a failure part-way through still knows what it
+      # has already uploaded.
+      outputs.each {|name, payload| blobs[name] = payload && ActiveStorage::Blob.create_and_upload!(**payload) }
+
       ActiveRecord::Base.transaction do
         yield if block_given?
 
         submission.update! blobs
+
+        committed = true
       end
     rescue StandardError
-      blobs.each_value { it&.purge_later }
+      blobs.each_value { it&.purge_later } unless committed
 
       raise
     end

--- a/app/jobs/regenerate_submission_flatfiles_job.rb
+++ b/app/jobs/regenerate_submission_flatfiles_job.rb
@@ -52,34 +52,25 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
       filename:       submission.ddbj_record.filename,
       content_type:   submission.ddbj_record.content_type,
       flatfile_omits: retracted_entry_ids(rows)
-    } do |updates|
+    } do |outputs|
       # Written once, from the outputs the comparison was made against.
       # Generating a second time to write what was just compared doubled
       # the cost of every submission a run actually changed — which, on
       # the runs this tool exists for, is all of them.
-      next unless changed?(submission, updates)
+      next unless changed?(submission, outputs)
 
-      # The dates, the attachments that print them, and the history, in
-      # one commit. Written apart, a job that died between them left a
-      # flatfile saying one date and the row behind it saying another —
-      # and the next run would read the file as already correct, generate
-      # the same bytes, and skip, so the two would never be brought back
-      # together.
-      #
-      # The bytes are not in it: Active Storage defers the upload to
-      # after_commit, so a storage failure still leaves rows pointing at
-      # blobs that were never written — and the checksum on the row makes
-      # the next run skip them. Submission#prime_cache! is the shape that
-      # closes that (upload first, swap the pointer under the lock);
-      # ApplySubmissionRequestJob writes its outputs the same way this
-      # does, so it belongs in SubmissionOutputWriter rather than here.
-      ActiveRecord::Base.transaction do
+      # The dates, the attachments that print them, and the history, in one
+      # commit — and the bytes uploaded before it opens. Written apart, a job
+      # that died between them left a flatfile saying one date and the row
+      # behind it saying another, and the next run would read the file as
+      # already correct, generate the same bytes, and skip, so the two would
+      # never be brought back together. `write_outputs!` is where the upload
+      # ordering lives, so ApplySubmissionRequestJob gets it too.
+      write_outputs! submission, outputs do
         # By id when the run named accessions, and by submission when it
         # did not — the whole-submission case would otherwise send every
         # entry id back as an IN list.
         (accessions ? Entry.where(id: redated.map(&:id)) : submission.entries).update_all(locus_date: date) if date
-
-        submission.update! updates
 
         # Every entry of the submission, not only the redated ones: the
         # action is the rewrite of the file, and the file is theirs too.
@@ -106,19 +97,11 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
 
   private
 
-  # Detect v3 BEFORE parsing — v3 ddbj_records can be multi-GB and
-  # V3::Parser is full-document (Oj.load on the whole blob). Eating that
-  # allocation just to raise V3NotImplementedError would burn RAM and IO
-  # with no value. The detector peeks 64KB of head bytes.
   def read_record(submission)
     submission.ddbj_record.open do |file|
-      major, = DDBJRecord::SchemaVersionDetector.detect(file)
-      file.rewind
-
-      if major == '3'
-        raise DDBJRecord::V3NotImplementedError,
-              "Submission ##{submission.id}: flatfile regeneration not yet implemented for v3 records (Phase 6+)"
-      end
+      # The flatfile renderer is v2-shaped, so a v3 record cannot be
+      # regenerated. Refused before the body is read.
+      DDBJRecord.refuse_v3! file, "Submission ##{submission.id}"
 
       DDBJRecord.parse(file)
     end

--- a/app/jobs/regenerate_submission_flatfiles_job.rb
+++ b/app/jobs/regenerate_submission_flatfiles_job.rb
@@ -150,10 +150,10 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
   # nothing to say about a submission leaves its blobs, and its history,
   # alone — a new date is a change like any other, and reaches here as
   # one, because the outputs were built with it already applied.
-  def changed?(submission, updates)
-    attachment_changed?(submission.ddbj_record, updates[:ddbj_record]) ||
-      attachment_changed?(submission.flatfile_na, updates[:flatfile_na]) ||
-      attachment_changed?(submission.flatfile_aa, updates[:flatfile_aa])
+  def changed?(submission, outputs)
+    attachment_changed?(submission.ddbj_record, outputs[:ddbj_record]) ||
+      attachment_changed?(submission.flatfile_na, outputs[:flatfile_na]) ||
+      attachment_changed?(submission.flatfile_aa, outputs[:flatfile_aa])
   end
 
   # Retracting an entry changes the flatfile, so this is also what makes
@@ -197,11 +197,11 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
     }
   end
 
-  def attachment_changed?(attachment, payload)
-    if payload.nil?
+  def attachment_changed?(attachment, output)
+    if output.nil?
       attachment.attached?
     elsif attachment.attached?
-      Digest::MD5.file(payload[:io].path).base64digest != attachment.blob.checksum
+      Digest::MD5.file(output[:io].path).base64digest != attachment.blob.checksum
     else
       true
     end

--- a/app/models/ddbj_record.rb
+++ b/app/models/ddbj_record.rb
@@ -225,6 +225,27 @@ module DDBJRecord
   # template) still expect the v2 shape and will raise `NoMethodError` on
   # v3 input. No production producer emits v3 yet; consumer porting is
   # tracked in Phase 3 of tmp/data-migration/implementation-plan.md.
+  # Refuses a v3 record before anything reads its body.
+  #
+  # Two consumers cannot handle one — the flatfile renderer and
+  # StreamingParser are both v2-shaped — and each used to detect the version,
+  # rewind and compose the message itself. Version detection belongs to the
+  # thing that knows about versions, so a third consumer does not have to be
+  # told the procedure.
+  #
+  # Detected rather than parsed: a v3 record can be multi-GB and V3::Parser
+  # reads the whole document, so eating that allocation only to refuse would
+  # burn RAM and IO for nothing. The detector peeks at 64KB of head bytes.
+  def self.refuse_v3!(io, subject)
+    major, = SchemaVersionDetector.detect(io)
+
+    io.rewind
+
+    return unless major == '3'
+
+    raise V3NotImplementedError, "#{subject}: v3 records are not implemented yet (Phase 6+)"
+  end
+
   def self.parse(io)
     unless io.respond_to?(:rewind)
       raise ArgumentError, "DDBJRecord.parse requires a rewindable IO; got #{io.class}"

--- a/app/models/ddbj_record.rb
+++ b/app/models/ddbj_record.rb
@@ -213,18 +213,6 @@ module DDBJRecord
     :features
   )
 
-  # Dispatch on `schema_version`. v2 streams through SAJ (memory bound by the
-  # largest single entry — see CLAUDE.md / streaming_parser.rb); v3 currently
-  # buffers the full document because V3::Parser is non-streaming. The IO
-  # must be rewindable so the detector's head-peek does not steal the v2
-  # streaming path.
-  #
-  # The v3 path returns a `DDBJRecord::V3::Root`, which is structurally
-  # distinct from `DDBJRecord::Root`. As of Phase 2, downstream consumers
-  # (DDBJRecordValidator, RegenerateSubmissionFlatfilesJob, the flatfile
-  # template) still expect the v2 shape and will raise `NoMethodError` on
-  # v3 input. No production producer emits v3 yet; consumer porting is
-  # tracked in Phase 3 of tmp/data-migration/implementation-plan.md.
   # Refuses a v3 record before anything reads its body.
   #
   # Two consumers cannot handle one — the flatfile renderer and
@@ -246,6 +234,16 @@ module DDBJRecord
     raise V3NotImplementedError, "#{subject}: v3 records are not implemented yet (Phase 6+)"
   end
 
+  # Dispatch on `schema_version`. v2 streams through SAJ (memory bound by the
+  # largest single entry — see CLAUDE.md / streaming_parser.rb); v3 currently
+  # buffers the full document because V3::Parser is non-streaming. The IO
+  # must be rewindable so the detector's head-peek does not steal the v2
+  # streaming path.
+  #
+  # The v3 path returns a `DDBJRecord::V3::Root`, which is structurally
+  # distinct from `DDBJRecord::Root`, and consumers that cannot take one call
+  # `refuse_v3!` above rather than discovering it as a `NoMethodError`. No
+  # production producer emits v3 yet.
   def self.parse(io)
     unless io.respond_to?(:rewind)
       raise ArgumentError, "DDBJRecord.parse requires a rewindable IO; got #{io.class}"

--- a/app/models/regenerate_flatfiles_run.rb
+++ b/app/models/regenerate_flatfiles_run.rb
@@ -11,23 +11,6 @@ class RegenerateFlatfilesRun < ApplicationRecord
   # last time" — it cannot be re-derived from a list of numbers.
   TARGETS = %w[accessions all retry].freeze
 
-  # `force` is a retired option: runs made before dates were written by
-  # accession could be told to rewrite files whose content had not
-  # changed, because a date was applied only to what the comparison had
-  # already called changed — so setting one without it did nothing.
-  #
-  # Nothing reads the column, and nothing ever set it but that option, so
-  # it is only the `true` rows that still say anything. It is kept for
-  # them; the column is a candidate for dropping once they stop being
-  # interesting.
-
-  # How long a run may report nothing before it stops being believed.
-  #
-  # It is deliberately not read as "the workers are gone": a run queued
-  # behind a long migration has never touched its row either, and saying
-  # its jobs are lost would invite a second run over the same
-  # submissions. What it does is stop the screen polling for ever, and
-  # stop one silent run blocking every later one.
   STALE_AFTER = 1.hour
 
   belongs_to :retry_of, class_name: 'RegenerateFlatfilesRun', optional: true

--- a/app/models/regenerate_flatfiles_run.rb
+++ b/app/models/regenerate_flatfiles_run.rb
@@ -11,6 +11,13 @@ class RegenerateFlatfilesRun < ApplicationRecord
   # last time" — it cannot be re-derived from a list of numbers.
   TARGETS = %w[accessions all retry].freeze
 
+  # How long a run may report nothing before it stops being believed.
+  #
+  # It is deliberately not read as "the workers are gone": a run queued
+  # behind a long migration has never touched its row either, and saying
+  # its jobs are lost would invite a second run over the same
+  # submissions. What it does is stop the screen polling for ever, and
+  # stop one silent run blocking every later one.
   STALE_AFTER = 1.hour
 
   belongs_to :retry_of, class_name: 'RegenerateFlatfilesRun', optional: true

--- a/db/migrate/20260810145311_drop_force_from_regenerate_flatfiles_runs.rb
+++ b/db/migrate/20260810145311_drop_force_from_regenerate_flatfiles_runs.rb
@@ -1,0 +1,12 @@
+class DropForceFromRegenerateFlatfilesRuns < ActiveRecord::Migration[8.1]
+  # A retired option with nothing left to say. It let a run rewrite files whose
+  # content had not changed, which existed because a date was applied only to
+  # what the comparison had already called changed — so asking for a date
+  # without it did nothing. Dates are written by accession now and a date is a
+  # change like any other, so the option went; the column was kept in case its
+  # `true` rows explained an old run, and there are none (production: 5 runs, 0
+  # with force).
+  def change
+    remove_column :regenerate_flatfiles_runs, :force, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_101709) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_145311) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -206,7 +206,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_101709) do
     t.datetime "created_at", null: false
     t.integer "failed", default: 0, null: false
     t.datetime "finished_at"
-    t.boolean "force", default: false, null: false
     t.date "locus_date"
     t.text "numbers"
     t.integer "regenerated", default: 0, null: false

--- a/test/jobs/apply_submission_request_job_test.rb
+++ b/test/jobs/apply_submission_request_job_test.rb
@@ -149,7 +149,7 @@ class ApplySubmissionRequestJobTest < ActiveSupport::TestCase
 
     request.reload
     assert request.application_failed?
-    assert_match(/v3 record application not yet implemented/, request.error_message)
+    assert_match(/v3 records are not implemented yet/, request.error_message)
   end
 
   private

--- a/test/jobs/regenerate_submission_flatfiles_job_test.rb
+++ b/test/jobs/regenerate_submission_flatfiles_job_test.rb
@@ -199,6 +199,31 @@ class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
                  'the date moved although the file it prints was never written'
   end
 
+  # upload の途中で落ちた場合、それまでに上げた分を残さない。1 回目で落とす
+  # テストではこの経路を通らない。
+  test 'a failure part-way through the upload purges what it had already uploaded' do
+    uploaded = []
+    real     = ActiveStorage::Blob.method(:create_and_upload!)
+
+    stub = ->(**kwargs) {
+      raise Errno::ECONNREFUSED, 'seaweedfs' if uploaded.any?
+
+      real.call(**kwargs).tap { uploaded << it }
+    }
+
+    assert_raises Errno::ECONNREFUSED do
+      ActiveStorage::Blob.stub :create_and_upload!, stub do
+        RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, new_run, Date.new(2026, 9, 1)
+      end
+    end
+
+    assert_equal 1, uploaded.size, 'this pins nothing unless exactly one upload got through'
+
+    perform_enqueued_jobs
+
+    assert_not ActiveStorage::Blob.exists?(uploaded.sole.id), 'the blob uploaded before the failure was left behind'
+  end
+
   # 反対側: upload は成功したがコミットが落ちた場合、誰も指していない blob を
   # 残さない。
   test 'a failed commit purges the blobs it had already uploaded' do

--- a/test/jobs/regenerate_submission_flatfiles_job_test.rb
+++ b/test/jobs/regenerate_submission_flatfiles_job_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   setup do
     request = SubmissionRequest.new(user: users(:alice), db: 'st26')
 
@@ -45,7 +47,7 @@ class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
 
     assert_equal @submission,                        failure.submission
     assert_equal @submission.entries.first.accession, failure.label
-    assert_match(/not yet implemented for v3/,        failure.message)
+    assert_match(/v3 records are not implemented yet/, failure.message)
   end
 
   # A date is a change like any other. It used to be applied only to
@@ -170,6 +172,56 @@ class RegenerateSubmissionFlatfilesJobTest < ActiveSupport::TestCase
     RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, new_run, nil
 
     assert_match(/01-SEP-2026/, @submission.reload.flatfile_na.download)
+  end
+
+  # upload を after_commit に任せていたときは、コミット後にストレージ書き込みが
+  # 落ちると行だけが残った。しかも行は「あるべきバイト列」の checksum を持つので、
+  # 次のランは同じものを生成して一致と判断し skip する。実体のない blob が永久に
+  # 残り、それを知らせるものは何も無い (日付のガードは日付しか見ない)。
+  test 'a storage failure leaves the record and the flatfiles as they were' do
+    before_record   = @submission.ddbj_record.blob.id
+    before_flatfile = @submission.flatfile_na.blob.id
+    before_date     = @submission.entries.first.locus_date
+
+    boom = ->(*) { raise Errno::ECONNREFUSED, 'seaweedfs' }
+
+    assert_raises Errno::ECONNREFUSED do
+      ActiveStorage::Blob.stub :create_and_upload!, boom do
+        RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, new_run, Date.new(2026, 9, 1)
+      end
+    end
+
+    @submission.reload
+
+    assert_equal before_record,   @submission.ddbj_record.blob.id
+    assert_equal before_flatfile, @submission.flatfile_na.blob.id
+    assert_equal before_date,     @submission.entries.first.reload.locus_date,
+                 'the date moved although the file it prints was never written'
+  end
+
+  # 反対側: upload は成功したがコミットが落ちた場合、誰も指していない blob を
+  # 残さない。
+  test 'a failed commit purges the blobs it had already uploaded' do
+    uploaded = []
+
+    real = ActiveStorage::Blob.method(:create_and_upload!)
+    stub = ->(**kwargs) { real.call(**kwargs).tap { uploaded << it } }
+
+    assert_raises ActiveRecord::RecordInvalid do
+      ActiveStorage::Blob.stub :create_and_upload!, stub do
+        EntryHistory.stub :insert_all!, ->(*) { raise ActiveRecord::RecordInvalid.new(Entry.new) } do
+          RegenerateSubmissionFlatfilesJob.perform_now @submission, @admin, new_run, Date.new(2026, 9, 1)
+        end
+      end
+    end
+
+    assert_predicate uploaded, :any?, 'nothing was uploaded, so this pins nothing'
+
+    perform_enqueued_jobs
+
+    uploaded.each do |blob|
+      assert_not ActiveStorage::Blob.exists?(blob.id), "blob ##{blob.id} was left behind"
+    end
   end
 
   test 'the history names the user who asked for the run' do


### PR DESCRIPTION
## 1. upload が commit の外にあった

`submission.update!` に payload を渡すと Active Storage は upload を `after_commit` に回すので、**コミット後にストレージ書き込みが落ちると行だけが残ります。** しかも行は「あるべきバイト列」の checksum を持つため、次のランは同じものを生成して一致と判断し skip します。実体のない blob が永久に残り、**それを知らせるものは何もありません** — `LocusDateDisagreement` のガードは日付を見るので、日付が正しいこの穴は素通りします。

先に upload し、ポインタだけを呼び出し側の transaction で差し替えます (`Submission#prime_cache!` と同じ形)。`SubmissionOutputWriter#write_outputs!` に置いたので、**同じ穴のあった `ApplySubmissionRequestJob` も一緒に塞がりました。**

`nil` は保存します。「そのファイルは無い」の意味で、AA entry が無くなった submission の AA flatfile を外すのがこれです。

### purge の条件 (レビューで見つかった、私が作った穴)

最初の実装は `rescue` で無条件に purge していました。`transaction` は COMMIT 成功後に `after_commit` を自分の呼び出しの中で走らせ、そこで投げられたものを再 raise します。Active Storage は `AnalyzeJob` をそこで enqueue するので、キューの DB が一瞬落ちればここに例外として届き、**正しく commit された行が指すバイト列を消す** — 塞いだつもりの穴の裏返しでした。

rollback したときだけ purge します。`committed` は block の末尾で立てるので、COMMIT 自体が失敗した場合は purge せず blob が残ります。孤児のバイト列は `PurgeUnattachedUploadsJob` が回収できますが、生きている行のバイト列を消すのは取り返しがつきません。

**この分岐はテストしていません。** トランザクショナルフィクスチャでは `transaction` が savepoint になり `after_commit` が走らないので、投げるものがありません。コードにその旨を書いてあります。

### upload の途中失敗 (同じくレビュー由来)

`transform_values` が `begin` の外にあったので、1 つ目が成功して 2 つ目が落ちると 1 つ目が誰にも指されず残っていました。逐次 accumulate に変え、**1 回だけ成功させてから落とす**テストを追加しています。

## 2. v3 の拒否を 1 箇所に寄せた

`DDBJRecord` が version を検出できるのに、`detect` → `rewind` → 文言という手順を呼び出し元 3 箇所が覚えていました。`DDBJRecord.refuse_v3!` に寄せたので、次の consumer が手順を知る必要はありません。本文を読まずに検出する理由 (v3 は multi-GB で `V3::Parser` は全文読み) もそこに移しました。

## 3. `runs.force` を落とした

読み手がおらず、意味があるのは `true` の行だけですが、**production には 1 件もありません** (runs 5 件中 0)。

`null: false` の列を落とすので、デプロイ中に旧コンテナが `RegenerateFlatfilesRun.create!` を実行すると失敗する窓があります。影響は「デプロイ中に管理画面で Regenerate を押した 1 回」で、死んだ列のために 2 回デプロイするのは不釣り合いと判断しました。

## 4. 見送り: 生成物の MD5 の二重計算

`changed?` と Active Storage の unfurl の両方で計算しているのは事実です。ただし直すには `build_after_unfurling` / `upload_without_unfurling` が必要で、`CreateOne#upload` に no-op の分岐があります。archive 全件のランは終わっており、今後は submission 単位の実行が主なので、**いま払う複雑さに見合いません。** 再び全件ランが必要になったときに、その時の Active Storage の実装を見て入れるのが良いと思います。

## そのほか

- `STALE_AFTER` のコメントを `force` のものと一緒に消していたので復元
- `refuse_v3!` を `parse` の doc コメントと `parse` の間に挿入してしまい、コメントが別メソッドの説明になっていたので位置を直す
- `changed?` / `attachment_changed?` の引数名を `outputs` / `output` に揃える

## 検証

`bin/rails test:all` — 1178 runs, 0 failures / `bin/rubocop` — 506 files clean。`/code-review` を 1 巡通しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)