### PR TITLE
旧名フォールバックを「いつ消せるか」ごと書き残す

### DIFF
--- a/app/jobs/regenerate_submission_flatfiles_job.rb
+++ b/app/jobs/regenerate_submission_flatfiles_job.rb
@@ -179,6 +179,15 @@ class RegenerateSubmissionFlatfilesJob < ApplicationJob
       # Refused per submission. `rescue_from` turns it into a failure row, so a
       # run reports exactly which submissions are not ready and rewrites none of
       # them.
+      #
+      # A record with no date at all is nothing to compare against, so it
+      # passes. That is also what makes the old-name fallback in
+      # DDBJRecord::Builders worth keeping rather than merely harmless: without
+      # it every pre-rename record would arrive here blank, and the ~18,000
+      # submissions this guard was written for would stop being compared. The
+      # comment there says when the fallback can go. Refusing a blank instead is
+      # not an option — the only escape below is naming the accession with a
+      # date, and a run carries one date for all of them.
       unless dated.include?(acc) || entry.locus_date.blank? || entry.locus_date == acc.locus_date.to_s
         raise LocusDateDisagreement,
               "Submission ##{acc.submission_id}: #{entry.id} has LOCUS date #{entry.locus_date} in its record and " \

--- a/app/models/ddbj_record/builders.rb
+++ b/app/models/ddbj_record/builders.rb
@@ -192,11 +192,38 @@ module DDBJRecord
         locus:           h['locus'],
         version:         h['version'],
 
-        # `last_updated` is what this field was called before 2026-08, and
-        # reading it is not only about the archive: submission-bulk-st26 still
-        # writes that key (`lib/st26/submission.rb`), so it is a live ingest
-        # path. Dropping it before the client is updated would blank the LOCUS
-        # date on every *new* submission as well as every stored one.
+        # `last_updated` is what this field was called before 2026-08-10. Every
+        # record stored before then still spells it that way — the backfill put
+        # the operator's date back into `entries.locus_date` and never touched a
+        # blob — so this is what lets the ~18,000 submissions applied before the
+        # rename still be read for the date they were published with.
+        #
+        # **Removing it would not break the output; it would stop the output
+        # being checked.** RegenerateSubmissionFlatfilesJob's guard reads a
+        # record with no date as nothing to compare against
+        # (`entry.locus_date.blank?`), so those submissions would render from
+        # the column unverified rather than refuse. The column is backfilled and
+        # very likely right — but on the ones the backfill deliberately skipped
+        # (already regenerated, or a date it could not read) that comparison is
+        # the last thing that would catch a wrong one.
+        #
+        # Making that guard refuse a blank instead is not the way out: the only
+        # escape from it is naming the accession with a date, so every one of
+        # these submissions would need a date to be regenerated at all — and a
+        # run carries one date, which cannot reproduce dates that differ per
+        # entry.
+        #
+        # **When this can go: when nothing spells it the old way any more.**
+        # Regenerating a submission rewrites its record under the new name, so
+        # the population shrinks on its own, and disappears for free on the day
+        # something else calls for an archive-wide regeneration. It does not
+        # need forcing. Two tests in apply_submission_request_job_test.rb fail
+        # if the fallback goes early, and they say why.
+        #
+        # submission-bulk-st26 carries the same fallback on its reading side
+        # (`lib/st26/submission.rb`, `persist_artifacts`), for these same
+        # records — its `reconcile` downloads these very blobs. One population,
+        # two fallbacks: they retire together, not one at a time.
         #
         # `.presence`, because `''` is truthy: a record carrying an empty
         # `locus_date` beside a real `last_updated` would otherwise lose the date

--- a/app/models/ddbj_record/builders.rb
+++ b/app/models/ddbj_record/builders.rb
@@ -198,14 +198,24 @@ module DDBJRecord
         # blob — so this is what lets the ~18,000 submissions applied before the
         # rename still be read for the date they were published with.
         #
-        # **Removing it would not break the output; it would stop the output
-        # being checked.** RegenerateSubmissionFlatfilesJob's guard reads a
+        # **Removing it would stop the output being checked, and on one path
+        # would break it.** RegenerateSubmissionFlatfilesJob's guard reads a
         # record with no date as nothing to compare against
         # (`entry.locus_date.blank?`), so those submissions would render from
         # the column unverified rather than refuse. The column is backfilled and
         # very likely right — but on the ones the backfill deliberately skipped
         # (already regenerated, or a date it could not read) that comparison is
         # the last thing that would catch a wrong one.
+        #
+        # The path that breaks is ingest rather than the archive: apply reads
+        # the record the client uploaded, and a checkout of submission-bulk-st26
+        # from before its own rename still sends the old key. Without this the
+        # date would be unreadable, apply would stamp its own date into the
+        # column and the record alike, and the guard would see the two agree —
+        # the 62-entry incident, at the point of ingest. Nothing on this side
+        # pins the client's version. (A request validated before the rename is
+        # not the same worry: one may only be applied within a day of being
+        # validated, so that window closes on its own.)
         #
         # Making that guard refuse a blank instead is not the way out: the only
         # escape from it is naming the accession with a date, so every one of
@@ -217,8 +227,8 @@ module DDBJRecord
         # Regenerating a submission rewrites its record under the new name, so
         # the population shrinks on its own, and disappears for free on the day
         # something else calls for an archive-wide regeneration. It does not
-        # need forcing. Two tests in apply_submission_request_job_test.rb fail
-        # if the fallback goes early, and they say why.
+        # need forcing. `apply_submission_request_job_test.rb` fails if the
+        # fallback goes early — one test, named for the reason.
         #
         # submission-bulk-st26 carries the same fallback on its reading side
         # (`lib/st26/submission.rb`, `persist_artifacts`), for these same


### PR DESCRIPTION
`DDBJRecord::Builders#build_entry` の `h['locus_date'].presence || h['last_updated']` を消せるか検討して、**消さない**ことにした。その判断が残っていないと、次に同じ検討をした人が同じところまで辿り直すことになるので書き残す。

## 外すと何が起きるか

archive については出力は壊れない。壊れるのは**検査**の方。

`RegenerateSubmissionFlatfilesJob` のガードは、record に日付が無ければ照合するものが無いとして素通りする（`entry.locus_date.blank?`）。フォールバックを外すと改名前の record はすべてここで blank になるので、~18,000 submission が列から**無検証で**描画されるようになる。

列はバックフィル済みなので出力自体は正しい。ただしバックフィルが手を出さなかった submission（既に Regenerate 済みのもの、日付が読めなかったもの）では、その照合が最後の砦になる。

## 出力が静かに壊れる経路が 1 つある

**ingest 側。** apply が読むのは client がアップロードした request の record で、**submission-bulk-st26 の改名（#87）より前の checkout は今も旧名を送る**。フォールバックが無ければ日付が読めず、apply が自分の日付を列と record の**両方**に書き、両者は一致するのでガードは黙る — **62 entry の事故が ingest 側で再現する。** サーバ側に client の版を縛る仕組みは無い。

残す理由としてはこれが最も強い。なお改名前に validate された request は別の話で、validate から 1 日以内しか apply できないので窓は自然に閉じる（`submissions_controller.rb`）。

## ガード側で blank を拒否にする案は成立しない

ガードを抜けられるのは `dated.include?(acc)` — accession を日付付きで名指しする経路だけ。blank を拒否にすると、旧名 record を持つ submission は日付を指定しないと Regenerate できなくなる。日付を変えたくないのに日付を指定させられるうえ、run 1 回につき 1 日付なので entry ごとに異なる既存の日付は再現できない。

## いつ消せるか

旧名で書かれた record が無くなったとき。Regenerate は record を新しい名前で書き直すので母集団は自然に減り、別の理由で全件 Regenerate をやる日が来ればついでに消える。強制する必要はない。

早すぎる削除は `test/jobs/apply_submission_request_job_test.rb` が捕まえる — **1 本**、`'still reads the date from a record written under the old name'`。`||` を外して全体を走らせると 1178 runs でこれだけが落ちる。

## あわせて

ガード側（`build_entries`）にも、blank 素通りが意図的であることと、それがフォールバックを残す理由でもあることを書いた。ガードだけ読んだ人が blank 素通りを緩みと見て締めにいくのを防ぐため。

クライアント側の対応する PR: ddbj/submission-bulk-st26#88

コメントのみの変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)