### PR TITLE
Add sets: submissions that belong together, and the people they belong to

### DIFF
--- a/app/controllers/accessions_controller.rb
+++ b/app/controllers/accessions_controller.rb
@@ -13,8 +13,10 @@ class AccessionsController < ApplicationController
     keyset_page(scope)
   end
 
+  # Readable, like the list it is reached from. `owned_entries` below is
+  # the flat synchronisation walk and stays "mine".
   def show
-    @accession = owned_entries.find_by!(accession: params[:number])
+    @accession = readable_entries.find_by!(accession: params[:number])
   end
 
   private
@@ -38,11 +40,21 @@ class AccessionsController < ApplicationController
   def scoped_entries
     return owned_entries unless nested_submission_id
 
-    current_user.submissions.find(nested_submission_id).entries
+    # Readable, not owned. The nested list is what the submission's own
+    # screen shows, and that screen now opens for a set's members — the
+    # accessions are a large part of why somebody looks at a colleague's
+    # submission at all. The flat list below stays "mine": it is a
+    # synchronisation walk, and widening it would put other people's rows
+    # into a local copy that is meant to be one submitter's.
+    Submission.readable_by(current_user).find(nested_submission_id).entries
   end
 
   def owned_entries
     Entry.joins(:submission).merge(current_user.submissions)
+  end
+
+  def readable_entries
+    Entry.joins(:submission).merge(Submission.readable_by(current_user))
   end
 
   # A page of the nested list is read by a person: they want to know how

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,35 @@ class ApplicationController < ActionController::API
   include Pagy::Method
   include WebRedirect
 
+  # Refusing something the caller can see. Where the caller cannot see it
+  # the answer is still a 404 — scoping the lookup, as
+  # SubmissionRequestsController does — so this is only for the case
+  # where hiding the thing would be the confusing answer: you are in this
+  # set, you just are not the one who may rename it.
+  class Forbidden < StandardError
+    include PublicError
+  end
+
+  # The request is understood and refused on its own terms. Not a
+  # validation failure on a record, so it has nowhere else to come from.
+  class UnprocessableContent < StandardError
+    include PublicError
+  end
+
   before_action :authenticate!
+
+  # Views render without a `current_user` helper — ActionController::API
+  # carries no helper machinery — and some of them have to say what the
+  # caller may do rather than leave the client to re-derive the rule. Nil
+  # on the unauthenticated endpoints, which is what they mean.
+  before_action { @viewer = current_user }
+
+  # A curator is acting as this submitter. Asked by the writes that
+  # record who did them — see `refuse_proxy!`. Reading it forces the
+  # authentication it describes, so it is never stale.
+  def proxying?
+    current_user && @proxying == true
+  end
 
   def current_user
     return @current_user if defined?(@current_user)
@@ -12,6 +40,8 @@ class ApplicationController < ActionController::API
       next nil unless user = token.count('.') == 2 ? find_user_from_jwt(token) : find_user_from_api_key(token)
 
       if user.admin? && uid = request.headers['X-Dway-User-Id']
+        @proxying = true
+
         User.find_by(uid:)
       else
         user
@@ -20,6 +50,25 @@ class ApplicationController < ActionController::API
   end
 
   private
+
+  def forbid!(message)
+    raise Forbidden, message
+  end
+
+  # Acting as somebody else is for helping them with what they submitted.
+  # It does not extend to deciding who they collaborate with: a set
+  # membership and an invitation both record who did it, and under a
+  # proxy that record would name the person being helped rather than the
+  # curator doing the helping. Reading is untouched.
+  def refuse_proxy!
+    return unless proxying?
+
+    forbid! 'Sets cannot be changed while acting as another account.'
+  end
+
+  def refuse!(message)
+    raise UnprocessableContent, message
+  end
 
   def authenticate!
     return if current_user

--- a/app/controllers/concerns/accession_summaries.rb
+++ b/app/controllers/concerns/accession_summaries.rb
@@ -1,0 +1,27 @@
+# {submission_id => [first_accession, count]} for the two databases that
+# keep their accessions in a bag — BioSample samples and ST.26 entries —
+# via one grouped MIN / COUNT per model.
+#
+# A list page prints one accession and one count per row. Without this it
+# gets them by loading the bag, and a page can hold several submissions of
+# 27K entries each.
+module AccessionSummaries
+  extend ActiveSupport::Concern
+
+  private
+
+  def sample_accession_summaries(submissions)
+    summarise(Sample, submissions.select(&:biosample_db?).map(&:id))
+      .merge(summarise(Entry, submissions.select(&:st26_db?).map(&:id)))
+  end
+
+  def summarise(model, ids)
+    return {} if ids.empty?
+
+    model
+      .where(submission_id: ids)
+      .group(:submission_id)
+      .pluck(:submission_id, Arel.sql('MIN(accession)'), Arel.sql('COUNT(accession)'))
+      .to_h {|sid, first, count| [sid, [first, count]] }
+  end
+end

--- a/app/controllers/concerns/enum_filterable.rb
+++ b/app/controllers/concerns/enum_filterable.rb
@@ -24,7 +24,10 @@ module EnumFilterable
   # script looping on a stale filter value is a client mistake reported
   # to the client — turning each one into an error event would bury the
   # faults that are ours.
-  class UnknownFilterValue < ActionController::BadRequest; end
+  class UnknownFilterValue < ActionController::BadRequest
+    # The message names the value the caller sent and what was expected.
+    include PublicError
+  end
 
   # What of the client's input is quoted back. The parameter is not
   # necessarily the small list of strings it is supposed to be —

--- a/app/controllers/concerns/public_error.rb
+++ b/app/controllers/concerns/public_error.rb
@@ -1,0 +1,33 @@
+# Whether an exception's message belongs in the response body.
+#
+# Include this in an error class whose message is a sentence written for
+# whoever will read it — "Only the owner can rename a set", not
+# "PG::UniqueViolation: ERROR: duplicate key value violates …".
+#
+# Rails' own messages are written for us. Some of them recite the query
+# that produced them: `find_by!` on a scope names every column of the
+# WHERE clause, which on an unauthenticated endpoint hands out the
+# schema to anybody who passes a wrong token.
+module PublicError
+  # The `find(id)` form names only what the caller asked for and is
+  # genuinely useful in an API. The relation form names our columns.
+  WHERE_CLAUSE = '[WHERE'
+
+  def self.message_for(exception, fallback:)
+    # Rails' default `message` is the class name when nothing was given.
+    return fallback if exception.message == exception.class.to_s
+    return exception.message if exception.is_a?(PublicError)
+
+    # "Validation failed: Email is already a member of this set." Every
+    # validation in this application is a rule somebody typing into a form
+    # is meant to read, and the message is assembled from the attribute
+    # name and the sentence the model wrote. Withholding it turns the two
+    # most likely answers on any form — already taken, cannot be blank —
+    # into a status word.
+    return exception.message if exception.is_a?(ActiveRecord::RecordInvalid)
+
+    return exception.message if exception.is_a?(ActiveRecord::RecordNotFound) && exception.message.exclude?(WHERE_CLAUSE)
+
+    fallback
+  end
+end

--- a/app/controllers/concerns/set_contents.rb
+++ b/app/controllers/concerns/set_contents.rb
@@ -1,0 +1,86 @@
+# What is in a set, loaded the way a list page needs it: the curation
+# state and accession summary for every submission on the page in one
+# query each rather than per row — and only for the page.
+#
+# Paginated because there is no ceiling on what a set holds. A study
+# that ran for three years is hundreds of submissions, each of which
+# renders a progress block, and the set screen is not a place to
+# discover that by timing out.
+module SetContents
+  extend ActiveSupport::Concern
+
+  included do
+    include AccessionSummaries
+    include Pagy::Method
+  end
+
+  private
+
+  # Take the set's own row, then ask again whether the caller is still
+  # in it.
+  #
+  # Loading the set established that they were; a removal that starts
+  # after that and commits before this write would otherwise leave the
+  # thing they wrote behind — a submission nobody in the set can take
+  # out, or an invitation that walks its sender back in. The remover
+  # holds the same lock, so one of the two goes second and finds out.
+  def within_submission_set_membership(set)
+    set.with_lock do
+      raise ActiveRecord::RecordNotFound, "Couldn't find SubmissionSet with 'id'=#{set.id}" unless set.member?(current_user)
+
+      yield
+    end
+  end
+
+  def load_set_contents
+    scope = @set.inclusions
+                  .includes(submission_request: [:user, {submission: :project}])
+                  .order(:created_at, :id)
+
+    pagy, @inclusions = pagy(scope)
+
+    response.headers.merge! pagy.headers_hash
+
+    requests = @inclusions.map(&:submission_request)
+
+    @states                 = CurationState.batch(requests)
+    @bs_accession_summaries = sample_accession_summaries(requests.filter_map(&:submission))
+
+    # Only the viewer's own. An unread count says a conversation is going
+    # on, and the conversations that predate a set are between one
+    # submitter and DDBJ — being able to read somebody's submission here
+    # is not being party to that.
+    @unread_counts =
+      SubmissionMessage
+        .curator_role.unread
+        .where(submission_request_id: requests.select { it.user_id == current_user.id }.map(&:id))
+        .group(:submission_request_id)
+        .count
+
+    @counts = self.class.set_counts([@set.id])
+
+    # How much goes with each member if they are removed. Counted here
+    # rather than in the browser: the submissions on screen are one page
+    # of however many there are, so counting what is visible would tell
+    # somebody "0 submissions" while the removal took sixty out.
+    @submission_counts =
+      @set.inclusions
+            .joins(:submission_request)
+            .group('submission_requests.user_id')
+            .count
+  end
+
+  class_methods do
+    # Three COUNTs over however many sets are being rendered, rather
+    # than loading the rows to call `size` on them. Keyed by set id in
+    # both the one-set and the many-set case, so the partial that
+    # reads them does not have to know which it is looking at.
+    def set_counts(ids)
+      {
+        members:     SubmissionSetMember.joined.where(submission_set_id: ids).group(:submission_set_id).count,
+        invited:     SubmissionSetMember.pending.where(submission_set_id: ids).group(:submission_set_id).count,
+        submissions: SubmissionSetInclusion.where(submission_set_id: ids).group(:submission_set_id).count
+      }
+    end
+  end
+end

--- a/app/controllers/invitation_acceptances_controller.rb
+++ b/app/controllers/invitation_acceptances_controller.rb
@@ -1,0 +1,44 @@
+# Walking through the link. Authenticated, because this is the moment an
+# account is attached to the seat.
+#
+# The token is what is checked, not the address it was mailed to. See
+# SubmissionSetMember for why, and for what the roster shows in exchange.
+class InvitationAcceptancesController < ApplicationController
+  include SetContents
+
+  # Joining a set is a membership write like any other, and the row
+  # records the account that made it — under a proxy that would be the
+  # person being helped rather than the curator helping.
+  before_action :refuse_proxy!
+
+  def create
+    member = SubmissionSetMember.find_by!(invitation_token: params.expect(:invitation_token).presence)
+    @set = member.set
+
+    # Under a lock, and re-read inside it. Two people holding the same
+    # forwarded link would otherwise both pass the checks and both write
+    # the row: the loser is told they joined and has not, with the link
+    # already spent.
+    @set.with_lock do
+      member.reload
+
+      # Already in, by some other route — a second invitation, or this one
+      # from another tab. Not an error: they wanted to be in the set and
+      # they are. The invitation is spent rather than left outstanding for
+      # ever, which is what used to make it block the set's deletion.
+      if @set.member?(current_user)
+        member.destroy! if member.pending?
+        next
+      end
+
+      refuse! 'This invitation has already been used.' if member.joined?
+      refuse! 'This invitation has expired. Ask a member of the set to send it again.' if member.invitation_expired?
+
+      member.accept!(current_user)
+    end
+
+    @counts = self.class.set_counts([@set.id])
+
+    render status: :created
+  end
+end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,0 +1,21 @@
+# The page an invitation link lands on.
+#
+# Unauthenticated, and it has to be: the person holding the link may not
+# have a DDBJ Account yet, and the page's job is to tell them what they
+# are being invited to before it asks them to make one. What it
+# discloses — a set name and who invited them — is what the mail they
+# are holding already said.
+class InvitationsController < ApplicationController
+  skip_before_action :authenticate!, only: %i[show]
+
+  # Every state of the link is answered rather than hidden. The holder is
+  # the intended recipient, and "this has expired, ask them to send it
+  # again" or "you have already used this" is the one thing that gets
+  # them unstuck — unlike a reviewer share link, where a revoked link
+  # must be indistinguishable from one that never existed.
+  #
+  # Which is why acceptance does not clear the token: see SubmissionSetMember.
+  def show
+    @member = SubmissionSetMember.find_by!(invitation_token: params.expect(:token).presence)
+  end
+end

--- a/app/controllers/set_member_reminders_controller.rb
+++ b/app/controllers/set_member_reminders_controller.rb
@@ -1,0 +1,27 @@
+# Sending an invitation again. A new token and a new clock, so the link
+# that did not get used stops working — somebody asking for a resend is
+# replacing a link, not handing out a second one.
+#
+# Any member can do it: the point of a resend is usually that whoever
+# sent the first one is not around.
+class SetMemberRemindersController < ApplicationController
+  before_action :refuse_proxy!
+  before_action :load_member
+
+  def create
+    refuse! 'That person has already joined.' if @member.joined?
+
+    @member.resend!
+
+    SetInvitationMailer.with(member: @member).invite.deliver_later
+
+    render 'set_members/show', status: :created
+  end
+
+  private
+
+  def load_member
+    @set  = SubmissionSet.joined_by(current_user).find(params.expect(:set_id))
+    @member = @set.members.find(params.expect(:member_id))
+  end
+end

--- a/app/controllers/set_members_controller.rb
+++ b/app/controllers/set_members_controller.rb
@@ -1,0 +1,69 @@
+# The roster. Inviting somebody and taking them off are the same list
+# being written to, so they are the same resource — see SubmissionSetMember for
+# why an outstanding invitation is a row on it rather than a queue beside
+# it.
+class SetMembersController < ApplicationController
+  include SetContents
+
+  before_action :refuse_proxy!
+  before_action :load_set
+  before_action :load_member, only: %i[destroy]
+
+  # An invitation is mail sent from `repo@ddbj.nig.ac.jp` to an address
+  # somebody typed, so the ceiling is on people rather than on sets: a
+  # real collaboration invites a handful in a sitting, and nothing that
+  # is not an attempt to use us as a mail relay invites eighty.
+  rate_limit to: 30, within: 1.hour, by: -> { current_user&.id }, only: %i[create],
+             with: -> { render json: {error: 'Too many invitations in a short time. Try again later.'}, status: :too_many_requests }
+
+  # Any member invites. A collaboration is not organised around whoever
+  # happened to press New first, and an invitation that has to wait for
+  # them is one that does not go out.
+  def create
+    within_submission_set_membership(@set) do
+      @member = @set.members.create!(email: member_params[:email], invited_by: current_user)
+    end
+
+    SetInvitationMailer.with(member: @member).invite.deliver_later
+
+    render :show, status: :created
+  end
+
+  # Leaving, revoking an invitation that has not been used, and removing
+  # somebody are one act with three names.
+  def destroy
+    authorize_removal!
+
+    @member.remove!
+
+    head :no_content
+  end
+
+  private
+
+  def authorize_removal!
+    return if @member.user_id == current_user.id                            # leaving
+    return if @set.owned_by?(current_user)                                # the owner's set to keep in order
+    return if @member.pending? && @member.invited_by_id == current_user.id  # taking back your own invitation
+
+    forbid! 'Only the owner can remove another member.'
+  end
+
+  # The owner cannot walk out of their own set: nothing would then say
+  # who may rename or delete it, and the set would be left with no way
+  # to be put down. Deleting it is the way out, which is why it is
+  # refused rather than hidden.
+  def load_member
+    @member = @set.members.find(params.expect(:id))
+
+    return unless @member.user_id == @set.owner_id
+
+    refuse! 'The owner cannot leave their own set. Delete it instead.' if @member.user_id == current_user.id
+  end
+
+  def load_set
+    @set = SubmissionSet.joined_by(current_user).find(params.expect(:set_id))
+  end
+
+  def member_params = params.expect(set_member: %i[email])
+end

--- a/app/controllers/set_submissions_controller.rb
+++ b/app/controllers/set_submissions_controller.rb
@@ -1,0 +1,49 @@
+# What is in a set. Adding and removing are each member's own to do —
+# see SubmissionSetInclusion for why nobody can put somebody else's work here.
+class SetSubmissionsController < ApplicationController
+  include SetContents
+
+  before_action :refuse_proxy!
+  before_action :load_set
+
+  def create
+    # Scoped to what the caller owns, so a request they merely read
+    # through another set 404s rather than being quietly refused: from
+    # here, somebody else's submission is not an id they have.
+    request = current_user.submission_requests.find(params.expect(submission: [:submission_request_id])[:submission_request_id])
+
+    within_submission_set_membership(@set) do
+      @set.inclusions.create!(submission_request: request, added_by: current_user)
+    end
+
+    # Nothing back. Answering with the whole set would mean loading a
+    # page of it — progress bar, accession summary and curation state per
+    # row — on every add, for a body the client re-reads anyway.
+    #
+    # 204 rather than 201, even though this creates something: 204 is the
+    # status that says "no body", and the web client's fetch layer treats
+    # every other status as having one — a 201 with an empty body reaches
+    # it as a JSON parse error, which is how this shipped broken. Every
+    # other bodiless answer in this application is a 204 for the same
+    # reason.
+    head :no_content
+  end
+
+  def destroy
+    submission_set_inclusion = @set.inclusions.find_by!(submission_request_id: params.expect(:submission_request_id))
+
+    unless submission_set_inclusion.submission_request.user_id == current_user.id
+      forbid! 'Only the submission owner can take it out of a set.'
+    end
+
+    submission_set_inclusion.destroy!
+
+    head :no_content
+  end
+
+  private
+
+  def load_set
+    @set = SubmissionSet.joined_by(current_user).find(params.expect(:set_id))
+  end
+end

--- a/app/controllers/sets_controller.rb
+++ b/app/controllers/sets_controller.rb
@@ -1,0 +1,65 @@
+class SetsController < ApplicationController
+  include SetContents
+
+  before_action :refuse_proxy!, only: %i[create update destroy]
+  before_action :load_set,    only: %i[show update destroy]
+
+  def index
+    @sets = SubmissionSet.joined_by(current_user).order(:name, :id).includes(:owner)
+
+    # Counted, not loaded. `preload` here would instantiate every join row
+    # in every set the reader belongs to in order to print three
+    # integers each.
+    @counts = self.class.set_counts(@sets.map(&:id))
+  end
+
+  def show
+    load_set_contents
+  end
+
+  def create
+    @set = SubmissionSet.create!(name: set_params[:name], owner: current_user)
+
+    load_set_contents
+    render :show, status: :created
+  end
+
+  def update
+    forbid! 'Only the owner can rename a set.' unless @set.owned_by?(current_user)
+
+    @set.update!(set_params)
+
+    load_set_contents
+    render :show
+  end
+
+  # Deleting is the owner's, and only once the set is empty of everyone
+  # else's things: the submissions in it are their owners' to take out,
+  # and the people in it are not the owner's to dissolve.
+  #
+  # Under a lock, and re-checked inside it. `deletable?` and `destroy!`
+  # are two statements, and an invitation sent between them would be
+  # destroyed by the cascade — which is the exact outcome the rule exists
+  # to prevent.
+  def destroy
+    forbid! 'Only the owner can delete a set.' unless @set.owned_by?(current_user)
+
+    @set.with_lock do
+      refuse! SubmissionSet::EMPTY_FIRST unless @set.deletable?
+
+      @set.destroy!
+    end
+
+    head :no_content
+  end
+
+  private
+
+  # A set you are not in is not visible as a set you are not in —
+  # same reasoning as the request scoping, one floor up.
+  def load_set
+    @set = SubmissionSet.joined_by(current_user).find(params.expect(:id))
+  end
+
+  def set_params = params.expect(set: %i[name])
+end

--- a/app/controllers/submission_requests_controller.rb
+++ b/app/controllers/submission_requests_controller.rb
@@ -1,6 +1,7 @@
 class SubmissionRequestsController < ApplicationController
   include SourceIdFilterable
   include AccessionFilterable
+  include AccessionSummaries
   include EnumFilterable
 
   # The submitter's list, organised around "where is this now".
@@ -54,8 +55,12 @@ class SubmissionRequestsController < ApplicationController
     response.headers['Finished-Count']   = owned.finished.count.to_s
   end
 
+  # Wider than the list above, which is "mine". A set's members can read
+  # each other's submissions, and this is where they do it — the payload
+  # says which of the two the reader is (`owned`), and withholds the
+  # conversation either way.
   def show
-    @request = current_user.submission_requests.find(params.expect(:id))
+    @request = SubmissionRequest.readable_by(current_user).find(params.expect(:id))
   end
 
   def create
@@ -102,25 +107,6 @@ class SubmissionRequestsController < ApplicationController
     when 'all'      then scope
     else                 scope.unfinished
     end
-  end
-
-  # {submission_id => [first_accession, count]} for BS submissions, via one
-  # grouped MIN / COUNT over sample accessions.
-  # BioSample samples and ST.26 entries both, so neither list loads a bag
-  # of rows to print one accession and one count.
-  def sample_accession_summaries(submissions)
-    summarise(Sample, submissions.select(&:biosample_db?).map(&:id))
-      .merge(summarise(Entry, submissions.select(&:st26_db?).map(&:id)))
-  end
-
-  def summarise(model, ids)
-    return {} if ids.empty?
-
-    model
-      .where(submission_id: ids)
-      .group(:submission_id)
-      .pluck(:submission_id, Arel.sql('MIN(accession)'), Arel.sql('COUNT(accession)'))
-      .to_h {|sid, first, count| [sid, [first, count]] }
   end
 
   def request_params

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -9,8 +9,13 @@ class SubmissionsController < ApplicationController
     response.headers.merge! pagy.headers_hash
   end
 
+  # Readable, not owned — following the request's own screen, which now
+  # opens for a set's members. Nothing new is disclosed by it: what
+  # this returns is the same `submission` object already embedded in the
+  # request payload they can read. `index` above stays "mine", because a
+  # list of my submissions is what it says it is.
   def show
-    @submission = current_user.submissions.find(params.expect(:id))
+    @submission = Submission.readable_by(current_user).find(params.expect(:id))
   end
 
   def create

--- a/app/mailers/set_invitation_mailer.rb
+++ b/app/mailers/set_invitation_mailer.rb
@@ -1,0 +1,15 @@
+# "You have been invited to a set." Sent on the invitation and again on
+# every resend — each time with the link that is live now, since a resend
+# replaces the old one.
+class SetInvitationMailer < ApplicationMailer
+  def invite
+    @member  = params[:member]
+    @set   = @member.set
+    @inviter = @member.invited_by
+
+    # Straight to the address that was typed, not through `recipient_for`:
+    # the whole point is that this may reach somebody the system has never
+    # heard of, so there is no account to look an address up on.
+    mail(to: @member.email, subject: "[DDBJ Repository] You have been invited to “#{@set.name}”")
+  end
+end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -9,6 +9,15 @@ class Submission < ApplicationRecord
 
   has_one :request, dependent: :destroy, class_name: 'SubmissionRequest'
 
+  # Everything this person may read: their own, plus whatever has been
+  # shared into a set they have joined. The rule lives on
+  # SubmissionRequest — the request is the unit — and this follows it, so
+  # the two cannot drift apart and leave a set member holding a
+  # submission id that answers 404.
+  scope :readable_by, ->(user) {
+    where(id: SubmissionRequest.readable_by(user).select(:submission_id))
+  }
+
   has_many :updates,    dependent: :destroy, class_name: 'SubmissionUpdate'
   has_many :entries, dependent: :destroy
 

--- a/app/models/submission_request.rb
+++ b/app/models/submission_request.rb
@@ -34,7 +34,24 @@ class SubmissionRequest < ApplicationRecord
 
   has_one :reviewer_access, dependent: :destroy
 
+  # Which collaborations this submission has been shared into. Many,
+  # because a BioProject is a hub: the sets hanging off one are
+  # different studies rather than one.
+  has_many :set_inclusions, class_name: 'SubmissionSetInclusion', dependent: :destroy
+  has_many :sets, through: :set_inclusions, source: :set
+
   has_one_attached :ddbj_record
+
+  # Everything this person may read: their own, plus whatever has been
+  # shared into a set they have joined. Distinct from
+  # `user.submission_requests`, which stays what it says — ownership,
+  # and the only thing that grants writing.
+  scope :readable_by, ->(user) {
+    mine   = SubmissionSetMember.joined.where(user_id: user.id).select(:submission_set_id)
+    shared = SubmissionSetInclusion.where(submission_set_id: mine)
+
+    where(user_id: user.id).or(where(id: shared.select(:submission_request_id)))
+  }
 
   scope :assigned_to, ->(user) { where(assignee_id: user.id) }
   scope :unassigned,  -> { where(assignee_id: nil) }

--- a/app/models/submission_set.rb
+++ b/app/models/submission_set.rb
@@ -1,0 +1,80 @@
+# Submissions that belong together, and the people they belong to.
+#
+# Named after the submissions rather than after the people on purpose. A
+# lab is a group; bundling submissions at the granularity of a lab has no
+# use. What is worth bundling is a set of submissions that mean something
+# together, whatever granularity that turns out to be — and the people
+# fall out of it, rather than the set being a picture of an organisation.
+#
+# Two axes, and they are separate. SubmissionSetMember is who is in it;
+# SubmissionSetInclusion is what is in it. Being a member does not put
+# your submissions anywhere, and putting a submission in does not stop
+# being your call — each member adds and removes their own.
+#
+# **Adding a submission is the whole permission story.** There is no
+# other way a member comes to read somebody else's submission, no
+# per-submission grant to keep in step, and nothing to reconcile when a
+# person leaves: taking them off the roster takes their submissions with
+# them, because the permission was never anywhere else.
+class SubmissionSet < ApplicationRecord
+  # Whoever created it. Not a role with powers over the work — every
+  # member invites, and every member manages their own submissions —
+  # only over the set as an object: renaming it and deleting it.
+  belongs_to :owner, class_name: 'User'
+
+  has_many :members, -> { ordered }, class_name: 'SubmissionSetMember', inverse_of: :set, dependent: :destroy
+
+  # Accepted members only. A `through` association joins, so a row whose
+  # invitation is still out has no user to join to and simply is not
+  # here — which is what every caller asking "who is in this set"
+  # means.
+  has_many :users, through: :members
+
+  has_many :inclusions, class_name: 'SubmissionSetInclusion', inverse_of: :set, dependent: :destroy
+  has_many :submission_requests, through: :inclusions
+
+  validates :name, presence: true, length: {maximum: 200}
+
+  # The creator is on the roster from the start. A set nobody is in
+  # would have no one to invite the first member, and every rule below
+  # that says "members can" would have nothing to say about the person
+  # who just made it.
+  after_create do |set|
+    set.members.create!(user: set.owner, invited_by: set.owner, joined_at: Time.current)
+  end
+
+  # Sets this person is actually in. Outstanding invitations are not
+  # membership: nothing is shared with somebody who has not walked
+  # through the link yet.
+  scope :joined_by, ->(user) { where(id: SubmissionSetMember.joined.where(user_id: user.id).select(:submission_set_id)) }
+
+  def member?(user)
+    return false unless user
+
+    members.joined.exists?(user_id: user.id)
+  end
+
+  def owned_by?(user) = user && owner_id == user.id
+
+  # Empty of everything but the owner. A set with somebody else's
+  # submission in it is not the owner's to remove out from under them,
+  # and a set with other people in it is not theirs to dissolve — so
+  # the two get taken out first, by the people they belong to.
+  #
+  # An invitation nobody has walked through counts as somebody. Deleting
+  # the set would kill a link that is sitting in a mailbox, and would
+  # do it silently; taking the invitation back is a thing the owner can
+  # see and undo.
+  def deletable? = inclusions.none? && members.where.not(id: owner_membership).none?
+
+  # Said once, here, and served to the client rather than written out
+  # again in the template that shows it — the rule and its wording belong
+  # together, and two copies in two languages drift.
+  EMPTY_FIRST = 'Take the submissions out and remove everyone else — including invitations nobody has used — first.'.freeze
+
+  def delete_blocked_reason = deletable? ? nil : EMPTY_FIRST
+
+  private
+
+  def owner_membership = members.where(user_id: owner_id).select(:id)
+end

--- a/app/models/submission_set_inclusion.rb
+++ b/app/models/submission_set_inclusion.rb
@@ -1,0 +1,37 @@
+# One submission's place in one set.
+#
+# Points at the SubmissionRequest rather than the Submission: the request
+# is the unit everywhere else (see [[project-request-as-unit-deploy]]),
+# and a conversation about a submission starts before Apply, when there
+# is no Submission to point at. "Submission" is what a person calls it,
+# which is why the table is not named after the request.
+class SubmissionSetInclusion < ApplicationRecord
+  # `set` is the word everywhere else — the class is SubmissionSet only
+  # because Ruby owns the constant `Set`.
+  belongs_to :set, class_name: 'SubmissionSet', foreign_key: :submission_set_id, inverse_of: :inclusions
+  belongs_to :submission_request
+
+  # Who put it here — which is always its owner, since only they can.
+  # Kept anyway: an account can be proxied, and "who did this" is the
+  # question a support thread asks.
+  belongs_to :added_by, class_name: 'User'
+
+  # Also a unique index. The validation is what turns a double press into
+  # "it is already there" rather than a 500.
+  validates :submission_request_id, uniqueness: {scope: :submission_set_id}
+
+  validate :addable_by_adder
+
+  private
+
+  # Your own submission, and nobody else's. Reading somebody else's
+  # through a shared set does not carry the right to hand it on to a
+  # third set — the owner decides where their work is shared, every
+  # time.
+  def addable_by_adder
+    return if submission_request.nil? || added_by.nil?
+    return if submission_request.user_id == added_by_id
+
+    errors.add(:submission_request, 'can only be added by its owner')
+  end
+end

--- a/app/models/submission_set_member.rb
+++ b/app/models/submission_set_member.rb
@@ -1,0 +1,170 @@
+# One person's place in one set — whether they have accepted yet or
+# not.
+#
+# "Add a member" is a single action, so it leaves a single row, and the
+# roster is one list rather than a list of members beside a list of
+# outstanding invitations. `user_id` is what separates the two states:
+# absent means the invitation is still out.
+#
+# The invitation is a token in a link, not a match on the address. An
+# address is what the inviter typed and what the mail was sent to; it is
+# NOT what is checked on the way in, because the person who receives it
+# may not have a DDBJ Account yet and may well create one under a
+# different address — matching on the address would leave them at a dead
+# end with nothing on screen to explain it. What the token costs is that
+# a forwarded mail lets somebody else in, so the row records which
+# account accepted and the roster shows it whenever that account's
+# address is not the one invited. Forwarding an invitation to a
+# colleague is a real thing people do; the answer is to make it visible,
+# not to refuse it.
+class SubmissionSetMember < ApplicationRecord
+  # Long, because what an invitation waits for is not the round trip —
+  # it is somebody getting round to it.
+  INVITATION_VALIDITY = 30.days
+
+  # `set` is the word everywhere else — the class is SubmissionSet only
+  # because Ruby owns the constant `Set`.
+  belongs_to :set, class_name: 'SubmissionSet', foreign_key: :submission_set_id, inverse_of: :members
+  belongs_to :user, optional: true
+  belongs_to :invited_by, class_name: 'User'
+
+  normalizes :email, with: -> { it.presence&.strip&.downcase }
+
+  # Required of an invitation and of nothing else: the creator's own row
+  # was never invited, and a joined member's address is their account's.
+  validates :email, presence: true, if: :pending?
+  validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}, uniqueness: {scope: :submission_set_id}, allow_nil: true
+  validates :user_id, uniqueness: {scope: :submission_set_id}, allow_nil: true
+
+  validate :not_already_joined, on: :create, if: :pending?
+
+  scope :joined,  -> { where.not(user_id: nil) }
+  scope :pending, -> { where(user_id: nil) }
+  scope :ordered, -> { order(:created_at, :id) }
+
+  before_validation :issue_invitation!, on: :create, unless: :joined?
+
+  def pending? = user_id.nil?
+  def joined?  = !pending?
+
+  def invitation_expired? = pending? && invitation_expires_at.past?
+
+  # What the link says about itself. `accepted` exists because the token
+  # is kept after it has been walked through: somebody opening the mail a
+  # second time — from their phone, a week later — is told what happened
+  # rather than shown a 404 for a link that worked perfectly.
+  def invitation_state
+    return 'accepted' if joined?
+
+    invitation_expired? ? 'expired' : 'open'
+  end
+
+  # Whether the mail we send on an invitation actually leaves the
+  # building. Every deployed environment restricts outgoing mail while
+  # sending to real submitters is switched off, which would otherwise
+  # make this feature look like it works and quietly reach nobody — the
+  # roster says so, and offers the link to send by hand.
+  def deliverable? = email.present? && MailDomainAllowlistInterceptor.delivers_to?(email)
+
+  # Whether the account that walked through the invitation is registered
+  # at the address it was sent to. Three answers, not two: an account
+  # imported from D-way that has never signed in carries no address at
+  # all, and saying `same` for one of those would put a claim on the
+  # roster that nothing checked. `unknown` is the honest word, and this
+  # is the whole of the audit that pays for not binding the token to the
+  # address.
+  #
+  # nil where the question does not arise — the creator's own row, which
+  # was never invited.
+  def invited_address_match
+    return nil unless joined? && email.present?
+    return 'unknown' if user&.email.blank?
+
+    user.email.downcase == email ? 'same' : 'different'
+  end
+
+  # The token is deliberately NOT cleared: see the check constraint. It
+  # grants nothing from here — every path that acts on an invitation
+  # refuses a row that has been joined — and keeping it is what lets the
+  # link explain itself when it is opened again.
+  def accept!(acceptor)
+    update!(user: acceptor, joined_at: Time.current, invitation_expires_at: nil)
+  end
+
+  # The link that was mailed. Points at the SPA, which is where the page
+  # explaining the invitation lives.
+  def invitation_url = invitation_token && WebApp.url_for("/invitations/#{invitation_token}")
+
+  # Taking somebody off the roster takes with them everything their being
+  # here brought in.
+  #
+  # **Their submissions**, because the set was the only thing letting
+  # the others read that work; leaving it behind would go on sharing it
+  # after the person who put it there has gone, and they would have no
+  # way of noticing, since the set is no longer on their screen.
+  #
+  # **The invitations they sent**, because any member may invite. Without
+  # this, somebody who is asked to leave walks back in through a link
+  # they mailed to themselves a month earlier — and removal, which is the
+  # only revocation this design has, would revoke nothing.
+  #
+  # NOT an invitation somebody else sent *to* them: that is the other
+  # member's, and taking it back is theirs to do. Removing a person who
+  # has an outstanding invitation from a colleague therefore leaves a way
+  # back in — visible on the roster, which is where it belongs.
+  #
+  # Under a lock on the set. Serialising the writers is only half of it
+  # — a write that queues behind this one still believed it was a member
+  # when it started — so every write that adds to a set takes the same
+  # lock and asks again inside it (SetContents#within_set_membership).
+  # Without that half, a submission added mid-sweep is left behind: in the
+  # set, readable by everyone in it, and unreachable by its owner, for
+  # whom the set is no longer on screen.
+  def remove!
+    set.with_lock do
+      if joined?
+        set.inclusions
+             .joins(:submission_request)
+             .where(submission_requests: {user_id: user_id})
+             .destroy_all
+
+        set.members.pending.where(invited_by_id: user_id).destroy_all
+      end
+
+      destroy!
+    end
+  end
+
+  # A fresh token and a fresh clock. The old link stops working, which is
+  # what somebody asking for a resend expects — they are replacing a link
+  # that did not get used, not handing out a second one.
+  #
+  # Refused on a joined row here rather than only in the controller: the
+  # database would refuse it too (the state constraint), and a check
+  # constraint surfacing as a 500 is not the way anybody should find out.
+  def resend!
+    raise ArgumentError, 'That person has already joined.' if joined?
+
+    issue_invitation!
+    save!
+  end
+
+  private
+
+  # Inviting somebody who is already here is a misfire rather than a
+  # second seat — and the unique index would not catch it, since it is
+  # their account's address being matched and not the one they were
+  # invited at.
+  def not_already_joined
+    return if email.blank? || set.nil?
+
+    return unless set.members.joined.joins(:user).where('lower(users.email) = ?', email).exists?
+
+    errors.add(:email, 'is already a member of this set')
+  end
+
+  def issue_invitation!
+    self.invitation_token      = self.class.generate_unique_secure_token(length: 32)
+    self.invitation_expires_at = INVITATION_VALIDITY.from_now
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,14 @@ class User < ApplicationRecord
   # Named ledger filters. Personal, so they go when the account does.
   has_many :saved_views, dependent: :destroy
 
+  # Sets this account belongs to. No `dependent` on either: a set is
+  # shared work rather than one person's, so an account cannot take one
+  # with it — the foreign key refuses the deletion, which is the honest
+  # answer until somebody decides what handing a set over looks like.
+  has_many :submission_set_members, dependent: nil
+  has_many :submission_sets, through: :submission_set_members
+  has_many :owned_submission_sets, class_name: 'SubmissionSet', inverse_of: :owner, foreign_key: :owner_id, dependent: nil
+
   belongs_to :notes_updated_by, class_name: 'User', optional: true
 
   scope :with_submission_requests, -> { where(id: SubmissionRequest.select(:user_id)) }

--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -1,7 +1,11 @@
 using PathnameContain
 
 class Validation < ApplicationRecord
-  class UnprocessableContent < StandardError; end
+  # Raised with a sentence for the submitter, so it is answered rather
+  # than swallowed into a bare status.
+  class UnprocessableContent < StandardError
+    include PublicError
+  end
 
   belongs_to :subject, polymorphic: true
 

--- a/app/views/errors/_exception.json.jb
+++ b/app/views/errors/_exception.json.jb
@@ -1,3 +1,6 @@
+# `status_in_words` is Rambulance's status symbol — `unprocessable_content`,
+# not a sentence. Where it stands in for a message it is what somebody
+# reads, so it is written the way they read it.
 {
-  error: exception.message == exception.class.to_s ? status_in_words : exception.message
+  error: PublicError.message_for(exception, fallback: status_in_words.to_s.humanize)
 }

--- a/app/views/errors/internal_server_error.json.jb
+++ b/app/views/errors/internal_server_error.json.jb
@@ -1,1 +1,7 @@
-render('exception')
+# Never the exception's own words. A fault is by definition something we
+# did not write a sentence for, and Rails' message for one carries
+# whatever produced it — a SQL statement, a file path, a credential in a
+# connection string.
+{
+  error: status_in_words.to_s.humanize
+}

--- a/app/views/invitation_acceptances/create.json.jb
+++ b/app/views/invitation_acceptances/create.json.jb
@@ -1,0 +1,1 @@
+render('sets/set_summary', set: @set, viewer: @viewer, counts: @counts)

--- a/app/views/invitations/show.json.jb
+++ b/app/views/invitations/show.json.jb
@@ -1,0 +1,10 @@
+# Unauthenticated. Only what the mail in the reader's hand already said,
+# plus which of its three states the link is in — see SubmissionSetMember for why
+# "already used" is answered rather than hidden.
+{
+  set_name: @member.set.name,
+  invited_by: @member.invited_by.uid,
+  email:      @member.email,
+  expires_at: @member.invitation_expires_at&.iso8601,
+  status:     @member.invitation_state
+}

--- a/app/views/reviews/show.json.jb
+++ b/app/views/reviews/show.json.jb
@@ -1,9 +1,9 @@
 # Reviewer-facing view of a submission request. Deliberately a separate
 # template from submission_requests/show so the two can diverge; this is
-# where they do. `conversation: false` withholds the messaging facts — a
-# share-link holder is not authenticated, and must not learn that a curator
-# asked something or when the thread was last touched.
+# where they do. No viewer — a share-link holder is not authenticated,
+# and must not learn that a curator asked something, when the thread was
+# last touched, or who else is working on this.
 render(
   partial: 'submission_requests/submission_request',
-  locals:  {submission_request: @request, conversation: false, closure: false}
+  locals:  {submission_request: @request, viewer: nil}
 )

--- a/app/views/set_invitation_mailer/invite.html.erb
+++ b/app/views/set_invitation_mailer/invite.html.erb
@@ -1,0 +1,26 @@
+<p>Hello,</p>
+
+<p><%= @inviter.uid %> has invited you to the set “<%= @set.name %>” on DDBJ Repository.</p>
+
+<p>
+  A set is submissions that belong together — the ones behind a paper, a study, a
+  piece of work. Everyone in the set can see what the others have put in it and how
+  far along it is. Which of your own submissions go in stays your decision, and you
+  can take them back out at any time.
+</p>
+
+<p><%= link_to 'Open the invitation', @member.invitation_url %></p>
+
+<p>It is valid until <%= I18n.l(@member.invitation_expires_at.to_date, format: :long) %>.</p>
+
+<p>
+  If you do not have a DDBJ Account yet, that page will point you at the form to create
+  one and bring you back afterwards.
+</p>
+
+<p>
+  If you were not expecting this, you can ignore this mail — nothing is shared with you
+  until you open the link.
+</p>
+
+<p>Regards,<br>DDBJ Repository</p>

--- a/app/views/set_invitation_mailer/invite.text.erb
+++ b/app/views/set_invitation_mailer/invite.text.erb
@@ -1,0 +1,22 @@
+Hello,
+
+<%= @inviter.uid %> has invited you to the set “<%= @set.name %>” on DDBJ Repository.
+
+A set is submissions that belong together — the ones behind a paper, a
+study, a piece of work. Everyone in the set can see what the others have
+put in it and how far along it is. Which of your own submissions go in
+stays your decision, and you can take them back out at any time.
+
+Open the invitation:
+<%= @member.invitation_url %>
+
+It is valid until <%= I18n.l(@member.invitation_expires_at.to_date, format: :long) %>.
+
+If you do not have a DDBJ Account yet, that page will point you at the
+form to create one and bring you back afterwards.
+
+If you were not expecting this, you can ignore this mail — nothing is
+shared with you until you open the link.
+
+Regards,
+DDBJ Repository

--- a/app/views/set_members/_member.json.jb
+++ b/app/views/set_members/_member.json.jb
@@ -1,0 +1,53 @@
+# locals: (member:, set:, viewer:, submission_counts: {})
+
+owner = member.user_id == set.owner_id
+you   = member.user_id == viewer.id
+
+{
+  id:     member.id,
+  email:  member.email,
+  uid:    member.user&.uid,
+  # One vocabulary for the roster and for the invitation page, so the
+  # two cannot describe the same row differently.
+  status: member.invitation_state,
+
+  owner:      owner,
+  you:        you,
+  invited_by: member.invited_by.uid,
+  joined_at:  member.joined_at&.iso8601,
+
+  invitation_expires_at: member.invitation_expires_at&.iso8601,
+
+  # The rule, rather than the client re-deriving it. It cannot: leaving,
+  # removing somebody, and taking back an invitation you sent are three
+  # different permissions, and under a proxy login the account the client
+  # thinks it is is not the account the server is acting as.
+  #
+  # The owner's own row is never removable — nobody else may remove them,
+  # and they cannot walk out of a set that would then have nobody to
+  # rename or delete it. Deleting it is the way out.
+  removable: !owner && (you || set.owned_by?(viewer) || (member.pending? && member.invited_by_id == viewer.id)),
+
+  # What goes with them if they are removed. Counted over the whole
+  # set, not over the page the reader happens to be on.
+  submission_count: submission_counts.fetch(member.user_id, 0),
+
+  # Whether the account that walked through the invitation is registered
+  # at the address it went to: 'same', 'different', or 'unknown' when the
+  # account carries no address at all. Null where the question does not
+  # arise — the creator's own row, which was never invited. This is the
+  # whole of the audit that pays for not binding the token to the
+  # address; see SubmissionSetMember.
+  invited_address_match: member.invited_address_match,
+
+  # An outstanding invitation, as a link. Two reasons it is here rather
+  # than only in the mail: every deployed environment restricts outgoing
+  # mail while sending to real submitters is switched off, so the mail
+  # may have reached nobody; and mail goes missing. Handing it to a
+  # member grants nothing they did not already have — they can invite
+  # whoever they like.
+  invitation_url: member.pending? ? member.invitation_url : nil,
+
+  # Whether that mail actually left the building.
+  mail_deliverable: member.pending? ? member.deliverable? : nil
+}

--- a/app/views/set_members/show.json.jb
+++ b/app/views/set_members/show.json.jb
@@ -1,0 +1,1 @@
+render('set_members/member', member: @member, set: @member.set, viewer: @viewer, submission_counts: {})

--- a/app/views/sets/_set_submission.json.jb
+++ b/app/views/sets/_set_submission.json.jb
@@ -1,0 +1,25 @@
+# locals: (inclusion:, viewer:, states: {}, unread_counts: {}, bs_accession_summaries: {})
+
+submission_request = inclusion.submission_request
+
+{
+  # Whose it is, and since when. In every other list this is one person's
+  # work and goes without saying; here it is the first thing a reader
+  # needs.
+  owner_uid: submission_request.user.uid,
+  added_at:  inclusion.created_at.iso8601,
+
+  # Whether it is yours to take out. Said by the server for the same
+  # reason `removable` is: under a proxy login the account the client
+  # believes it is is not the account the server acts as, so comparing
+  # uids in the browser gets it backwards.
+  owned: submission_request.user_id == viewer.id,
+
+  submission: render(
+    'submission_requests/submission_request_summary',
+    submission_request:,
+    states:,
+    unread_counts:,
+    bs_accession_summaries:
+  )
+}

--- a/app/views/sets/_set_summary.json.jb
+++ b/app/views/sets/_set_summary.json.jb
@@ -1,0 +1,16 @@
+# locals: (set:, viewer:, counts:)
+
+{
+  id:         set.id,
+  name:       set.name,
+  owner_uid:  set.owner.uid,
+  owned:      set.owner_id == viewer.id,
+  created_at: set.created_at.iso8601,
+
+  # Counted in SQL and handed in, never derived from a loaded
+  # association: there is no ceiling on what a set holds, and these
+  # three integers must not be what loads it.
+  member_count:     counts.fetch(:members).fetch(set.id, 0),
+  invited_count:    counts.fetch(:invited).fetch(set.id, 0),
+  submission_count: counts.fetch(:submissions).fetch(set.id, 0)
+}

--- a/app/views/sets/index.json.jb
+++ b/app/views/sets/index.json.jb
@@ -1,0 +1,1 @@
+render(partial: 'set_summary', collection: @sets, as: :set, locals: {viewer: @viewer, counts: @counts})

--- a/app/views/sets/show.json.jb
+++ b/app/views/sets/show.json.jb
@@ -1,0 +1,27 @@
+render('sets/set_summary', set: @set, viewer: @viewer, counts: @counts).merge(
+  # Whether it can go, and if not, why — said by the side that holds the
+  # rule. A screen that expresses it by hiding the button leaves an owner
+  # with one forgotten invitation looking at a set with, apparently, no
+  # way to get rid of it.
+  deletable:             @set.deletable?,
+  delete_blocked_reason: @set.delete_blocked_reason,
+
+  members: render(
+    partial:    'set_members/member',
+    collection: @set.members.includes(:user, :invited_by),
+    as:         :member,
+    locals:     {set: @set, viewer: @viewer, submission_counts: @submission_counts}
+  ),
+
+  submissions: render(
+    partial:    'sets/set_submission',
+    collection: @inclusions,
+    as:         :inclusion,
+    locals:     {
+      viewer:                 @viewer,
+      states:                 @states,
+      unread_counts:          @unread_counts,
+      bs_accession_summaries: @bs_accession_summaries
+    }
+  )
+)

--- a/app/views/submission_requests/_submission_request.json.jb
+++ b/app/views/submission_requests/_submission_request.json.jb
@@ -1,4 +1,4 @@
-# locals: (submission_request:, conversation: true, closure: true)
+# locals: (submission_request:, viewer: nil)
 
 state = CurationState.new(submission_request)
 
@@ -21,25 +21,50 @@ payload = {
   progress: render('submission_requests/progress', state: state)
 }
 
-# Whether the button is offered, rather than the client re-deriving the
-# rule from the status — the rule is "what is asking for something can be
-# put down", and only the server knows it. Withheld from the reviewer
-# view, which is read-only: `closed_at` is a fact about the request and
-# goes either way, but an affordance nobody there can use is noise.
-payload[:closable] = submission_request.closable? if closure
+# Everything below this line is for somebody who is signed in.
+#
+# The reviewer view renders this same body through an unauthenticated
+# share token and passes no viewer — that is what `viewer: nil` means
+# here, and it is the whole of the difference between the two. It must
+# not disclose that a curator ↔ submitter conversation exists, nor who
+# else is working on this.
+if viewer
+  # A set's members can read each other's submissions. Owning one is
+  # what says whether the controls on the page are yours to press.
+  owned = submission_request.user_id == viewer.id
 
-# The reviewer view renders this same body through an unauthenticated share
-# token, and must not disclose that a curator ↔ submitter conversation
-# exists — not its unread count, not when it was last touched. That is the
-# `conversation: false` case; see reviews/show.json.jb and the
-# `ReviewerSubmissionRequest` schema.
-if conversation
-  payload[:unread_curator_message_count] = submission_request.messages.curator_role.unread.count
+  payload[:owned] = owned
+
+  # Whose it is. Needed because the page reads differently for somebody
+  # who is not the submitter — every sentence on it is written in the
+  # second person, and "your file is ready to submit" over an empty
+  # button row is worse than not showing it.
+  payload[:owner_uid] = submission_request.user.uid
+
+  # Whether the button is offered, rather than the client re-deriving the
+  # rule from the status — the rule is "what is asking for something can
+  # be put down", and only the server knows it.
+  payload[:closable] = owned && submission_request.closable?
+
+  # Only the sets this reader is in. For the owner that is every set it
+  # belongs to (a submission can only be put in a set by its owner, who
+  # has to be a member to do it); for anybody else it is the one they
+  # share, and the other collaborations stay theirs to know about.
+  payload[:sets] = submission_request.sets.merge(SubmissionSet.joined_by(viewer)).order(:name).map {
+    {id: it.id, name: it.name}
+  }
+
+  # The conversation is between one submitter and DDBJ. Being able to
+  # read somebody's submission through a shared set is not being party
+  # to that, so a member who does not own it is told what a reviewer is
+  # told: nothing. (Set-wide conversation is its own thing and does not
+  # come through here.)
+  payload[:unread_curator_message_count] = owned ? submission_request.messages.curator_role.unread.count : 0
 
   # Dates the conversation for the submitter's status card ("last message
   # 07-29"). Deliberately a fact rather than an expectation — how long a
   # reply takes is not something this system knows.
-  payload[:last_message_at] = submission_request.messages.maximum(:created_at)&.iso8601
+  payload[:last_message_at] = owned ? submission_request.messages.maximum(:created_at)&.iso8601 : nil
 end
 
 payload

--- a/app/views/submission_requests/_submission_request_summary.json.jb
+++ b/app/views/submission_requests/_submission_request_summary.json.jb
@@ -19,5 +19,5 @@ state = states[submission_request.id] || CurationState.new(submission_request)
   processing:                   submission_request.processing?,
   unread_curator_message_count: unread_counts.fetch(submission_request.id, 0),
 
-  progress: render('progress', state: state)
+  progress: render('submission_requests/progress', state: state)
 }

--- a/app/views/submission_requests/show.json.jb
+++ b/app/views/submission_requests/show.json.jb
@@ -1,1 +1,4 @@
-render(@request)
+# The full path, not `render(@request)`: this template is also rendered
+# by ClosuresController, and a partial named relatively is looked up
+# under the rendering controller's own prefix.
+render('submission_requests/submission_request', submission_request: @request, viewer: @viewer)

--- a/config/initializers/rambulance.rb
+++ b/config/initializers/rambulance.rb
@@ -2,15 +2,25 @@ require 'rambulance/exceptions_app'
 
 Rambulance.setup do |config|
   config.rescue_responses = {
+    'ApplicationController::Forbidden'             => :forbidden,
+    'ApplicationController::UnprocessableContent'  => :unprocessable_content,
+
+    # Losing a race is not a fault. Two people inviting the same address,
+    # or one person pressing Add twice, land on a unique index; writing a
+    # row whose parent was deleted a moment earlier lands on a foreign
+    # key. Both answers are "that is no longer possible", which is what
+    # the caller would have been told a moment either side of it.
+    'ActiveRecord::RecordNotUnique'                => :unprocessable_content,
+    'ActiveRecord::InvalidForeignKey'              => :unprocessable_content,
+
     # Listed even though it subclasses ActionController::BadRequest: the
     # lookup is by exact class name, so the parent's mapping is not
     # inherited. The subclassing is for Sentry, whose exclusion list does
     # match by ancestry — a client's bad filter value should be answered,
     # not reported as a fault of ours.
-    'EnumFilterable::UnknownFilterValue'                    => :bad_request,
-    'Validation::UnprocessableContent'                      => :unprocessable_content,
-    'Validations::FilesController::NotFound'                => :not_found,
-    'Validations::ViaFilesController::UnprocessableContent' => :unprocessable_content
+    'EnumFilterable::UnknownFilterValue'           => :bad_request,
+
+    'Validation::UnprocessableContent'             => :unprocessable_content
   }
 end
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,16 @@
 Sentry.init do |config|
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
   config.dsn                = Rails.application.config_for(:app).sentry_dsn
+
+  # A refusal we wrote the words for is the system working. "Only the
+  # owner can rename a set" is not a fault to be woken up about, and
+  # the exclusion list matches by ancestry — which is why
+  # EnumFilterable::UnknownFilterValue subclasses ActionController::
+  # BadRequest rather than being listed here.
+  config.excluded_exceptions += %w[
+    ApplicationController::Forbidden
+    ApplicationController::UnprocessableContent
+    ActiveRecord::RecordNotUnique
+    ActiveRecord::InvalidForeignKey
+  ]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,34 @@ Rails.application.routes.draw do
     # because the only difference is which entries are in scope.
     resources :accessions, only: %i[index show], param: :number, constraints: {number: %r{[^/]+}}
 
+    # A set is submissions that belong together, and the people they
+    # belong to — two lists that meet only here. See SubmissionSet for
+    # why the permission story has no third place to live.
+    resources :sets, only: %i[index show create update destroy] do
+      resources :members, only: %i[create destroy], controller: 'set_members' do
+        # Sending the invitation again mints a new token, so the link that
+        # did not get used stops working. Creating a reminder, not
+        # updating the member: what happens is that a mail goes out.
+        resource :reminder, only: %i[create], controller: 'set_member_reminders'
+      end
+
+      # Keyed by the submission's own id rather than by the join row's:
+      # from the client's side the thing being taken out of the set is
+      # the submission, and the row that records it has no other use.
+      resources :submissions,
+                only:       %i[create destroy],
+                controller: 'set_submissions',
+                param:      :submission_request_id
+    end
+
+    # Where an invitation link lands. `show` is unauthenticated — the
+    # person holding it may not have an account yet, and the page has to
+    # be able to say what they are being invited to before it asks them
+    # to make one.
+    resources :invitations, only: %i[show], param: :token do
+      resource :acceptance, only: %i[create], controller: 'invitation_acceptances'
+    end
+
     resources :stats, only: %i[index]
   end
 

--- a/db/migrate/20260820000001_create_submission_sets.rb
+++ b/db/migrate/20260820000001_create_submission_sets.rb
@@ -1,0 +1,76 @@
+class CreateSubmissionSets < ActiveRecord::Migration[8.1]
+  # Two axes, deliberately separate tables: who is in a set
+  # (submission_set_members) and what is in it
+  # (submission_set_inclusions). Putting a submission in a set is the only
+  # thing that lets the set's members read it, which is why the two are
+  # joined only through the set.
+  def change
+    create_table :submission_sets do |t|
+      t.string     :name,  null: false
+      t.references :owner, null: false, foreign_key: {to_table: :users}
+
+      t.timestamps
+    end
+
+    # One row per person, whether they have accepted yet or not: "add a
+    # member" is one action, so it leaves one row. `user_id` is what
+    # separates the two states — absent means the invitation is still out.
+    create_table :submission_set_members do |t|
+      t.references :submission_set, null: false, foreign_key: true
+
+      # What the inviter typed. Absent on the creator's own row, who was
+      # never invited — a joined member's address is their account's.
+      t.string     :email
+      t.references :user,                        foreign_key: true
+      t.references :invited_by,    null: false,  foreign_key: {to_table: :users}
+      t.string     :invitation_token
+      t.datetime   :invitation_expires_at
+      t.datetime   :joined_at
+
+      t.timestamps
+    end
+
+    # The address is what the inviter typed, so it is matched the way a
+    # person would read it back.
+    add_index :submission_set_members, 'submission_set_id, lower(email)',
+              unique: true,
+              name:   'index_submission_set_members_on_set_and_lower_email'
+
+    add_index :submission_set_members, :invitation_token,
+              unique: true,
+              where:  'invitation_token IS NOT NULL'
+
+    # One account, one seat. Without this, somebody invited at two of
+    # their addresses joins twice and appears on the roster twice.
+    add_index :submission_set_members, %i[submission_set_id user_id],
+              unique: true,
+              where:  'user_id IS NOT NULL'
+
+    # Pending and joined are the only two states there are, and an
+    # invitation is not half an invitation: a pending row carries the
+    # address it went to, the token it went out as, and the date it stops
+    # working, or it does not exist.
+    #
+    # A joined row KEEPS its token. The token grants nothing once it has
+    # been walked through — acceptance refuses a row that is already
+    # joined — and keeping it is what lets the link say "this invitation
+    # has already been used" rather than answering the person holding it
+    # with a 404.
+    add_check_constraint :submission_set_members, <<~SQL.squish, name: 'submission_set_members_state_exclusivity'
+      (user_id IS     NULL AND joined_at IS     NULL AND email IS NOT NULL AND invitation_token IS NOT NULL AND invitation_expires_at IS NOT NULL) OR
+      (user_id IS NOT NULL AND joined_at IS NOT NULL)
+    SQL
+
+    create_table :submission_set_inclusions do |t|
+      t.references :submission_set,     null: false, foreign_key: true
+      t.references :submission_request, null: false, foreign_key: true
+      t.references :added_by,           null: false, foreign_key: {to_table: :users}
+
+      t.timestamps
+    end
+
+    # Many-to-many on purpose: a BioProject is a hub, and the sets hanging
+    # off it are different collaborations rather than one.
+    add_index :submission_set_inclusions, %i[submission_set_id submission_request_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_145311) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_20_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -346,6 +346,45 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_145311) do
     t.index ["user_id"], name: "index_submission_requests_on_user_id"
   end
 
+  create_table "submission_set_inclusions", force: :cascade do |t|
+    t.bigint "added_by_id", null: false
+    t.datetime "created_at", null: false
+    t.bigint "submission_request_id", null: false
+    t.bigint "submission_set_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["added_by_id"], name: "index_submission_set_inclusions_on_added_by_id"
+    t.index ["submission_request_id"], name: "index_submission_set_inclusions_on_submission_request_id"
+    t.index ["submission_set_id", "submission_request_id"], name: "idx_on_submission_set_id_submission_request_id_93e2b1c68d", unique: true
+    t.index ["submission_set_id"], name: "index_submission_set_inclusions_on_submission_set_id"
+  end
+
+  create_table "submission_set_members", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email"
+    t.datetime "invitation_expires_at"
+    t.string "invitation_token"
+    t.bigint "invited_by_id", null: false
+    t.datetime "joined_at"
+    t.bigint "submission_set_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index "submission_set_id, lower((email)::text)", name: "index_submission_set_members_on_set_and_lower_email", unique: true
+    t.index ["invitation_token"], name: "index_submission_set_members_on_invitation_token", unique: true, where: "(invitation_token IS NOT NULL)"
+    t.index ["invited_by_id"], name: "index_submission_set_members_on_invited_by_id"
+    t.index ["submission_set_id", "user_id"], name: "index_submission_set_members_on_submission_set_id_and_user_id", unique: true, where: "(user_id IS NOT NULL)"
+    t.index ["submission_set_id"], name: "index_submission_set_members_on_submission_set_id"
+    t.index ["user_id"], name: "index_submission_set_members_on_user_id"
+    t.check_constraint "user_id IS NULL AND joined_at IS NULL AND email IS NOT NULL AND invitation_token IS NOT NULL AND invitation_expires_at IS NOT NULL OR user_id IS NOT NULL AND joined_at IS NOT NULL", name: "submission_set_members_state_exclusivity"
+  end
+
+  create_table "submission_sets", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "owner_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["owner_id"], name: "index_submission_sets_on_owner_id"
+  end
+
   create_table "submission_updates", force: :cascade do |t|
     t.string "actor"
     t.datetime "created_at", null: false
@@ -450,6 +489,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_145311) do
   add_foreign_key "submission_requests", "submissions"
   add_foreign_key "submission_requests", "users"
   add_foreign_key "submission_requests", "users", column: "assignee_id"
+  add_foreign_key "submission_set_inclusions", "submission_requests"
+  add_foreign_key "submission_set_inclusions", "submission_sets"
+  add_foreign_key "submission_set_inclusions", "users", column: "added_by_id"
+  add_foreign_key "submission_set_members", "submission_sets"
+  add_foreign_key "submission_set_members", "users"
+  add_foreign_key "submission_set_members", "users", column: "invited_by_id"
+  add_foreign_key "submission_sets", "users", column: "owner_id"
   add_foreign_key "submission_updates", "submissions"
   add_foreign_key "submissions", "submission_updates", column: "cached_at_update_id", on_delete: :nullify
   add_foreign_key "submissions", "users"

--- a/schema/openapi.d.ts
+++ b/schema/openapi.d.ts
@@ -1027,6 +1027,616 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/sets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Sets you belong to. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Every set this account has joined. Outstanding invitations are not membership and do not appear here. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SetSummary"][];
+                    };
+                };
+                401: components["responses"]["Unauthorized"];
+            };
+        };
+        put?: never;
+        /** @description Create a set. You become its owner and its first member. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        set: {
+                            name: string;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description The new set. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Set"];
+                    };
+                };
+                401: components["responses"]["Unauthorized"];
+                /** @description Sets cannot be changed while acting as another account. */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                422: components["responses"]["UnprocessableContent"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sets/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: number;
+            };
+            cookie?: never;
+        };
+        /**
+         * @description One set: its roster and a page of the submissions in it. A set you
+         *     are not in answers 404 rather than 403 — from outside, it is not a
+         *     set you have an id for.
+         *
+         *     The roster comes whole (a set is people, and there are not many of
+         *     them); the submissions are paginated, because a study that ran for
+         *     three years is hundreds of them and each one renders a progress block.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    page?: number;
+                };
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The set. */
+                200: {
+                    headers: {
+                        "Total-Pages"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Set"];
+                    };
+                };
+                401: components["responses"]["Unauthorized"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        /**
+         * @description Delete a set. The owner's, and only once everyone else has left and
+         *     every submission has been taken out — the submissions are their
+         *     owners' to remove, and the people are not the owner's to dissolve.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Deleted. */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                /** @description The set still has other members or submissions in it. */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** @description Rename a set. The owner's, not every member's. */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        set: {
+                            name: string;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description The renamed set. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Set"];
+                    };
+                };
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                422: components["responses"]["UnprocessableContent"];
+            };
+        };
+        trace?: never;
+    };
+    "/sets/{set_id}/members": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * @description Invite somebody by email. Any member may invite. The mail carries a
+         *     single-use link; what is checked on the way in is that link and not
+         *     the address, so the recipient may accept with an account registered
+         *     at a different address — the roster says so when they do.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    set_id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        set_member: {
+                            email: string;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /**
+                 * @description The invited member, with the invitation still outstanding. Check
+                 *     `mail_deliverable`: where outgoing mail is restricted the invitation
+                 *     is real but nobody was told, and `invitation_url` is what to send.
+                 */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SetMember"];
+                    };
+                };
+                401: components["responses"]["Unauthorized"];
+                /** @description Sets cannot be changed while acting as another account. */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                404: components["responses"]["NotFound"];
+                422: components["responses"]["UnprocessableContent"];
+                /** @description Too many invitations in a short time. */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sets/{set_id}/members/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+                id: number;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * @description Leave, take back an invitation you sent, or (as the owner) remove
+         *     somebody. Removing a member takes their submissions out of the set
+         *     with them: the set was the only thing letting the others read that
+         *     work.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    set_id: number;
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Removed. */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                /** @description The owner cannot leave their own set. */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sets/{set_id}/members/{member_id}/reminder": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+                member_id: number;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * @description Send the invitation again. A fresh token and a fresh clock, so the
+         *     link that did not get used stops working.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    set_id: number;
+                    member_id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The member, with a new invitation outstanding. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SetMember"];
+                    };
+                };
+                401: components["responses"]["Unauthorized"];
+                /** @description Sets cannot be changed while acting as another account. */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                404: components["responses"]["NotFound"];
+                /** @description That person has already joined. */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sets/{set_id}/submissions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * @description Put one of your submissions in the set, which is what lets the
+         *     set's members read it. Yours only — reading somebody else's
+         *     through a shared set does not carry the right to hand it on.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    set_id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        submission: {
+                            submission_request_id: number;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /**
+                 * @description Added. No body: answering with the set would mean loading a page of
+                 *     it — a progress block and an accession summary per row — for
+                 *     something the client re-reads anyway. 204 rather than 201 because
+                 *     204 is the status that says there is no body to read.
+                 */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                401: components["responses"]["Unauthorized"];
+                /** @description Sets cannot be changed while acting as another account. */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                404: components["responses"]["NotFound"];
+                422: components["responses"]["UnprocessableContent"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sets/{set_id}/submissions/{submission_request_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+                submission_request_id: number;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** @description Take your submission back out of the set. */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    set_id: number;
+                    submission_request_id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Removed. */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/invitations/{token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * @description What an invitation link is for, readable without an account — the
+         *     person holding it may not have one yet. An expired invitation is
+         *     answered rather than hidden: the holder is the intended recipient,
+         *     and "ask them to send it again" is the only thing that unsticks them.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    token: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The invitation. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Invitation"];
+                    };
+                };
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/invitations/{invitation_token}/acceptance": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                invitation_token: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Walk through the invitation and join the set. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    invitation_token: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /**
+                 * @description The set you have joined — or were already in, if this invitation
+                 *     was a second one sent to the same person, in which case it is simply
+                 *     spent.
+                 */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SetSummary"];
+                    };
+                };
+                401: components["responses"]["Unauthorized"];
+                404: components["responses"]["NotFound"];
+                /** @description The invitation has expired, or somebody has already used it. */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/stats": {
         parameters: {
             query?: never;
@@ -1117,6 +1727,138 @@ export interface components {
             unread_curator_message_count: number;
             progress: components["schemas"]["Progress"];
         };
+        SetSummary: {
+            id: number;
+            name: string;
+            owner_uid: string;
+            /** @description You created it, so renaming and deleting it are yours. */
+            owned: boolean;
+            /** Format: date-time */
+            created_at: string;
+            /** @description People who have accepted. */
+            member_count: number;
+            /** @description Invitations still outstanding. */
+            invited_count: number;
+            submission_count: number;
+        };
+        Set: {
+            id: number;
+            name: string;
+            owner_uid: string;
+            owned: boolean;
+            /** Format: date-time */
+            created_at: string;
+            member_count: number;
+            invited_count: number;
+            submission_count: number;
+            /**
+             * @description Whether the set can be deleted now — only once everyone else has
+             *     left and every submission has been taken out. Deleting is the
+             *     owner's; this says nothing about who you are.
+             */
+            deletable: boolean;
+            /**
+             * @description Why it cannot be, in words. Null when it can. Served rather than
+             *     re-worded by the client, so the rule and its wording stay together.
+             */
+            delete_blocked_reason: string | null;
+            members: components["schemas"]["SetMember"][];
+            submissions: components["schemas"]["SetSubmission"][];
+        };
+        SetMember: {
+            id: number;
+            /** @description The address the invitation was sent to. Null on the creator's own row, who was never invited. */
+            email: string | null;
+            /** @description The account that accepted. Null while the invitation is still out. */
+            uid: string | null;
+            /**
+             * @description `accepted` — they are in. `open` — the invitation is out and live.
+             *     `expired` — it lapsed; any member can send it again. The same three
+             *     words the invitation page uses, so the roster and the link cannot
+             *     describe one row differently.
+             * @enum {string}
+             */
+            status: "open" | "expired" | "accepted";
+            owner: boolean;
+            you: boolean;
+            invited_by: string;
+            /** Format: date-time */
+            joined_at: string | null;
+            /** Format: date-time */
+            invitation_expires_at: string | null;
+            /**
+             * @description Whether you may take this row off the roster — by leaving, by
+             *     removing somebody as the owner, or by taking back an invitation you
+             *     sent. Stated by the server because the three are different
+             *     permissions and, under a proxy login, the account the client
+             *     believes it is is not the account the server acts as.
+             */
+            removable: boolean;
+            /**
+             * @description How many of this set's submissions are theirs, and would therefore
+             *     be taken out of it with them. Counted over the whole set, not over
+             *     the page of submissions being shown.
+             */
+            submission_count: number;
+            /**
+             * @description Whether the account that walked through the invitation is registered
+             *     at the address it was sent to. `unknown` when that account carries
+             *     no address at all — most accounts imported from D-way have never
+             *     signed in. Null where the question does not arise: the creator's own
+             *     row, which was never invited.
+             *
+             *     A forwarded invitation is a real thing people do, so this is
+             *     reported rather than refused — it is the whole of the audit that
+             *     pays for not binding the token to the address.
+             * @enum {string|null}
+             */
+            invited_address_match: "same" | "different" | "unknown" | null;
+            /**
+             * @description The link an outstanding invitation was mailed as. Null once it has
+             *     been walked through. Offered to members so they can send it by hand
+             *     when the mail did not arrive — which includes every environment
+             *     where outgoing mail is restricted (see `mail_deliverable`).
+             */
+            invitation_url: string | null;
+            /**
+             * @description Whether the invitation mail actually leaves the building. False in a
+             *     deployed environment whose outgoing mail is restricted to DDBJ
+             *     addresses, in which case the invitation exists and works but nobody
+             *     was told about it — hand them `invitation_url` instead. Null once
+             *     the invitation has been walked through.
+             */
+            mail_deliverable: boolean | null;
+        };
+        SetSubmission: {
+            /** Format: date-time */
+            added_at: string;
+            /** @description Whose submission this is. In every other list it goes without saying; here it is the first thing a reader needs. */
+            owner_uid: string;
+            /**
+             * @description It is yours, so taking it out of the set is yours to do. Said by
+             *     the server for the same reason `removable` is on a member.
+             */
+            owned: boolean;
+            submission: components["schemas"]["SubmissionRequestSummary"];
+        };
+        Invitation: {
+            set_name: string;
+            invited_by: string;
+            email: string;
+            /**
+             * Format: date-time
+             * @description Null once the invitation has been walked through.
+             */
+            expires_at: string | null;
+            /**
+             * @description `open` — ready to be walked through. `expired` — ask a member of the
+             *     set to send it again. `accepted` — somebody has already used this
+             *     link; the token is kept after acceptance precisely so the page can
+             *     say so instead of answering with a 404.
+             * @enum {string}
+             */
+            status: "open" | "expired" | "accepted";
+        };
         ReviewerAccess: {
             enabled: boolean;
             url?: string;
@@ -1151,6 +1893,15 @@ export interface components {
             /** Format: date-time */
             created_at: string;
             /**
+             * @description The sets this submission has been shared into. Withheld from the
+             *     reviewer view — somebody holding a share link is not party to who
+             *     else is working on this.
+             */
+            sets: {
+                id: number;
+                name: string;
+            }[];
+            /**
              * Format: date-time
              * @description When the submitter put this request down. A request that failed
              *     validation cannot be advanced — a corrected file arrives as a new
@@ -1159,10 +1910,24 @@ export interface components {
              */
             closed_at: string | null;
             /**
-             * @description Whether the submitter may close it now. True only while the request
-             *     is asking them for something (validation failed, or ready to apply).
+             * @description Whether you may close it now. True only while the request is asking
+             *     its owner for something (validation failed, or ready to apply) —
+             *     and never for somebody reading it through a shared set.
              */
             closable: boolean;
+            /**
+             * @description You are the submitter. False when you are reading this through a
+             *     set somebody else's submission was shared into, in which case
+             *     nothing on the page is yours to press and the conversation facts
+             *     are withheld.
+             */
+            owned: boolean;
+            /**
+             * @description Whose submission this is. Yours when `owned`; otherwise the
+             *     colleague whose work you are reading through a shared set — the
+             *     page says so rather than addressing you as its submitter.
+             */
+            owner_uid: string;
             processing: boolean;
             ddbj_record: components["schemas"]["Attachment"];
             validation: components["schemas"]["Validation"] | null;

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -1023,6 +1023,553 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /sets:
+    get:
+      description: Sets you belong to.
+
+      tags:
+        - Sets
+
+      responses:
+        '200':
+          description: Every set this account has joined. Outstanding invitations are not membership and do not appear here.
+
+          content:
+            application/json:
+              schema:
+                type: array
+
+                items:
+                  $ref: '#/components/schemas/SetSummary'
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+    post:
+      description: Create a set. You become its owner and its first member.
+
+      tags:
+        - Sets
+
+      requestBody:
+        required: true
+
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [set]
+
+              properties:
+                set:
+                  type: object
+                  additionalProperties: false
+                  required: [name]
+
+                  properties:
+                    name:
+                      type: string
+
+      responses:
+        '201':
+          description: The new set.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Set'
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '403':
+          description: Sets cannot be changed while acting as another account.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
+
+  /sets/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+    get:
+      description: |
+        One set: its roster and a page of the submissions in it. A set you
+        are not in answers 404 rather than 403 — from outside, it is not a
+        set you have an id for.
+
+        The roster comes whole (a set is people, and there are not many of
+        them); the submissions are paginated, because a study that ran for
+        three years is hundreds of them and each one renders a progress block.
+
+      tags:
+        - Sets
+
+      parameters:
+        - name: page
+          in: query
+
+          schema:
+            type: number
+
+      responses:
+        '200':
+          description: The set.
+
+          headers:
+            Total-Pages:
+              schema:
+                type: string
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Set'
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    patch:
+      description: Rename a set. The owner's, not every member's.
+
+      tags:
+        - Sets
+
+      requestBody:
+        required: true
+
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [set]
+
+              properties:
+                set:
+                  type: object
+                  additionalProperties: false
+                  required: [name]
+
+                  properties:
+                    name:
+                      type: string
+
+      responses:
+        '200':
+          description: The renamed set.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Set'
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
+
+    delete:
+      description: |
+        Delete a set. The owner's, and only once everyone else has left and
+        every submission has been taken out — the submissions are their
+        owners' to remove, and the people are not the owner's to dissolve.
+
+      tags:
+        - Sets
+
+      responses:
+        '204':
+          description: Deleted.
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+        '422':
+          description: The set still has other members or submissions in it.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /sets/{set_id}/members:
+    parameters:
+      - name: set_id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+    post:
+      description: |
+        Invite somebody by email. Any member may invite. The mail carries a
+        single-use link; what is checked on the way in is that link and not
+        the address, so the recipient may accept with an account registered
+        at a different address — the roster says so when they do.
+
+      tags:
+        - Sets
+
+      requestBody:
+        required: true
+
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [set_member]
+
+              properties:
+                set_member:
+                  type: object
+                  additionalProperties: false
+                  required: [email]
+
+                  properties:
+                    email:
+                      type: string
+
+      responses:
+        '201':
+          description: |
+            The invited member, with the invitation still outstanding. Check
+            `mail_deliverable`: where outgoing mail is restricted the invitation
+            is real but nobody was told, and `invitation_url` is what to send.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetMember'
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '403':
+          description: Sets cannot be changed while acting as another account.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
+
+        '429':
+          description: Too many invitations in a short time.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /sets/{set_id}/members/{id}:
+    parameters:
+      - name: set_id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+      - name: id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+    delete:
+      description: |
+        Leave, take back an invitation you sent, or (as the owner) remove
+        somebody. Removing a member takes their submissions out of the set
+        with them: the set was the only thing letting the others read that
+        work.
+
+      tags:
+        - Sets
+
+      responses:
+        '204':
+          description: Removed.
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+        '422':
+          description: The owner cannot leave their own set.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /sets/{set_id}/members/{member_id}/reminder:
+    parameters:
+      - name: set_id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+      - name: member_id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+    post:
+      description: |
+        Send the invitation again. A fresh token and a fresh clock, so the
+        link that did not get used stops working.
+
+      tags:
+        - Sets
+
+      responses:
+        '201':
+          description: The member, with a new invitation outstanding.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetMember'
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '403':
+          description: Sets cannot be changed while acting as another account.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+        '422':
+          description: That person has already joined.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /sets/{set_id}/submissions:
+    parameters:
+      - name: set_id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+    post:
+      description: |
+        Put one of your submissions in the set, which is what lets the
+        set's members read it. Yours only — reading somebody else's
+        through a shared set does not carry the right to hand it on.
+
+      tags:
+        - Sets
+
+      requestBody:
+        required: true
+
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [submission]
+
+              properties:
+                submission:
+                  type: object
+                  additionalProperties: false
+                  required: [submission_request_id]
+
+                  properties:
+                    submission_request_id:
+                      type: number
+
+      responses:
+        '204':
+          description: |
+            Added. No body: answering with the set would mean loading a page of
+            it — a progress block and an accession summary per row — for
+            something the client re-reads anyway. 204 rather than 201 because
+            204 is the status that says there is no body to read.
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '403':
+          description: Sets cannot be changed while acting as another account.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
+
+  /sets/{set_id}/submissions/{submission_request_id}:
+    parameters:
+      - name: set_id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+      - name: submission_request_id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+    delete:
+      description: Take your submission back out of the set.
+
+      tags:
+        - Sets
+
+      responses:
+        '204':
+          description: Removed.
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /invitations/{token}:
+    parameters:
+      - name: token
+        in: path
+        required: true
+
+        schema:
+          type: string
+
+    get:
+      description: |
+        What an invitation link is for, readable without an account — the
+        person holding it may not have one yet. An expired invitation is
+        answered rather than hidden: the holder is the intended recipient,
+        and "ask them to send it again" is the only thing that unsticks them.
+
+      security: []
+
+      tags:
+        - Sets
+
+      responses:
+        '200':
+          description: The invitation.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Invitation'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /invitations/{invitation_token}/acceptance:
+    parameters:
+      - name: invitation_token
+        in: path
+        required: true
+
+        schema:
+          type: string
+
+    post:
+      description: Walk through the invitation and join the set.
+
+      tags:
+        - Sets
+
+      responses:
+        '201':
+          description: |
+            The set you have joined — or were already in, if this invitation
+            was a second one sent to the same person, in which case it is simply
+            spent.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetSummary'
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+        '422':
+          description: The invitation has expired, or somebody has already used it.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /stats:
     get:
       description: |
@@ -1155,8 +1702,13 @@ components:
           format: date-time
 
         submission_id:
-          type: number
-          nullable: true
+          # `type: [number, 'null']`, not OpenAPI 3.0's `nullable: true` —
+          # this document is 3.1, where `nullable` is not a keyword at all
+          # and was silently declaring the field non-null. Every request
+          # that has not been applied yet sends null here.
+          type:
+            - number
+            - 'null'
 
         source_id:
           type:
@@ -1180,6 +1732,317 @@ components:
 
         progress:
           $ref: '#/components/schemas/Progress'
+
+    SetSummary:
+      type: object
+      additionalProperties: false
+
+      required:
+        - id
+        - name
+        - owner_uid
+        - owned
+        - created_at
+        - member_count
+        - invited_count
+        - submission_count
+
+      properties:
+        id:
+          type: number
+
+        name:
+          type: string
+
+        owner_uid:
+          type: string
+
+        owned:
+          description: You created it, so renaming and deleting it are yours.
+          type: boolean
+
+        created_at:
+          type: string
+          format: date-time
+
+        member_count:
+          description: People who have accepted.
+          type: number
+
+        invited_count:
+          description: Invitations still outstanding.
+          type: number
+
+        submission_count:
+          type: number
+
+    Set:
+      type: object
+      additionalProperties: false
+
+      required:
+        - id
+        - name
+        - owner_uid
+        - owned
+        - created_at
+        - member_count
+        - invited_count
+        - submission_count
+        - deletable
+        - delete_blocked_reason
+        - members
+        - submissions
+
+      properties:
+        id:
+          type: number
+
+        name:
+          type: string
+
+        owner_uid:
+          type: string
+
+        owned:
+          type: boolean
+
+        created_at:
+          type: string
+          format: date-time
+
+        member_count:
+          type: number
+
+        invited_count:
+          type: number
+
+        submission_count:
+          type: number
+
+        deletable:
+          description: |
+            Whether the set can be deleted now — only once everyone else has
+            left and every submission has been taken out. Deleting is the
+            owner's; this says nothing about who you are.
+          type: boolean
+
+        delete_blocked_reason:
+          description: |
+            Why it cannot be, in words. Null when it can. Served rather than
+            re-worded by the client, so the rule and its wording stay together.
+          type:
+            - string
+            - 'null'
+
+        members:
+          type: array
+
+          items:
+            $ref: '#/components/schemas/SetMember'
+
+        submissions:
+          type: array
+
+          items:
+            $ref: '#/components/schemas/SetSubmission'
+
+    SetMember:
+      type: object
+      additionalProperties: false
+
+      required:
+        - id
+        - email
+        - uid
+        - status
+        - owner
+        - you
+        - invited_by
+        - joined_at
+        - invitation_expires_at
+        - removable
+        - submission_count
+        - invited_address_match
+        - invitation_url
+        - mail_deliverable
+
+      properties:
+        id:
+          type: number
+
+        email:
+          description: The address the invitation was sent to. Null on the creator's own row, who was never invited.
+          type:
+            - string
+            - 'null'
+
+        uid:
+          description: The account that accepted. Null while the invitation is still out.
+          type:
+            - string
+            - 'null'
+
+        status:
+          description: |
+            `accepted` — they are in. `open` — the invitation is out and live.
+            `expired` — it lapsed; any member can send it again. The same three
+            words the invitation page uses, so the roster and the link cannot
+            describe one row differently.
+          type: string
+
+          enum:
+            - open
+            - expired
+            - accepted
+
+        owner:
+          type: boolean
+
+        you:
+          type: boolean
+
+        invited_by:
+          type: string
+
+        joined_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+
+        invitation_expires_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+
+        removable:
+          description: |
+            Whether you may take this row off the roster — by leaving, by
+            removing somebody as the owner, or by taking back an invitation you
+            sent. Stated by the server because the three are different
+            permissions and, under a proxy login, the account the client
+            believes it is is not the account the server acts as.
+          type: boolean
+
+        submission_count:
+          description: |
+            How many of this set's submissions are theirs, and would therefore
+            be taken out of it with them. Counted over the whole set, not over
+            the page of submissions being shown.
+          type: number
+
+        invited_address_match:
+          description: |
+            Whether the account that walked through the invitation is registered
+            at the address it was sent to. `unknown` when that account carries
+            no address at all — most accounts imported from D-way have never
+            signed in. Null where the question does not arise: the creator's own
+            row, which was never invited.
+
+            A forwarded invitation is a real thing people do, so this is
+            reported rather than refused — it is the whole of the audit that
+            pays for not binding the token to the address.
+          type:
+            - string
+            - 'null'
+
+          enum:
+            - same
+            - different
+            - unknown
+            - null
+
+        invitation_url:
+          description: |
+            The link an outstanding invitation was mailed as. Null once it has
+            been walked through. Offered to members so they can send it by hand
+            when the mail did not arrive — which includes every environment
+            where outgoing mail is restricted (see `mail_deliverable`).
+          type:
+            - string
+            - 'null'
+
+        mail_deliverable:
+          description: |
+            Whether the invitation mail actually leaves the building. False in a
+            deployed environment whose outgoing mail is restricted to DDBJ
+            addresses, in which case the invitation exists and works but nobody
+            was told about it — hand them `invitation_url` instead. Null once
+            the invitation has been walked through.
+          type:
+            - boolean
+            - 'null'
+
+    SetSubmission:
+      type: object
+      additionalProperties: false
+
+      required:
+        - added_at
+        - owner_uid
+        - owned
+        - submission
+
+      properties:
+        added_at:
+          type: string
+          format: date-time
+
+        owner_uid:
+          description: Whose submission this is. In every other list it goes without saying; here it is the first thing a reader needs.
+          type: string
+
+        owned:
+          description: |
+            It is yours, so taking it out of the set is yours to do. Said by
+            the server for the same reason `removable` is on a member.
+          type: boolean
+
+        submission:
+          $ref: '#/components/schemas/SubmissionRequestSummary'
+
+    Invitation:
+      type: object
+      additionalProperties: false
+
+      required:
+        - set_name
+        - invited_by
+        - email
+        - expires_at
+        - status
+
+      properties:
+        set_name:
+          type: string
+
+        invited_by:
+          type: string
+
+        email:
+          type: string
+
+        expires_at:
+          description: Null once the invitation has been walked through.
+          type:
+            - string
+            - 'null'
+          format: date-time
+
+        status:
+          description: |
+            `open` — ready to be walked through. `expired` — ask a member of the
+            set to send it again. `accepted` — somebody has already used this
+            link; the token is kept after acceptance precisely so the page can
+            say so instead of answering with a 404.
+          type: string
+
+          enum:
+            - open
+            - expired
+            - accepted
 
     ReviewerAccess:
       type: object
@@ -1248,6 +2111,8 @@ components:
         - created_at
         - closed_at
         - closable
+        - owned
+        - owner_uid
         - processing
         - ddbj_record
         - validation
@@ -1255,6 +2120,7 @@ components:
         - progress
         - unread_curator_message_count
         - last_message_at
+        - sets
 
       properties:
         id:
@@ -1285,6 +2151,25 @@ components:
           type: string
           format: date-time
 
+        sets:
+          description: |
+            The sets this submission has been shared into. Withheld from the
+            reviewer view — somebody holding a share link is not party to who
+            else is working on this.
+          type: array
+
+          items:
+            type: object
+            additionalProperties: false
+            required: [id, name]
+
+            properties:
+              id:
+                type: number
+
+              name:
+                type: string
+
         closed_at:
           description: |
             When the submitter put this request down. A request that failed
@@ -1298,9 +2183,25 @@ components:
 
         closable:
           description: |
-            Whether the submitter may close it now. True only while the request
-            is asking them for something (validation failed, or ready to apply).
+            Whether you may close it now. True only while the request is asking
+            its owner for something (validation failed, or ready to apply) —
+            and never for somebody reading it through a shared set.
           type: boolean
+
+        owned:
+          description: |
+            You are the submitter. False when you are reading this through a
+            set somebody else's submission was shared into, in which case
+            nothing on the page is yours to press and the conversation facts
+            are withheld.
+          type: boolean
+
+        owner_uid:
+          description: |
+            Whose submission this is. Yours when `owned`; otherwise the
+            colleague whose work you are reading through a shared set — the
+            page says so rather than addressing you as its submitter.
+          type: string
 
         processing:
           type: boolean

--- a/test/integration/invitations_test.rb
+++ b/test/integration/invitations_test.rb
@@ -1,0 +1,116 @@
+require 'test_helper'
+
+class InvitationsTest < ActionDispatch::IntegrationTest
+  setup do
+    @alice = users(:alice)
+    @carol = users(:carol)
+
+    @set  = SubmissionSet.create!(name: 'Deep sea study', owner: @alice)
+    @member = @set.members.create!(email: 'newcomer@example.org', invited_by: @alice)
+  end
+
+  test 'the landing page reads without an account' do
+    get invitation_path(@member.invitation_token)
+
+    assert_conform_schema 200
+
+    body = response.parsed_body
+
+    assert_equal 'Deep sea study',       body['set_name']
+    assert_equal @alice.uid,             body['invited_by']
+    assert_equal 'newcomer@example.org', body['email']
+    assert_equal 'open',                 body['status']
+  end
+
+  test 'an expired invitation says so rather than hiding' do
+    @member.update_columns(invitation_expires_at: 1.day.ago)
+
+    get invitation_path(@member.invitation_token)
+
+    assert_conform_schema 200
+    assert_equal 'expired', response.parsed_body['status']
+  end
+
+  # The token is kept after acceptance for exactly this: somebody opening
+  # the mail again from another device is told what happened rather than
+  # shown a 404 for a link that worked perfectly.
+  test 'a link that has already been used says so' do
+    @member.accept!(@carol)
+
+    get invitation_path(@member.invitation_token)
+
+    assert_conform_schema 200
+    assert_equal 'accepted', response.parsed_body['status']
+  end
+
+  test 'an unknown token is not found' do
+    with_exceptions_app do
+      get invitation_path('nope')
+    end
+
+    assert_conform_schema 404
+  end
+
+  test 'accepting joins the set, whatever address the account is registered at' do
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    post invitation_acceptance_path(@member.invitation_token)
+
+    assert_conform_schema 201
+    assert_equal 'Deep sea study', response.parsed_body['name']
+
+    @member.reload
+
+    assert_equal @carol.id, @member.user_id
+    assert       @set.member?(@carol)
+  end
+
+  test 'the link stops working once somebody has walked through it' do
+    token = @member.invitation_token
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+    post invitation_acceptance_path(token)
+
+    default_headers['Authorization'] = "Bearer #{users(:dave).api_key}"
+
+    with_exceptions_app do
+      post invitation_acceptance_path(token)
+    end
+
+    assert_conform_schema 422
+    assert_not @set.member?(users(:dave))
+  end
+
+  test 'an expired invitation cannot be walked through' do
+    @member.update_columns(invitation_expires_at: 1.day.ago)
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    with_exceptions_app do
+      post invitation_acceptance_path(@member.invitation_token)
+    end
+
+    assert_conform_schema 422
+  end
+
+  # Two people inviting the same person is a thing that happens. They
+  # wanted to be in the set and they are, so the second link is simply
+  # spent — left outstanding it would count against the set for ever
+  # and block its deletion.
+  test 'a second invitation to a set you are already in is spent, not refused' do
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    post invitation_acceptance_path(@member.invitation_token)
+
+    assert_conform_schema 201
+    assert_not SubmissionSetMember.exists?(@member.id)
+  end
+
+  test 'accepting without logging in is refused' do
+    post invitation_acceptance_path(@member.invitation_token)
+
+    assert_conform_schema 401
+  end
+end

--- a/test/integration/set_members_test.rb
+++ b/test/integration/set_members_test.rb
@@ -1,0 +1,243 @@
+require 'test_helper'
+
+class SubmissionSetMembersTest < ActionDispatch::IntegrationTest
+  JSON_HEADERS = {'Content-Type' => 'application/json'}.freeze
+
+  setup do
+    @alice = users(:alice)
+    @carol = users(:carol)
+
+    default_headers['Authorization'] = "Bearer #{@alice.api_key}"
+
+    @set = SubmissionSet.create!(name: 'Deep sea study', owner: @alice)
+  end
+
+  test 'inviting mails the address a single-use link' do
+    assert_difference 'SubmissionSetMember.count', 1 do
+      assert_enqueued_emails 1 do
+        post set_members_path(@set),
+             params:  {set_member: {email: ' Newcomer@Example.ORG '}}.to_json,
+             headers: JSON_HEADERS
+      end
+    end
+
+    assert_conform_schema 201
+
+    body = response.parsed_body
+
+    assert_equal 'newcomer@example.org', body['email']
+    assert_equal 'open', body['status']
+    assert_nil   body['uid']
+  end
+
+  test 'any member can invite, not just the owner' do
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    post set_members_path(@set), params: {set_member: {email: 'newcomer@example.org'}}.to_json, headers: JSON_HEADERS
+
+    assert_conform_schema 201
+  end
+
+  test 'inviting somebody already on the roster is refused' do
+    @carol.update!(email: 'carol@example.com')
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    with_exceptions_app do
+      post set_members_path(@set),
+           params:  {set_member: {email: 'Carol@Example.com'}}.to_json,
+           headers: JSON_HEADERS
+    end
+
+    assert_conform_schema 422
+  end
+
+  test 'resending mints a new token and kills the old link' do
+    member = @set.members.create!(email: 'newcomer@example.org', invited_by: @alice)
+    was    = member.invitation_token
+
+    assert_enqueued_emails 1 do
+      post set_member_reminder_path(@set, member)
+    end
+
+    assert_conform_schema 201
+    assert_not_equal was, member.reload.invitation_token
+  end
+
+  test 'resending to somebody who has already joined is refused' do
+    member = @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    with_exceptions_app do
+      post set_member_reminder_path(@set, member)
+    end
+
+    assert_conform_schema 422
+  end
+
+  test 'a member can leave, and their submissions go with them' do
+    member = @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    carols = @carol.submission_requests.create!(db: 'bioproject', status: :applied, migration_run_id: SecureRandom.uuid)
+    @set.inclusions.create!(submission_request: carols, added_by: @carol)
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    delete set_member_path(@set, member)
+
+    assert_conform_schema 204
+    assert_empty @set.inclusions.reload
+  end
+
+  test 'one member cannot remove another' do
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    dave   = users(:dave)
+    target = @set.members.create!(user: dave, invited_by: @alice, joined_at: Time.current)
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    with_exceptions_app do
+      delete set_member_path(@set, target)
+    end
+
+    assert_conform_schema 403
+  end
+
+  test 'the owner can remove anybody' do
+    target = @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    delete set_member_path(@set, target)
+
+    assert_conform_schema 204
+  end
+
+  test 'the person who sent an invitation can take it back' do
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    post set_members_path(@set), params: {set_member: {email: 'newcomer@example.org'}}.to_json, headers: JSON_HEADERS
+
+    delete set_member_path(@set, response.parsed_body['id'])
+
+    assert_conform_schema 204
+  end
+
+  test 'the owner cannot walk out of their own set' do
+    with_exceptions_app do
+      delete set_member_path(@set, @set.members.find_by!(user_id: @alice.id))
+    end
+
+    assert_conform_schema 422
+  end
+
+  # Every deployed environment restricts outgoing mail while sending to
+  # real submitters is switched off. Without this the feature looks like
+  # it works and reaches nobody — so the answer says whether the mail left
+  # the building, and hands over the link either way.
+  test 'the answer says whether the mail actually goes anywhere, and carries the link regardless' do
+    restrict_mail_to('ddbj.nig.ac.jp') do
+      post set_members_path(@set),
+           params:  {set_member: {email: 'colleague@university.edu'}}.to_json,
+           headers: JSON_HEADERS
+
+      assert_conform_schema 201
+
+      body = response.parsed_body
+
+      assert_equal false, body['mail_deliverable']
+      assert_match %r{/web/invitations/.+}, body['invitation_url']
+    end
+  end
+
+  test 'a link is only offered while the invitation is outstanding' do
+    member = @set.members.create!(email: 'newcomer@example.org', invited_by: @alice)
+    member.accept!(@carol)
+
+    get set_path(@set)
+
+    assert_conform_schema 200
+
+    row = response.parsed_body['members'].find { it['uid'] == @carol.uid }
+
+    assert_nil row['invitation_url']
+    assert_nil row['mail_deliverable']
+  end
+
+  test 'the roster says what each row may have done to it' do
+    invited = @set.members.create!(email: 'newcomer@example.org', invited_by: @alice)
+    joined  = @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    get set_path(@set)
+
+    rows = response.parsed_body['members'].index_by { it['id'] }
+
+    assert_equal false, rows.fetch(@set.members.find_by!(user_id: @alice.id).id)['removable'] # the owner's own row
+    assert_equal true,  rows.fetch(invited.id)['removable']
+    assert_equal true,  rows.fetch(joined.id)['removable']
+
+    # ...and the same roster read by somebody who is not the owner.
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    get set_path(@set)
+
+    rows = response.parsed_body['members'].index_by { it['id'] }
+
+    assert_equal true,  rows.fetch(joined.id)['removable']  # leaving
+    assert_equal false, rows.fetch(invited.id)['removable'] # somebody else's invitation
+  end
+
+  test 'a member who invited somebody can take that invitation back' do
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    post set_members_path(@set), params: {set_member: {email: 'newcomer@example.org'}}.to_json, headers: JSON_HEADERS
+
+    assert_equal true, response.parsed_body['removable']
+
+    delete set_member_path(@set, response.parsed_body['id'])
+
+    assert_conform_schema 204
+  end
+
+  test 'a set you are not in has no roster to write to' do
+    other = SubmissionSet.create!(name: 'Not yours', owner: @carol)
+
+    with_exceptions_app do
+      post set_members_path(other), params: {set_member: {email: 'newcomer@example.org'}}.to_json, headers: JSON_HEADERS
+    end
+
+    assert_conform_schema 404
+
+    member = other.members.sole
+
+    with_exceptions_app { delete set_member_path(other, member) }
+    assert_conform_schema 404
+
+    with_exceptions_app { post set_member_reminder_path(other, member) }
+    assert_conform_schema 404
+  end
+
+  # Acting as somebody else is for helping them with what they submitted.
+  # Deciding who they collaborate with is not that, and the row would
+  # record the wrong person as having done it.
+  test 'a curator acting as somebody else cannot write to their sets' do
+    curator = users(:bob)
+
+    default_headers['Authorization']   = "Bearer #{curator.api_key}"
+    default_headers['X-Dway-User-Id']  = @alice.uid
+
+    with_exceptions_app do
+      post set_members_path(@set), params: {set_member: {email: 'newcomer@example.org'}}.to_json, headers: JSON_HEADERS
+    end
+
+    assert_conform_schema 403
+
+    # Reading is untouched.
+    get set_path(@set)
+
+    assert_conform_schema 200
+  end
+end

--- a/test/integration/set_sharing_boundary_test.rb
+++ b/test/integration/set_sharing_boundary_test.rb
@@ -1,0 +1,118 @@
+require 'test_helper'
+
+# What being able to READ somebody's submission through a set does not
+# get you.
+#
+# `SubmissionRequestsController#show` was widened to `readable_by`; every
+# other endpoint that takes a submission request id stayed owner-scoped.
+# That boundary is the whole security story of the widening, and it is
+# held by one line in each of five controllers — exactly the shape a
+# future refactor "helpfully" unifies. These tests are what would notice.
+class GroupSharingBoundaryTest < ActionDispatch::IntegrationTest
+  setup do
+    @alice = users(:alice)
+    @carol = users(:carol)
+
+    # Carol's submission, shared into a set Alice is in.
+    @theirs = @carol.submission_requests.create!(db: 'bioproject', status: :ready_to_apply, migration_run_id: SecureRandom.uuid)
+    attach_ddbj_record @theirs
+
+    set = SubmissionSet.create!(name: 'Deep sea study', owner: @alice)
+    set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+    set.inclusions.create!(submission_request: @theirs, added_by: @carol)
+
+    default_headers['Authorization'] = "Bearer #{@alice.api_key}"
+  end
+
+  test 'reading it is allowed' do
+    get submission_request_path(@theirs)
+
+    assert_conform_schema 200
+    assert_equal false, response.parsed_body['owned']
+  end
+
+  test 'the conversation is not' do
+    with_exceptions_app { get submission_request_messages_path(@theirs) }
+    assert_response :not_found
+
+    with_exceptions_app do
+      post submission_request_messages_path(@theirs),
+           params:  {submission_message: {body: 'Hello'}}.to_json,
+           headers: {'Content-Type' => 'application/json'}
+    end
+    assert_response :not_found
+  end
+
+  test 'minting a share link for it is not' do
+    with_exceptions_app { get submission_request_reviewer_access_path(@theirs) }
+    assert_response :not_found
+
+    with_exceptions_app do
+      post submission_request_reviewer_access_path(@theirs),
+           params:  {reviewer_access: {expires_at: 1.week.from_now.iso8601}}.to_json,
+           headers: {'Content-Type' => 'application/json'}
+    end
+    assert_response :not_found
+  end
+
+  test 'closing it is not' do
+    with_exceptions_app { post submission_request_closure_path(@theirs) }
+    assert_response :not_found
+  end
+
+  test 'polling its status is not' do
+    with_exceptions_app { get submission_request_status_path(@theirs) }
+    assert_response :not_found
+  end
+
+  test 'applying it is not' do
+    with_exceptions_app { post submission_request_submission_path(@theirs) }
+    assert_response :not_found
+  end
+
+  # The accessions are a large part of why somebody opens a colleague's
+  # submission at all, so the nested list follows the detail screen.
+  test 'the submission and its accessions follow the detail screen' do
+    submission = Submission.create!(user: @carol, db: 'bioproject')
+    attach_submission_files submission
+    @theirs.update_columns(submission_id: submission.id)
+
+    get submission_accessions_path(submission)
+    assert_conform_schema 200
+
+    get submission_path(submission)
+    assert_conform_schema 200
+  end
+
+  # ...but the flat cross-submission walk stays one submitter's. It is a
+  # synchronisation endpoint: a client keeps a local copy from it, and
+  # somebody else's rows appearing in that copy is the one thing it must
+  # not do.
+  test 'the cross-submission accession walk stays mine' do
+    submission = Submission.create!(user: @carol, db: 'st26')
+    @theirs.update_columns(submission_id: submission.id)
+
+    entry = submission.entries.create!(accession: 'LC999999', entry_id: 'E1', locus_date: Date.current)
+
+    get accessions_path
+
+    assert_conform_schema 200
+    assert_not_includes response.parsed_body.pluck('accession'), entry.accession
+  end
+
+  test 'taking the submission out of the set takes the reading with it' do
+    SubmissionSetInclusion.destroy_all
+
+    with_exceptions_app { get submission_request_path(@theirs) }
+
+    assert_conform_schema 404
+  end
+
+  test 'removing the member takes the reading with it' do
+    SubmissionSet.sole.members.find_by!(user_id: @carol.id).remove!
+
+    with_exceptions_app { get submission_request_path(@theirs) }
+
+    assert_conform_schema 404
+  end
+end

--- a/test/integration/set_submissions_test.rb
+++ b/test/integration/set_submissions_test.rb
@@ -1,0 +1,114 @@
+require 'test_helper'
+
+class SubmissionSetInclusionsTest < ActionDispatch::IntegrationTest
+  JSON_HEADERS = {'Content-Type' => 'application/json'}.freeze
+
+  setup do
+    @alice = users(:alice)
+    @carol = users(:carol)
+
+    default_headers['Authorization'] = "Bearer #{@alice.api_key}"
+
+    @set   = SubmissionSet.create!(name: 'Deep sea study', owner: @alice)
+    @submission_request = submission_requests(:bioproject) # owned by :alice
+  end
+
+  # 204, not 201: the answer carries no body, and 204 is the status that
+  # says so. The web client's fetch layer parses every other status as
+  # JSON, so a 201 with an empty body reaches it as a parse error.
+  test 'adding says only that it is added' do
+    assert_difference 'SubmissionSetInclusion.count', 1 do
+      post set_submissions_path(@set),
+           params:  {submission: {submission_request_id: @submission_request.id}}.to_json,
+           headers: JSON_HEADERS
+    end
+
+    assert_conform_schema 204
+
+    get set_path(@set)
+
+    assert_conform_schema 200
+
+    body = response.parsed_body
+
+    assert_equal 1, body['submission_count']
+    assert_equal [@alice.uid], body['submissions'].map { it['owner_uid'] }
+    assert_equal [true],       body['submissions'].map { it['owned'] }
+    assert_equal @submission_request.id, body['submissions'].sole['submission']['id']
+  end
+
+  test 'somebody else\'s submission is not an id you have' do
+    carols = @carol.submission_requests.create!(db: 'bioproject', status: :applied, migration_run_id: SecureRandom.uuid)
+
+    with_exceptions_app do
+      post set_submissions_path(@set),
+           params:  {submission: {submission_request_id: carols.id}}.to_json,
+           headers: JSON_HEADERS
+    end
+
+    assert_conform_schema 404
+  end
+
+  test 'reading through a shared set does not let you hand it on' do
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+    @set.inclusions.create!(submission_request: @submission_request, added_by: @alice)
+
+    carols_own = SubmissionSet.create!(name: "Carol's other study", owner: @carol)
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    with_exceptions_app do
+      post set_submissions_path(carols_own),
+           params:  {submission: {submission_request_id: @submission_request.id}}.to_json,
+           headers: JSON_HEADERS
+    end
+
+    assert_conform_schema 404
+  end
+
+  test 'only the submission owner can take it out' do
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+    @set.inclusions.create!(submission_request: @submission_request, added_by: @alice)
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    with_exceptions_app do
+      delete set_submission_path(@set, @submission_request)
+    end
+
+    assert_conform_schema 403
+  end
+
+  test 'the owner takes it out' do
+    @set.inclusions.create!(submission_request: @submission_request, added_by: @alice)
+
+    delete set_submission_path(@set, @submission_request)
+
+    assert_conform_schema 204
+    assert_empty @set.inclusions.reload
+  end
+
+  test 'a member sees whose submission it is, but not that a private conversation exists' do
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+    @set.inclusions.create!(submission_request: @submission_request, added_by: @alice)
+
+    @submission_request.messages.create!(user: users(:bob), author_role: :curator, body: 'Please check the organism.')
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    get set_path(@set)
+
+    assert_conform_schema 200
+    assert_equal 0, response.parsed_body['submissions'].sole['submission']['unread_curator_message_count']
+  end
+
+  test 'the owner still sees their own unread count' do
+    @set.inclusions.create!(submission_request: @submission_request, added_by: @alice)
+    @submission_request.messages.create!(user: users(:bob), author_role: :curator, body: 'Please check the organism.')
+
+    get set_path(@set)
+
+    assert_conform_schema 200
+    assert_equal 1, response.parsed_body['submissions'].sole['submission']['unread_curator_message_count']
+  end
+end

--- a/test/integration/sets_test.rb
+++ b/test/integration/sets_test.rb
@@ -1,0 +1,214 @@
+require 'test_helper'
+
+class GroupsTest < ActionDispatch::IntegrationTest
+  JSON_HEADERS = {'Content-Type' => 'application/json'}.freeze
+
+  setup do
+    @alice = users(:alice)
+    @carol = users(:carol)
+
+    default_headers['Authorization'] = "Bearer #{@alice.api_key}"
+
+    @set = SubmissionSet.create!(name: 'Deep sea study', owner: @alice)
+  end
+
+  test 'index lists the sets you have joined, and not the ones you have only been invited to' do
+    SubmissionSet.create!(name: 'Somebody else', owner: @carol).members.create!(email: 'alice@example.com', invited_by: @carol)
+
+    get sets_path
+
+    assert_conform_schema 200
+    assert_equal ['Deep sea study'], response.parsed_body.map { it['name'] }
+  end
+
+  test 'create makes the creator the owner and the first member' do
+    assert_difference 'SubmissionSet.count', 1 do
+      post sets_path, params: {set: {name: 'Hot spring metagenome'}}.to_json, headers: JSON_HEADERS
+    end
+
+    assert_conform_schema 201
+
+    body = response.parsed_body
+
+    assert_equal 'Hot spring metagenome', body['name']
+    assert_equal true,  body['owned']
+    assert_equal 1,     body['member_count']
+    assert_equal 0,     body['invited_count']
+    assert_equal [@alice.uid], body['members'].map { it['uid'] }
+  end
+
+  test 'show 404s for a set you are not in' do
+    other = SubmissionSet.create!(name: 'Not yours', owner: @carol)
+
+    with_exceptions_app do
+      get set_path(other)
+    end
+
+    assert_conform_schema 404
+  end
+
+  test 'rename is the owner only' do
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    with_exceptions_app do
+      patch set_path(@set), params: {set: {name: 'Renamed'}}.to_json, headers: JSON_HEADERS
+    end
+
+    assert_conform_schema 403
+    assert_equal 'Deep sea study', @set.reload.name
+  end
+
+  test 'delete is refused while anybody else is still in it' do
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    with_exceptions_app do
+      delete set_path(@set)
+    end
+
+    assert_conform_schema 422
+    assert SubmissionSet.exists?(@set.id)
+  end
+
+  test 'delete is refused while a submission is still in it' do
+    @set.inclusions.create!(submission_request: submission_requests(:bioproject), added_by: @alice)
+
+    with_exceptions_app do
+      delete set_path(@set)
+    end
+
+    assert_conform_schema 422
+  end
+
+  test 'delete is refused while an invitation nobody has used is still out' do
+    @set.members.create!(email: 'newcomer@example.org', invited_by: @alice)
+
+    with_exceptions_app do
+      delete set_path(@set)
+    end
+
+    assert_conform_schema 422
+  end
+
+  test 'delete empties out' do
+    delete set_path(@set)
+
+    assert_conform_schema 204
+    assert_not SubmissionSet.exists?(@set.id)
+  end
+
+  test 'a set you are not in cannot be renamed or deleted either' do
+    other = SubmissionSet.create!(name: 'Not yours', owner: @carol)
+
+    with_exceptions_app do
+      patch set_path(other), params: {set: {name: 'Renamed'}}.to_json, headers: JSON_HEADERS
+    end
+
+    assert_conform_schema 404
+
+    with_exceptions_app { delete set_path(other) }
+
+    assert_conform_schema 404
+  end
+
+  test 'a curator acting as somebody else cannot make or unmake their sets' do
+    default_headers['Authorization']  = "Bearer #{users(:bob).api_key}"
+    default_headers['X-Dway-User-Id'] = @alice.uid
+
+    with_exceptions_app do
+      post sets_path, params: {set: {name: 'On their behalf'}}.to_json, headers: JSON_HEADERS
+    end
+
+    assert_conform_schema 403
+
+    get sets_path
+
+    assert_conform_schema 200
+  end
+
+  # A set has no ceiling on what it holds, so the screen reads a page of
+  # it. Without this nothing would notice the day somebody puts three
+  # years of a study in one place.
+  test 'the submissions in a set are paginated' do
+    3.times do
+      request = @alice.submission_requests.create!(db: 'bioproject', status: :applied, migration_run_id: SecureRandom.uuid)
+      @set.inclusions.create!(submission_request: request, added_by: @alice)
+    end
+
+    get set_path(@set)
+
+    assert_conform_schema 200
+    assert_equal 3, response.parsed_body['submissions'].size
+    assert_equal '1', response.headers['Total-Pages']
+
+    # The count is of everything in the set; the list is of one page of
+    # it, so a page past the end is empty rather than a lie about size.
+    get set_path(@set, page: 2)
+
+    assert_conform_schema 200
+
+    body = response.parsed_body
+
+    assert_equal 3, body['submission_count']
+    assert_empty body['submissions']
+  end
+
+  test 'the reason a set cannot be deleted is served, not left to the client to word' do
+    @set.members.create!(email: 'newcomer@example.org', invited_by: @alice)
+
+    get set_path(@set)
+
+    assert_conform_schema 200
+
+    body = response.parsed_body
+
+    assert_equal false, body['deletable']
+    assert_equal SubmissionSet::EMPTY_FIRST, body['delete_blocked_reason']
+  end
+
+  test 'an empty set of your own says it can go' do
+    get set_path(@set)
+
+    body = response.parsed_body
+
+    assert_equal true, body['deletable']
+    assert_nil body['delete_blocked_reason']
+  end
+
+  # Counted over the whole set. Counting the page on screen would tell
+  # somebody "0 submissions" while the removal took sixty out.
+  test 'each member carries what would go with them, past the end of the page' do
+    2.times do
+      request = @carol.submission_requests.create!(db: 'bioproject', status: :applied, migration_run_id: SecureRandom.uuid)
+      @set.inclusions.create!(submission_request: request, added_by: @carol)
+    end
+
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    get set_path(@set, page: 2)
+
+    assert_conform_schema 200
+
+    body = response.parsed_body
+
+    assert_empty body['submissions']
+    assert_equal 2, body['members'].find { it['uid'] == @carol.uid }['submission_count']
+  end
+
+  # Serialising the remover was never enough on its own: the queued
+  # writer still believed it was a member when it ran.
+  test 'a write that queued behind a removal finds out it is no longer a member' do
+    member = @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    member.remove!
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    with_exceptions_app do
+      post set_members_path(@set), params: {set_member: {email: 'newcomer@example.org'}}.to_json, headers: JSON_HEADERS
+    end
+
+    assert_conform_schema 404
+  end
+end

--- a/test/integration/submission_requests_test.rb
+++ b/test/integration/submission_requests_test.rb
@@ -346,4 +346,65 @@ class SubmissionRequestsTest < ActionDispatch::IntegrationTest
   def sign_in_as_user(user)
     default_headers['Authorization'] = "Bearer #{user.api_key}"
   end
+
+  test 'show marks your own as yours' do
+    request = submission_requests(:bioproject)
+    attach_ddbj_record request
+    attach_submission_files request.submission
+
+    get submission_request_path(request)
+
+    assert_conform_schema 200
+    assert_equal true, response.parsed_body['owned']
+  end
+
+  test 'a set member can read a submission shared into it, but not its conversation' do
+    carol  = users(:carol)
+    theirs = carol.submission_requests.create!(db: 'bioproject', status: :applied, migration_run_id: SecureRandom.uuid)
+    attach_ddbj_record theirs
+
+    theirs.messages.create!(user: users(:bob), author_role: :curator, body: 'Please check the organism.')
+
+    with_exceptions_app do
+      get submission_request_path(theirs)
+    end
+
+    assert_conform_schema 404
+
+    set = SubmissionSet.create!(name: 'Deep sea study', owner: @user)
+    set.members.create!(user: carol, invited_by: @user, joined_at: Time.current)
+    set.inclusions.create!(submission_request: theirs, added_by: carol)
+
+    get submission_request_path(theirs)
+
+    assert_conform_schema 200
+
+    body = response.parsed_body
+
+    assert_equal false,          body['owned']
+    assert_equal false,          body['closable']
+    assert_equal 0,              body['unread_curator_message_count']
+    assert_nil                   body['last_message_at']
+    assert_equal ['Deep sea study'], body['sets'].map { it['name'] }
+  end
+
+  test 'the sets a submission is in are only the ones you are also in' do
+    carol  = users(:carol)
+    theirs = carol.submission_requests.create!(db: 'bioproject', status: :applied, migration_run_id: SecureRandom.uuid)
+    attach_ddbj_record theirs
+
+    shared = SubmissionSet.create!(name: 'Shared study', owner: @user)
+    shared.members.create!(user: carol, invited_by: @user, joined_at: Time.current)
+    shared.inclusions.create!(submission_request: theirs, added_by: carol)
+
+    # Carol's other collaboration, which alice is not part of. That the
+    # same submission is in it is not alice's to know.
+    elsewhere = SubmissionSet.create!(name: 'Another study', owner: carol)
+    elsewhere.inclusions.create!(submission_request: theirs, added_by: carol)
+
+    get submission_request_path(theirs)
+
+    assert_conform_schema 200
+    assert_equal ['Shared study'], response.parsed_body['sets'].map { it['name'] }
+  end
 end

--- a/test/mailers/set_invitation_mailer_test.rb
+++ b/test/mailers/set_invitation_mailer_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class SetInvitationMailerTest < ActionMailer::TestCase
+  setup do
+    @alice  = users(:alice)
+    @set  = SubmissionSet.create!(name: 'Deep sea study', owner: @alice)
+    @member = @set.members.create!(email: 'newcomer@example.org', invited_by: @alice)
+  end
+
+  test 'goes to the address that was typed, not to an account' do
+    mail = SetInvitationMailer.with(member: @member).invite
+
+    assert_equal ['newcomer@example.org'], mail.to
+    assert_match 'Deep sea study', mail.subject
+  end
+
+  test 'carries the link that is live now' do
+    mail = SetInvitationMailer.with(member: @member).invite
+
+    assert_match @member.invitation_url, mail.text_part.body.to_s
+    assert_match @member.invitation_url, mail.html_part.body.to_s
+  end
+
+  test 'a resend carries the new link and not the old one' do
+    was = @member.invitation_url
+
+    @member.resend!
+
+    body = SetInvitationMailer.with(member: @member).invite.text_part.body.to_s
+
+    assert_match @member.invitation_url, body
+    assert_no_match(/#{Regexp.escape(was)}/, body)
+  end
+end

--- a/test/models/submission_request_test.rb
+++ b/test/models/submission_request_test.rb
@@ -274,4 +274,38 @@ class SubmissionRequestTest < ActiveSupport::TestCase
 
     assert_includes SubmissionRequest.unfinished, request
   end
+
+  test 'readable_by covers your own and whatever a set has shared with you' do
+    alice = users(:alice)
+    carol = users(:carol)
+
+    mine   = submission_requests(:bioproject) # alice's
+    theirs = carol.submission_requests.create!(db: 'bioproject', status: :applied, migration_run_id: SecureRandom.uuid)
+
+    assert_not_includes SubmissionRequest.readable_by(alice), theirs
+
+    set = SubmissionSet.create!(name: 'Deep sea study', owner: alice)
+    set.members.create!(user: carol, invited_by: alice, joined_at: Time.current)
+    set.inclusions.create!(submission_request: theirs, added_by: carol)
+
+    assert_includes SubmissionRequest.readable_by(alice), theirs
+    assert_includes SubmissionRequest.readable_by(alice), mine
+
+    # Ownership is what it always was. Sharing does not widen it, which is
+    # what keeps `user.submission_requests` safe to write through.
+    assert_not_includes alice.submission_requests, theirs
+  end
+
+  test 'an invitation nobody has walked through shares nothing' do
+    alice = users(:alice)
+    carol = users(:carol)
+
+    theirs = carol.submission_requests.create!(db: 'bioproject', status: :applied, migration_run_id: SecureRandom.uuid)
+
+    set = SubmissionSet.create!(name: 'Deep sea study', owner: carol)
+    set.members.create!(email: 'alice@example.com', invited_by: carol)
+    set.inclusions.create!(submission_request: theirs, added_by: carol)
+
+    assert_not_includes SubmissionRequest.readable_by(alice), theirs
+  end
 end

--- a/test/models/submission_set_member_test.rb
+++ b/test/models/submission_set_member_test.rb
@@ -1,0 +1,185 @@
+require 'test_helper'
+
+class SubmissionSetMemberTest < ActiveSupport::TestCase
+  setup do
+    @alice = users(:alice)
+    @carol = users(:carol)
+    @set = SubmissionSet.create!(name: 'Deep sea study', owner: @alice)
+  end
+
+  test 'the creator is on the roster, with no invitation to walk through' do
+    member = @set.members.sole
+
+    assert_equal @alice, member.user
+    assert member.joined?
+    assert_nil member.email
+    assert_nil member.invitation_token
+  end
+
+  test 'an invitation carries a token and a clock' do
+    member = @set.members.create!(email: 'newcomer@example.org', invited_by: @alice)
+
+    assert member.pending?
+    assert_equal 32, member.invitation_token.length
+    assert_in_delta SubmissionSetMember::INVITATION_VALIDITY.from_now, member.invitation_expires_at, 5
+    assert_not member.invitation_expired?
+  end
+
+  test 'the address is stored the way a person would read it back' do
+    member = @set.members.create!(email: '  Newcomer@Example.ORG ', invited_by: @alice)
+
+    assert_equal 'newcomer@example.org', member.email
+  end
+
+  test 'accepting keeps the token, so the link can explain itself when it is opened again' do
+    member = @set.members.create!(email: 'newcomer@example.org', invited_by: @alice)
+    token  = member.invitation_token
+
+    member.accept!(@carol)
+
+    assert member.joined?
+    assert_equal token, member.invitation_token
+    assert_equal 'accepted', member.invitation_state
+    assert @set.member?(@carol)
+  end
+
+  test 'an invitation says which of its three states it is in' do
+    member = @set.members.create!(email: 'newcomer@example.org', invited_by: @alice)
+
+    assert_equal 'open', member.invitation_state
+
+    member.update_columns(invitation_expires_at: 1.day.ago)
+    assert_equal 'expired', member.reload.invitation_state
+
+    member.update_columns(invitation_expires_at: 1.day.from_now)
+    member.reload.accept!(@carol)
+    assert_equal 'accepted', member.invitation_state
+  end
+
+  test 'resending is refused on somebody who has already joined, rather than left to the check constraint' do
+    member = @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    assert_raises(ArgumentError) { member.resend! }
+  end
+
+  test 'removing somebody takes back the invitations they sent' do
+    member = @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    # Any member may invite, so a member who is asked to leave could
+    # otherwise walk straight back in through a link they sent themselves.
+    theirs = @set.members.create!(email: 'mallory-2@example.org', invited_by: @carol)
+    mine   = @set.members.create!(email: 'newcomer@example.org',  invited_by: @alice)
+
+    member.remove!
+
+    assert_not SubmissionSetMember.exists?(theirs.id)
+    assert     SubmissionSetMember.exists?(mine.id)
+  end
+
+  test 'the roster says whether the account matches the address the invitation went to' do
+    @carol.update!(email: 'carol@example.com')
+
+    forwarded = @set.members.create!(email: 'forwarded-to@example.org', invited_by: @alice)
+    forwarded.accept!(@carol)
+
+    assert_equal 'different', forwarded.invited_address_match
+  end
+
+  test 'accepting at the address it was sent to is unremarkable' do
+    @carol.update!(email: 'carol@example.com')
+
+    member = @set.members.create!(email: 'Carol@Example.com', invited_by: @alice)
+    member.accept!(@carol)
+
+    assert_equal 'same', member.invited_address_match
+  end
+
+  # Most accounts imported from D-way have never signed in and carry no
+  # address. Saying "same" for one of those would put a claim on the
+  # roster that nothing checked.
+  test 'an account with no address on file is unknown rather than matching' do
+    @carol.update!(email: nil)
+
+    member = @set.members.create!(email: 'newcomer@example.org', invited_by: @alice)
+    member.accept!(@carol)
+
+    assert_equal 'unknown', member.invited_address_match
+  end
+
+  test 'the creator was never invited, so the question does not arise' do
+    assert_nil @set.members.sole.invited_address_match
+  end
+
+  test 'resending replaces the link rather than adding one' do
+    member = @set.members.create!(email: 'newcomer@example.org', invited_by: @alice)
+    was    = member.invitation_token
+
+    travel 1.day do
+      member.resend!
+    end
+
+    assert_not_equal was, member.invitation_token
+    assert_operator member.invitation_expires_at, :>, SubmissionSetMember::INVITATION_VALIDITY.from_now
+  end
+
+  test 'removing somebody takes their submissions out with them, and leaves everyone else alone' do
+    member = @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    theirs = @carol.submission_requests.create!(db: 'bioproject', status: :applied, migration_run_id: SecureRandom.uuid)
+    mine   = submission_requests(:bioproject)
+
+    @set.inclusions.create!(submission_request: theirs, added_by: @carol)
+    @set.inclusions.create!(submission_request: mine,   added_by: @alice)
+
+    member.remove!
+
+    assert_equal [mine], @set.inclusions.reload.map(&:submission_request)
+  end
+
+  test 'one account cannot hold two seats in the same set' do
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    second = @set.members.build(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    assert_not second.valid?
+  end
+
+  test 'a set is deletable only once it is nobody else and nothing else' do
+    assert @set.deletable?
+
+    member = @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+    assert_not @set.deletable?
+
+    member.remove!
+    assert @set.reload.deletable?
+
+    # An invitation sitting unused in somebody's mailbox counts as
+    # somebody: deleting the set would kill that link silently.
+    invitation = @set.members.create!(email: 'newcomer@example.org', invited_by: @alice)
+    assert_not @set.reload.deletable?
+
+    invitation.remove!
+    assert @set.reload.deletable?
+
+    @set.inclusions.create!(submission_request: submission_requests(:bioproject), added_by: @alice)
+    assert_not @set.reload.deletable?
+  end
+
+  test 'a submission can only be put in a set by its owner' do
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    intruder = @set.inclusions.build(submission_request: submission_requests(:bioproject), added_by: @carol)
+
+    assert_not intruder.valid?
+  end
+
+  test 'the same submission can be in more than one set' do
+    other   = SubmissionSet.create!(name: 'Another study', owner: @alice)
+    request = submission_requests(:bioproject)
+
+    @set.inclusions.create!(submission_request: request, added_by: @alice)
+    other.inclusions.create!(submission_request: request, added_by: @alice)
+
+    assert_equal 2, request.sets.count
+  end
+end

--- a/web/app/components/reviewer-access.gts
+++ b/web/app/components/reviewer-access.gts
@@ -139,9 +139,11 @@ export default class ReviewerAccess extends Component<Signature> {
   }
 
   <template>
-    <section class="mt-4">
-      <h2 class="h4">Reviewer access</h2>
-
+    {{! No heading, for the same reason as the Sets panel beside it — and
+    here it was worse than repetition: the summary says "Share with a
+    reviewer" and this said "Reviewer access", leaving the reader to
+    wonder which one names the thing. }}
+    <section>
       <p class="text-body-secondary small">
         Share a read-only link that lets a reviewer view this request without logging in. Messages are not shown to
         reviewers.
@@ -201,7 +203,10 @@ export default class ReviewerAccess extends Component<Signature> {
 
         {{#if this.enabled}}
           <div class="col-auto">
-            <button type="button" class="btn btn-outline-danger" disabled={{this.busy}} {{on "click" this.disable}}>
+            {{! Amber, not red. Red says something about the data — this
+            failed, this is overdue — and a control that competes with
+            that reading wins the attention without carrying the meaning. }}
+            <button type="button" class="btn btn-warning" disabled={{this.busy}} {{on "click" this.disable}}>
               Disable
             </button>
           </div>

--- a/web/app/components/set-membership.gts
+++ b/web/app/components/set-membership.gts
@@ -1,0 +1,213 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { concat, fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { uniqueId } from '@ember/helper';
+import { LinkTo } from '@ember/routing';
+
+import { errorMessage } from 'repository/utils/error-message';
+
+import type { RequestManager } from '@warp-drive/core';
+import type RouterService from '@ember/routing/router-service';
+import type ToastService from 'repository/services/toast';
+import type { components, paths } from 'schema/openapi';
+
+type Sets = paths['/sets']['get']['responses']['200']['content']['application/json'];
+type Membership = components['schemas']['SubmissionRequest']['sets'][number];
+
+interface Signature {
+  Args: {
+    requestId: number;
+    sets: Membership[];
+  };
+}
+
+// Putting your own submission into a set, and taking it back out. It
+// lives on the submission's own page rather than on the set's because
+// that is where the decision belongs: a set's other members can read
+// what is in it, and only the owner of a submission says whether theirs
+// is.
+export default class SetMembership extends Component<Signature> {
+  @service declare requestManager: RequestManager;
+  @service declare router: RouterService;
+  @service declare toast: ToastService;
+
+  @tracked mine: Sets = [];
+  @tracked selected = '';
+  @tracked busy = false;
+  @tracked error: string | null = null;
+
+  // Separate from `mine.length`, so a failed load does not tell somebody
+  // who is in six sets to go and create one.
+  @tracked loaded = false;
+
+  constructor(owner: unknown, args: Signature['Args']) {
+    // @ts-expect-error -- Glimmer Component owner typing
+    super(owner, args);
+
+    // Swallowed on purpose: this is a panel offering a convenience, and
+    // a modal over the submission page because the set list could not
+    // be fetched would be worse than the panel saying nothing. `loaded`
+    // stays false, so it does not claim the reader has no sets either.
+    void this.load().catch(() => {});
+  }
+
+  async load() {
+    const { content } = await this.requestManager.request<Sets>({ url: '/sets' });
+
+    this.mine = content;
+    this.loaded = true;
+  }
+
+  // Only the ones it is not in yet. Offering a set it already belongs
+  // to would be an option whose only outcome is an error.
+  get available() {
+    const already = new Set(this.args.sets.map((set) => set.id));
+
+    return this.mine.filter((set) => !already.has(set.id));
+  }
+
+  get hasNoSets() {
+    return this.loaded && this.mine.length === 0;
+  }
+
+  // Already in all of them. Without a branch for this the panel renders
+  // the list and nothing else — no picker, no way on — which reads as
+  // "a submission belongs to one set". It does not: a BioProject is a
+  // hub, and the sets hanging off one are different collaborations.
+  get inEverySet() {
+    return this.loaded && this.mine.length > 0 && this.available.length === 0;
+  }
+
+  get addDisabled() {
+    return this.busy || !this.selected;
+  }
+
+  @action
+  updateSelected(e: Event) {
+    this.selected = (e.target as HTMLSelectElement).value;
+  }
+
+  @action
+  async add() {
+    if (this.busy || !this.selected) return;
+
+    this.busy = true;
+    this.error = null;
+
+    try {
+      await this.requestManager.request({
+        url: `/sets/${this.selected}/submissions`,
+        method: 'POST',
+        data: { submission: { submission_request_id: this.args.requestId } },
+      });
+
+      this.selected = '';
+      this.toast.show('Added to the set.', 'success');
+
+      await this.router.refresh();
+    } catch (e) {
+      this.error = errorMessage(e) ?? 'Could not add it to that set. Try again.';
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  @action
+  async remove(setId: number) {
+    if (this.busy) return;
+
+    this.busy = true;
+    this.error = null;
+
+    try {
+      await this.requestManager.request({
+        url: `/sets/${setId}/submissions/${this.args.requestId}`,
+        method: 'DELETE',
+      });
+
+      this.toast.show('Taken out of the set.', 'success');
+
+      await this.router.refresh();
+    } catch (e) {
+      this.error = errorMessage(e) ?? 'Could not take it out. Try again.';
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  <template>
+    {{! No heading: this is the body of a disclosure whose summary already
+    says "Sets", and saying it twice makes the reader look for the
+    difference. }}
+    <section data-test-sets>
+      <p class="text-body-secondary small">
+        A set is submissions that belong together — the ones behind a paper, a study, a piece of work. Everyone in the
+        set can see this submission and how far along it is. Taking it back out is always yours to do.
+      </p>
+
+      {{#if this.error}}
+        <div class="alert alert-warning" data-test-error>{{this.error}}</div>
+      {{/if}}
+
+      {{#if @sets.length}}
+        <ul class="list-group mb-3">
+          {{#each @sets as |set|}}
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+              <LinkTo @route="set" @model={{set.id}}>{{set.name}}</LinkTo>
+
+              <button
+                type="button"
+                class="btn btn-outline-secondary btn-sm"
+                disabled={{this.busy}}
+                aria-label={{concat "Take this submission out of " set.name}}
+                {{on "click" (fn this.remove set.id)}}
+              >
+                Take out
+              </button>
+            </li>
+          {{/each}}
+        </ul>
+      {{else}}
+        <p class="small text-body-secondary">This submission is not in any set.</p>
+      {{/if}}
+
+      {{#if this.available.length}}
+        <div class="row g-2 align-items-end">
+          <div class="col-auto">
+            {{#let (uniqueId) as |id|}}
+              <label for={{id}} class="form-label">{{if @sets.length "Add to another set" "Add to a set"}}</label>
+
+              <select id={{id}} class="form-select" {{on "change" this.updateSelected}}>
+                <option value="">Choose a set…</option>
+
+                {{#each this.available as |set|}}
+                  <option value={{set.id}} selected={{eq (concat set.id) this.selected}}>{{set.name}}</option>
+                {{/each}}
+              </select>
+            {{/let}}
+          </div>
+
+          <div class="col-auto">
+            <button type="button" class="btn btn-primary" disabled={{this.addDisabled}} {{on "click" this.add}}>
+              Add
+            </button>
+          </div>
+        </div>
+      {{else if this.inEverySet}}
+        <p class="small text-body-secondary mb-0">
+          It is in every set you are in. A submission can be in as many as it belongs in —
+          <LinkTo @route="sets">make another</LinkTo>
+          if it is part of something else too.
+        </p>
+      {{else if this.hasNoSets}}
+        <p class="small text-body-secondary mb-0">
+          <LinkTo @route="sets">Create a set</LinkTo>
+          to keep this with the submissions it belongs with.
+        </p>
+      {{/if}}
+    </section>
+  </template>
+}

--- a/web/app/controllers/invitation.ts
+++ b/web/app/controllers/invitation.ts
@@ -1,0 +1,12 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+
+export default class extends Controller {
+  // Set by Cloakman on the way back from creating an account. The flash
+  // it showed there does not travel across applications, so this page is
+  // the one that has to say the account is ready — otherwise somebody
+  // lands back on an unchanged page and cannot tell whether it worked.
+  queryParams = [{ signedUp: 'signed_up' }];
+
+  @tracked signedUp = '';
+}

--- a/web/app/controllers/set.ts
+++ b/web/app/controllers/set.ts
@@ -1,0 +1,12 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+
+export default class extends Controller {
+  queryParams = [
+    {
+      page: { type: 'number' } as const,
+    },
+  ];
+
+  @tracked page = 1;
+}

--- a/web/app/router.ts
+++ b/web/app/router.ts
@@ -32,4 +32,18 @@ Router.map(function () {
   this.route('review', { path: 'reviews/:token' }, function () {
     this.route('accessions');
   });
+
+  this.route('sets');
+  this.route('set', { path: 'sets/:set_id' });
+
+  // Where an invitation mail lands. Readable without a session — the
+  // person holding it may not have an account yet.
+  this.route('invitation', { path: 'invitations/:token' });
+
+  // Where DDBJ Account sends somebody back after they create one. It
+  // carries no token: an invitation token is a bearer credential, and
+  // handing it to a second application puts it in that application's
+  // logs and in the Referer of every link on its pages. The token waits
+  // here instead, and this route picks it up again.
+  this.route('invitation-resume', { path: 'invitation' });
 });

--- a/web/app/routes/invitation-resume.ts
+++ b/web/app/routes/invitation-resume.ts
@@ -1,0 +1,28 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+import { takeInvitationToken } from 'repository/routes/invitation';
+
+import type RouterService from '@ember/routing/router-service';
+
+// The landing spot for a return from DDBJ Account. See router.ts for why
+// the token is not in the URL that goes there — it is picked up from
+// where the invitation page left it.
+export default class InvitationResumeRoute extends Route {
+  @service declare router: RouterService;
+
+  beforeModel() {
+    const token = takeInvitationToken();
+
+    // Nothing waiting, or nothing recent enough. A bookmarked URL, or a
+    // signup abandoned last month. The front page is a better answer than
+    // an error: whoever this is either has an invitation mail to open or
+    // has no business here.
+    if (!token) return this.router.replaceWith('index');
+
+    // `signedUp`, the controller's own property name — not `signed_up`,
+    // which is only what it is called in the URL. Ember matches on the
+    // former and silently ignores anything else.
+    return this.router.replaceWith('invitation', token, { queryParams: { signedUp: '1' } });
+  }
+}

--- a/web/app/routes/invitation.ts
+++ b/web/app/routes/invitation.ts
@@ -1,0 +1,51 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+import type { RequestManager } from '@warp-drive/core';
+import type { paths } from 'schema/openapi';
+
+type Invitation = paths['/invitations/{token}']['get']['responses']['200']['content']['application/json'];
+
+// Where the token waits while the reader is off creating an account. See
+// router.ts: it is deliberately not in the URL handed to DDBJ Account.
+export const INVITATION_TOKEN_KEY = 'invitationToken';
+
+// The same window CurrentUserService gives `returnTo`, for the same
+// reason: creating an account is a round trip somebody can simply
+// abandon, and a token left in storage would otherwise resume an
+// invitation nobody is in the middle of any more.
+const INVITATION_TOKEN_TTL = 30 * 60 * 1000;
+
+export function stashInvitationToken(token: string) {
+  localStorage.setItem(INVITATION_TOKEN_KEY, JSON.stringify({ token, at: Date.now() }));
+}
+
+export function takeInvitationToken(): string | undefined {
+  const raw = localStorage.getItem(INVITATION_TOKEN_KEY);
+  localStorage.removeItem(INVITATION_TOKEN_KEY);
+
+  if (!raw) return undefined;
+
+  try {
+    const { token, at } = JSON.parse(raw) as { token?: string; at?: number };
+
+    if (!token || !at || Date.now() - at > INVITATION_TOKEN_TTL) return undefined;
+
+    return token;
+  } catch {
+    return undefined;
+  }
+}
+
+// No auth gate, deliberately. The person holding the link may not have a
+// DDBJ Account yet, and this page's job is to tell them what they are
+// being invited to before it asks them to make one.
+export default class InvitationRoute extends Route {
+  @service declare requestManager: RequestManager;
+
+  async model({ token }: { token: string }) {
+    const { content } = await this.requestManager.request<Invitation>({ url: `/invitations/${token}` });
+
+    return { token, invitation: content };
+  }
+}

--- a/web/app/routes/set.ts
+++ b/web/app/routes/set.ts
@@ -1,0 +1,36 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+import type CurrentUser from 'repository/services/current-user';
+import type { RequestManager } from '@warp-drive/core';
+import type Transition from '@ember/routing/transition';
+import type { paths } from 'schema/openapi';
+
+type Set = paths['/sets/{id}']['get']['responses']['200']['content']['application/json'];
+
+export default class SetRoute extends Route {
+  @service declare currentUser: CurrentUser;
+  @service declare requestManager: RequestManager;
+
+  queryParams = {
+    page: { refreshModel: true },
+  };
+
+  beforeModel(transition: Transition) {
+    this.currentUser.ensureLogin(transition);
+  }
+
+  // The roster comes whole; the submissions are a page of however many
+  // there are. A study that ran for three years is hundreds of them.
+  async model({ set_id: id, page }: { set_id: string; page?: number }) {
+    const { content, response } = await this.requestManager.request<Set>({
+      url: `/sets/${id}`,
+      options: { params: { page } },
+    });
+
+    return {
+      set: content,
+      totalPages: Number(response?.headers?.get('Total-Pages')) || 1,
+    };
+  }
+}

--- a/web/app/routes/sets.ts
+++ b/web/app/routes/sets.ts
@@ -1,0 +1,24 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+import type CurrentUser from 'repository/services/current-user';
+import type { RequestManager } from '@warp-drive/core';
+import type Transition from '@ember/routing/transition';
+import type { paths } from 'schema/openapi';
+
+type Sets = paths['/sets']['get']['responses']['200']['content']['application/json'];
+
+export default class SetsRoute extends Route {
+  @service declare currentUser: CurrentUser;
+  @service declare requestManager: RequestManager;
+
+  beforeModel(transition: Transition) {
+    this.currentUser.ensureLogin(transition);
+  }
+
+  async model() {
+    const { content } = await this.requestManager.request<Sets>({ url: '/sets' });
+
+    return content;
+  }
+}

--- a/web/app/services/current-user.ts
+++ b/web/app/services/current-user.ts
@@ -14,6 +14,10 @@ type Me = paths['/me']['get']['responses']['200']['content']['application/json']
 
 export class LoginError extends Error {}
 
+// Long enough for an OAuth round trip that includes making an account,
+// short enough that an abandoned one does not redirect a login tomorrow.
+const RETURN_TO_TTL = 30 * 60 * 1000;
+
 export default class CurrentUserService extends Service {
   @service declare requestManager: RequestManager;
   @service declare router: RouterService;
@@ -91,11 +95,38 @@ export default class CurrentUserService extends Service {
   expireSession() {
     if (this.sessionExpired) return;
 
-    localStorage.setItem('returnTo', this.router.currentURL ?? '/');
+    this.rememberReturn();
     localStorage.removeItem('token');
 
     this.clear();
     this.sessionExpired = true;
+  }
+
+  // Where to come back to after a full page load takes us out to the
+  // identity provider. Stamped, because the round trip is one somebody
+  // can simply abandon — close the tab, give up and go make an account —
+  // and an address left in storage would otherwise hijack an unrelated
+  // login days later, landing it on a page that may not even exist any
+  // more.
+  rememberReturn(url: string = this.router.currentURL ?? '/') {
+    localStorage.setItem('returnTo', JSON.stringify({ url, at: Date.now() }));
+  }
+
+  takeReturn(): string | undefined {
+    const raw = localStorage.getItem('returnTo');
+    localStorage.removeItem('returnTo');
+
+    if (!raw) return undefined;
+
+    try {
+      const { url, at } = JSON.parse(raw) as { url?: string; at?: number };
+
+      if (!url || !at || Date.now() - at > RETURN_TO_TTL) return undefined;
+
+      return url;
+    } catch {
+      return undefined;
+    }
   }
 
   async login(token: string, proxyUid?: string) {
@@ -112,8 +143,7 @@ export default class CurrentUserService extends Service {
       this.startProxy(proxyUid);
     }
 
-    const returnTo = localStorage.getItem('returnTo');
-    localStorage.removeItem('returnTo');
+    const returnTo = this.takeReturn();
 
     if (this.previousTransition) {
       this.previousTransition.retry();

--- a/web/app/styles/app.css
+++ b/web/app/styles/app.css
@@ -92,3 +92,10 @@ textarea.form-control.textarea-autogrow {
   min-height: 4lh;
   max-height: 20lh;
 }
+
+/* The reason a set cannot be deleted yet, under the button that is
+   asking to. A sentence, not a label — measured so it wraps rather than
+   stretching the header row it sits in. */
+.delete-hint {
+  max-width: 20rem;
+}

--- a/web/app/templates/application.gts
+++ b/web/app/templates/application.gts
@@ -44,6 +44,10 @@ export default class extends Component {
                 <LinkTo @route="index" class="nav-link">My submissions</LinkTo>
               </li>
 
+              <li class="nav-item">
+                <LinkTo @route="sets" class="nav-link">Sets</LinkTo>
+              </li>
+
               {{#if this.currentUser.user.isAdmin}}
                 <li class="nav-item">
                   <a href={{adminURL}} class="nav-link">Administration</a>

--- a/web/app/templates/invitation.gts
+++ b/web/app/templates/invitation.gts
@@ -1,0 +1,225 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { on } from '@ember/modifier';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { LinkTo } from '@ember/routing';
+import { pageTitle } from 'ember-page-title';
+
+import ENV from 'repository/config/environment';
+import formatDatetime from 'repository/helpers/format-datetime';
+import { stashInvitationToken } from 'repository/routes/invitation';
+import { errorMessage } from 'repository/utils/error-message';
+import { signUpURL } from 'repository/utils/runtime-config';
+
+import type InvitationController from 'repository/controllers/invitation';
+import type CurrentUserService from 'repository/services/current-user';
+import type { RequestManager } from '@warp-drive/core';
+import type RouterService from '@ember/routing/router-service';
+import type ToastService from 'repository/services/toast';
+import type { components } from 'schema/openapi';
+
+type Invitation = components['schemas']['Invitation'];
+type SetSummary = components['schemas']['SetSummary'];
+
+interface Signature {
+  Args: {
+    model: {
+      token: string;
+      invitation: Invitation;
+    };
+
+    controller: InvitationController;
+  };
+}
+
+// Where an invitation mail lands. Readable without a session, because the
+// person holding it may not have a DDBJ Account yet and this page's job is
+// to say what they are being invited to before it asks them to make one.
+export default class extends Component<Signature> {
+  @service declare currentUser: CurrentUserService;
+  @service declare requestManager: RequestManager;
+  @service declare router: RouterService;
+  @service declare toast: ToastService;
+
+  @tracked busy = false;
+  @tracked error: string | null = null;
+
+  authURL = ENV.authURL;
+
+  get open() {
+    return this.args.model.invitation.status === 'open';
+  }
+
+  // Somebody has already walked through this link — very likely the
+  // reader themselves, from another device. Answered rather than hidden:
+  // the token is kept after acceptance precisely so this page can say so.
+  get used() {
+    return this.args.model.invitation.status === 'accepted';
+  }
+
+  get expired() {
+    return this.args.model.invitation.status === 'expired';
+  }
+
+  // Only while it is still true. It comes back on the URL, so after
+  // logging in the reader would otherwise be told to log in below a Join
+  // button.
+  get justSignedUp() {
+    return Boolean(this.args.controller.signedUp) && !this.currentUser.isLoggedIn && this.open;
+  }
+
+  get signUpURL() {
+    const back = new URL(`${ENV.rootURL}invitation`, window.location.origin);
+    back.searchParams.set('signed_up', '1');
+
+    return signUpURL(back.toString());
+  }
+
+  // A full page load is about to happen, so the transition this route was
+  // reached by will not survive it. The token is left here rather than
+  // handed to DDBJ Account (see router.ts), and the address to come back
+  // to goes where a 401 leaves one.
+  @action
+  leaveForSignUp() {
+    stashInvitationToken(this.args.model.token);
+  }
+
+  @action
+  rememberReturn() {
+    this.currentUser.rememberReturn();
+  }
+
+  @action
+  async accept() {
+    if (this.busy) return;
+
+    this.busy = true;
+    this.error = null;
+
+    try {
+      const { content } = await this.requestManager.request<SetSummary>({
+        url: `/invitations/${this.args.model.token}/acceptance`,
+        method: 'POST',
+      });
+
+      this.toast.show(`You have joined “${content.name}”.`, 'success');
+
+      await this.router.transitionTo('set', content.id);
+    } catch (e) {
+      // On the page rather than in a modal: the two things that land here
+      // — the link was used while this tab was open, or it lapsed — both
+      // need the reader to read the page again, not to dismiss a dialog
+      // over it.
+      this.error = errorMessage(e) ?? 'Could not join. Try opening the link again.';
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  <template>
+    {{pageTitle "Invitation"}}
+
+    <div class="row justify-content-center py-4">
+      <div class="col-12 col-lg-7">
+        <div class="eyebrow text-uppercase text-body-tertiary fw-semibold small mb-3">
+          DDBJ Repository
+        </div>
+
+        <h1 class="display-6 mb-3">
+          {{@model.invitation.invited_by}}
+          has invited you to “{{@model.invitation.set_name}}”
+        </h1>
+
+        <p class="fs-5 text-body-secondary prose mb-4">
+          A set is submissions that belong together — the ones behind a paper, a study, a piece of work. Everyone in the
+          set can see what the others have put in it and how far along it is. Which of your own submissions go in stays
+          your decision, and you can take them back out at any time.
+        </p>
+
+        {{#if this.justSignedUp}}
+          <div class="alert alert-success">
+            <p class="fw-semibold mb-1">Your DDBJ Account is ready.</p>
+            <p class="mb-0 small">Log in below to join the set.</p>
+          </div>
+        {{/if}}
+
+        {{#if this.error}}
+          <div class="alert alert-warning" data-test-error>{{this.error}}</div>
+        {{/if}}
+
+        {{#if this.expired}}
+          <div class="alert alert-warning">
+            <p class="fw-semibold mb-1">This invitation has expired.</p>
+
+            <p class="mb-0 small">
+              Ask
+              {{@model.invitation.invited_by}}
+              — or anyone else in the set — to send it again. The new mail will come to
+              {{@model.invitation.email}}.
+            </p>
+          </div>
+        {{else if this.used}}
+          <div class="alert alert-secondary">
+            <p class="fw-semibold mb-1">This invitation has already been used.</p>
+
+            <p class="mb-0 small">
+              If that was you, the set is on
+              <LinkTo @route="sets">your sets</LinkTo>. If it was not, ask
+              {{@model.invitation.invited_by}}
+              to send a new invitation to
+              {{@model.invitation.email}}.
+            </p>
+          </div>
+        {{else if this.currentUser.isLoggedIn}}
+          <button
+            type="button"
+            class="btn btn-primary btn-lg"
+            disabled={{this.busy}}
+            data-test-join
+            {{on "click" this.accept}}
+          >
+            Join
+            {{@model.invitation.set_name}}
+          </button>
+
+          {{! Not `currentUser.user.uid` while a proxy is on: that is the
+          curator's own account, and the server would refuse the write
+          anyway — joining a set is a decision recorded against whoever
+          made it. }}
+          {{#if this.currentUser.isProxyLoggedIn}}
+            <p class="text-warning-emphasis small mt-3 mb-0">
+              You are acting as another account. End the proxy before joining a set.
+            </p>
+          {{else}}
+            <p class="text-body-tertiary small mt-3 mb-0">
+              You will join as
+              {{this.currentUser.user.uid}}.
+            </p>
+          {{/if}}
+        {{else}}
+          <form action={{this.authURL}} method="POST" {{on "submit" this.rememberReturn}}>
+            <button type="submit" class="btn btn-primary btn-lg" data-test-login>Log in with DDBJ Account</button>
+          </form>
+
+          {{#if this.signUpURL}}
+            <p class="mt-4 mb-1 fw-semibold">Do not have a DDBJ Account?</p>
+
+            <p class="text-body-secondary">
+              <a href={{this.signUpURL}} data-test-sign-up {{on "click" this.leaveForSignUp}}>Create one</a>
+              — you will be brought back to this page when it is ready.
+            </p>
+          {{/if}}
+
+          <p class="text-body-tertiary small mt-3 mb-0">
+            This invitation was sent to
+            {{@model.invitation.email}}
+            and is valid until
+            {{formatDatetime @model.invitation.expires_at}}. You can accept it with any DDBJ Account; the set's roster
+            will show which one you used.
+          </p>
+        {{/if}}
+      </div>
+    </div>
+  </template>
+}

--- a/web/app/templates/login.gts
+++ b/web/app/templates/login.gts
@@ -1,5 +1,7 @@
 import ENV from 'repository/config/environment';
 
+import { accountURL, identityProviderHost } from 'repository/utils/runtime-config';
+
 import type { TOC } from '@ember/component/template-only';
 
 const authURL = ENV.authURL;
@@ -79,25 +81,3 @@ export default <template>
     </div>
   </div>
 </template> satisfies TOC<object>;
-
-// Both injected per environment by WebsController, and both absent in a
-// bare build — in which case the line and the link are simply not shown
-// rather than naming a host we are not sure about.
-function meta(name: string): string | undefined {
-  return document.querySelector(`meta[name="${name}"]`)?.getAttribute('content') || undefined;
-}
-
-function accountURL(): string | undefined {
-  return meta('account-url');
-}
-
-function identityProviderHost(): string | undefined {
-  const url = meta('identity-provider');
-  if (!url) return undefined;
-
-  try {
-    return new URL(url).host;
-  } catch {
-    return undefined;
-  }
-}

--- a/web/app/templates/request/index.gts
+++ b/web/app/templates/request/index.gts
@@ -10,10 +10,11 @@ import ValidityBadge from 'repository/components/validity-badge';
 import ValidationReport from 'repository/components/validation-report';
 import SubmissionMessages from 'repository/components/submission-messages';
 import ReviewerAccess from 'repository/components/reviewer-access';
+import SetMembership from 'repository/components/set-membership';
 import autoRefresh from 'repository/modifiers/auto-refresh';
 import dbLabel from 'repository/helpers/db-label';
 import formatDatetime from 'repository/helpers/format-datetime';
-import { requestState, toneClasses } from 'repository/utils/request-state';
+import { requestState, stateLabel, toneClasses } from 'repository/utils/request-state';
 
 import type { RequestManager } from '@warp-drive/core';
 import type RouterService from '@ember/routing/router-service';
@@ -103,7 +104,14 @@ export default class extends Component<Signature> {
 
   <template>
     <div {{autoRefresh while=@model.processing interval=1000}}>
-      <Breadcrumb @items={{array (hash label="My submissions" route="index") (hash label=(concat "#" @model.id))}} />
+      {{! "My submissions" is where the reader's own list is. Somebody
+      reading this through a shared set did not come from there and
+      would not find it there either. }}
+      {{#if @model.owned}}
+        <Breadcrumb @items={{array (hash label="My submissions" route="index") (hash label=(concat "#" @model.id))}} />
+      {{else}}
+        <Breadcrumb @items={{array (hash label="Sets" route="sets") (hash label=(concat "#" @model.id))}} />
+      {{/if}}
 
       <div class="d-flex align-items-baseline gap-2 flex-wrap mb-4">
         <h1 class="display-6 mb-0">#{{@model.id}}</h1>
@@ -122,84 +130,123 @@ export default class extends Component<Signature> {
         <span class="text-body-secondary">· submitted {{formatDatetime @model.created_at}}</span>
       </div>
 
-      <section class="border rounded-3 p-4 mb-4 {{this.tone.border}}" data-test-state>
-        <div class="d-flex align-items-center gap-2 mb-2">
-          <span class="badge rounded-pill {{this.tone.badge}}">{{this.state.badge}}</span>
+      {{! Every sentence in the panel below is written to the submitter —
+      "your file is ready", "we will email you". Over an empty button
+      row, read by a colleague, that is worse than saying nothing: the
+      amber "Action needed" badge would tell them something is on them
+      when nothing is. They get the same facts stated about somebody
+      else, and the progress steps underneath say the rest. }}
+      {{#unless @model.owned}}
+        <section class="border rounded-3 p-4 mb-4" data-test-shared-state>
+          <div class="d-flex align-items-center gap-2 mb-2">
+            <span class="badge rounded-pill text-bg-light border">Shared with you</span>
+          </div>
 
-          {{! When the thread was last touched — a fact. How long a reply
+          <h2 class="h4">{{@model.owner_uid}}'s submission</h2>
+
+          <p class="prose mb-1">
+            You can see this because it is in a set you are both in. It is theirs to send, to answer questions on and to
+            take back out of the set.
+          </p>
+
+          {{! Where it has got to, said about somebody rather than to them. }}
+          <p class="text-body-secondary mb-0">{{stateLabel @model owned=false}}.</p>
+        </section>
+      {{/unless}}
+
+      {{#if @model.owned}}
+        <section class="border rounded-3 p-4 mb-4 {{this.tone.border}}" data-test-state>
+          <div class="d-flex align-items-center gap-2 mb-2">
+            <span class="badge rounded-pill {{this.tone.badge}}">{{this.state.badge}}</span>
+
+            {{! When the thread was last touched — a fact. How long a reply
           takes is not something this system knows, so it does not say. }}
-          {{#if @model.last_message_at}}
-            <span class="small text-body-secondary">
-              last message
-              {{formatDatetime @model.last_message_at}}
-            </span>
-          {{/if}}
-        </div>
+            {{#if @model.last_message_at}}
+              <span class="small text-body-secondary">
+                last message
+                {{formatDatetime @model.last_message_at}}
+              </span>
+            {{/if}}
+          </div>
 
-        <h2 class="h4">{{this.state.heading}}</h2>
-        <p class="prose mb-3">{{this.state.body}}</p>
+          <h2 class="h4">{{this.state.heading}}</h2>
+          <p class="prose mb-3">{{this.state.body}}</p>
 
-        <div class="d-flex gap-2 flex-wrap">
-          {{! Everything that acts on the request is withheld once it is
+          <div class="d-flex gap-2 flex-wrap">
+            {{! Everything that acts on the request is withheld once it is
           closed. The status does not change when a request is put down,
           so a button gated on status alone stays on offer and then fails
           against a server that will not act on a closed request — and
           "Apply" beside "no longer waiting on you" is a contradiction
           before it is a broken button. Reopen is the way back, and it is
           what the panel above tells them to use. }}
-          {{#unless @model.closed_at}}
-            {{! "Send to DDBJ", not "Apply". There are two buttons in this
+            {{#unless @model.closed_at}}
+              {{! "Send to DDBJ", not "Apply". There are two buttons in this
             flow and only one of them hands anything over; naming them
             after what they do to DDBJ rather than after the endpoint is
             what makes which is which readable. }}
-            {{#if (eq @model.status "ready_to_apply")}}
-              <button type="button" class="btn btn-primary" data-test-send {{on "click" this.apply}}>Send to DDBJ</button>
-            {{/if}}
+              {{#if (eq @model.status "ready_to_apply")}}
+                <button type="button" class="btn btn-primary" data-test-send {{on "click" this.apply}}>Send to DDBJ</button>
+              {{/if}}
 
-            {{! Only where there is nothing else to do with the file. On a
+              {{! Only where there is nothing else to do with the file. On a
             request that validated, the next step is Apply, and a second
             primary button offering a fresh upload would compete with it. }}
-            {{#if (eq @model.status "validation_failed")}}
-              <button
-                type="button"
-                class="btn btn-primary"
-                data-test-close-and-resubmit
-                {{on "click" this.closeAndResubmit}}
-              >Close and submit a corrected file</button>
-            {{/if}}
+              {{#if (eq @model.status "validation_failed")}}
+                <button
+                  type="button"
+                  class="btn btn-primary"
+                  data-test-close-and-resubmit
+                  {{on "click" this.closeAndResubmit}}
+                >Close and submit a corrected file</button>
+              {{/if}}
 
-            {{! A failed attempt cannot be advanced — a corrected file is a
+              {{! A failed attempt cannot be advanced — a corrected file is a
             new request — so without this it asks to be dealt with for ever
             and crowds out the live one. Quiet, because it is the lesser of
             the two things on offer when both are. }}
-            {{#if @model.closable}}
-              <button type="button" class="btn btn-outline-secondary" data-test-close {{on "click" this.close}}>Close
-                this request</button>
-            {{/if}}
-          {{/unless}}
+              {{#if @model.closable}}
+                <button type="button" class="btn btn-outline-secondary" data-test-close {{on "click" this.close}}>Close
+                  this request</button>
+              {{/if}}
+            {{/unless}}
 
-          {{#if @model.closed_at}}
-            <button
-              type="button"
-              class="btn btn-outline-secondary"
-              data-test-reopen
-              {{on "click" this.reopen}}
-            >Reopen</button>
-          {{/if}}
-        </div>
-      </section>
+            {{#if @model.closed_at}}
+              <button
+                type="button"
+                class="btn btn-outline-secondary"
+                data-test-reopen
+                {{on "click" this.reopen}}
+              >Reopen</button>
+            {{/if}}
+          </div>
+        </section>
+      {{/if}}
 
       {{! A failed check is the one thing on this screen worth reading, so
       it is not folded away with the reference material at the bottom. A
       report that has to be opened before it says anything is a report
       nobody reads twice. }}
-      {{#if this.failedCheck}}
-        <ValidationReport @validation={{this.failedCheck}} />
+      {{! Its opening line is "this is still your draft — fix what is below",
+      which is an instruction to the wrong person when a colleague is the
+      one reading. What is on the screen for them is the state panel above
+      and the steps below, both of which say what happened without telling
+      them to do anything about it. }}
+      {{#if @model.owned}}
+        {{#if this.failedCheck}}
+          <ValidationReport @validation={{this.failedCheck}} />
+        {{/if}}
       {{/if}}
 
       <ProgressSteps @progress={{@model.progress}} />
 
-      <SubmissionMessages @requestId={{@model.id}} />
+      {{! The conversation is between one submitter and DDBJ. Reading
+      somebody's submission through a shared set is not being party to
+      it — the server withholds the messages, and offering the box would
+      only produce a 404. }}
+      {{#if @model.owned}}
+        <SubmissionMessages @requestId={{@model.id}} />
+      {{/if}}
 
       {{! Reference material. Present, but not in the way of the answer. }}
       {{! no-nested-interactive treats <details> as interactive and so
@@ -207,14 +254,19 @@ export default class extends Component<Signature> {
       to inside <summary>) are valid HTML and reachable by keyboard once
       the disclosure is open, which is exactly what these are. }}
       {{! template-lint-disable no-nested-interactive }}
-      <div class="mt-4 border-top">
+      {{! A list group rather than a border utility on each row: Bootstrap's
+      flush variant already draws the line between items and drops it
+      after the last one, so the stack keeps its separators however many
+      of these are on screen. Which varies — the sharing controls are the
+      submitter's, and somebody reading through a set sees neither. }}
+      <div class="mt-4 border-top list-group list-group-flush">
         {{! Only while the check passed. A failed one is reported above,
         said as work, and it carries this same table folded underneath
         itself — listing the findings twice on one screen makes the
         reader wonder which is the real one. }}
         {{#unless this.failedCheck}}
           {{#if @model.validation}}
-            <details class="py-3 border-bottom">
+            <details class="list-group-item px-0 py-3">
               <summary>
                 Validation report
                 <span class="text-body-secondary ms-2">
@@ -252,7 +304,7 @@ export default class extends Component<Signature> {
         {{/unless}}
 
         {{#if @model.submission}}
-          <details class="py-3 border-bottom">
+          <details class="list-group-item px-0 py-3">
             <summary>
               Accessions
               <span class="text-body-secondary ms-2">{{@model.submission.accessions_count}}</span>
@@ -264,7 +316,7 @@ export default class extends Component<Signature> {
           </details>
         {{/if}}
 
-        <details class="py-3 border-bottom">
+        <details class="list-group-item px-0 py-3">
           <summary>Files &amp; downloads</summary>
 
           <dl class="horizontal mt-3">
@@ -320,11 +372,22 @@ export default class extends Component<Signature> {
           </dl>
         </details>
 
-        <details class="py-3">
-          <summary>Share with a reviewer</summary>
+        {{! Where a submission is shared, and who it is shared with, are the
+        submitter's decisions. Somebody reading through a set sees the
+        set they share on the set's own page. }}
+        {{#if @model.owned}}
+          <details class="list-group-item px-0 py-3">
+            <summary>Sets</summary>
 
-          <ReviewerAccess @requestId={{@model.id}} />
-        </details>
+            <SetMembership @requestId={{@model.id}} @sets={{@model.sets}} />
+          </details>
+
+          <details class="list-group-item px-0 py-3">
+            <summary>Share with a reviewer</summary>
+
+            <ReviewerAccess @requestId={{@model.id}} />
+          </details>
+        {{/if}}
       </div>
     </div>
   </template>

--- a/web/app/templates/set.gts
+++ b/web/app/templates/set.gts
@@ -1,0 +1,607 @@
+import Component from '@glimmer/component';
+import { LinkTo } from '@ember/routing';
+import { action } from '@ember/object';
+import { array, concat, fn, hash, uniqueId } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { pageTitle } from 'ember-page-title';
+
+import Breadcrumb from 'repository/components/breadcrumb';
+import Pagination from 'repository/components/pagination';
+import dbLabel from 'repository/helpers/db-label';
+import formatDatetime from 'repository/helpers/format-datetime';
+import { requestState, stateLabel, toneClasses } from 'repository/utils/request-state';
+import { errorMessage } from 'repository/utils/error-message';
+
+import type SetController from 'repository/controllers/set';
+import type { RequestManager } from '@warp-drive/core';
+import type RouterService from '@ember/routing/router-service';
+import type ToastService from 'repository/services/toast';
+import type { components } from 'schema/openapi';
+
+type Set = components['schemas']['Set'];
+type Member = components['schemas']['SetMember'];
+type SetSubmission = components['schemas']['SetSubmission'];
+
+interface Signature {
+  Args: {
+    model: {
+      set: Set;
+      totalPages: number;
+    };
+
+    controller: SetController;
+  };
+}
+
+const entryLabel = (entry: SetSubmission) => stateLabel(entry.submission, { owned: entry.owned });
+const stateBadgeClass = (entry: SetSubmission) => toneClasses(requestState(entry.submission).tone).badge;
+
+const submissionLabel = (entry: SetSubmission) => entry.submission.source_id ?? `#${entry.submission.id}`;
+
+export default class extends Component<Signature> {
+  @service declare requestManager: RequestManager;
+  @service declare router: RouterService;
+  @service declare toast: ToastService;
+
+  @tracked email = '';
+  @tracked busy = false;
+
+  // Errors land on the form that caused them, not in a modal over the
+  // page: the likely ones here — "is already a member of this set", a
+  // duplicate name — are about the value still sitting in the box.
+  @tracked inviteError: string | null = null;
+  @tracked pageError: string | null = null;
+
+  // Which row is asking "are you sure", and how much goes with it.
+  // Removing somebody takes their submissions out of the set, and
+  // nothing else on this screen says so.
+  @tracked confirming: number | null = null;
+  @tracked confirmingCount = 0;
+
+  @tracked renaming = false;
+  @tracked name = '';
+
+  // Not `set`: Ember's classic object model owns `this.set()`, and an
+  // Octane class must not shadow it.
+  get submissionSet() {
+    return this.args.model.set;
+  }
+
+  get inviteDisabled() {
+    return this.busy || this.email.trim().length === 0;
+  }
+
+  get joinedCount() {
+    return this.submissionSet.members.filter((member) => member.status === 'accepted').length;
+  }
+
+  // Both from the server. Neither can be worked out here any more: the
+  // submissions on screen are one page of however many there are, so
+  // counting them would tell somebody "0 submissions" while the removal
+  // took sixty out — and the wording of the reason belongs with the rule.
+  get deleteHint() {
+    return this.submissionSet.delete_blocked_reason ?? undefined;
+  }
+
+  // Disabled with the reason beside it, rather than hidden. An owner with
+  // one forgotten invitation would otherwise see a set with, apparently,
+  // no way to get rid of it — and a button that is offered and always
+  // fails is no better.
+  get deleteDisabled() {
+    return this.busy || !this.submissionSet.deletable;
+  }
+
+  @action
+  updateEmail(e: Event) {
+    this.email = (e.target as HTMLInputElement).value;
+  }
+
+  @action
+  updateName(e: Event) {
+    this.name = (e.target as HTMLInputElement).value;
+  }
+
+  @action
+  startRename() {
+    this.name = this.submissionSet.name;
+    this.renaming = true;
+  }
+
+  @action
+  cancelRename() {
+    this.renaming = false;
+  }
+
+  @action
+  async rename(e: Event) {
+    e.preventDefault();
+
+    const name = this.name.trim();
+    if (!name || name === this.submissionSet.name) return this.cancelRename();
+
+    await this.run(async () => {
+      await this.requestManager.request({
+        url: `/sets/${this.submissionSet.id}`,
+        method: 'PATCH',
+        data: { set: { name } },
+      });
+
+      this.renaming = false;
+      this.toast.show('Set renamed.', 'success');
+    });
+  }
+
+  @action
+  async invite(e: Event) {
+    e.preventDefault();
+
+    if (this.inviteDisabled) return;
+
+    this.inviteError = null;
+
+    await this.run(
+      async () => {
+        const { content } = await this.requestManager.request<Member>({
+          url: `/sets/${this.submissionSet.id}/members`,
+          method: 'POST',
+          data: { set_member: { email: this.email.trim() } },
+        });
+
+        this.email = '';
+
+        // Not "Invitation sent" when the answer just said it was not.
+        // The roster carries the same fact and the link to send by hand;
+        // the toast must not contradict the row it is about to draw.
+        this.toast.show(
+          content.mail_deliverable === false
+            ? 'Invitation created. Mail is not being sent from this environment — copy the link from the list below.'
+            : 'Invitation sent.',
+          'success',
+        );
+      },
+      { onError: (m) => (this.inviteError = m) },
+    );
+  }
+
+  @action
+  async resend(member: Member) {
+    await this.run(async () => {
+      await this.requestManager.request({
+        url: `/sets/${this.submissionSet.id}/members/${member.id}/reminder`,
+        method: 'POST',
+      });
+
+      this.toast.show('Invitation sent again. The previous link no longer works.', 'success');
+    });
+  }
+
+  @action
+  askToRemove(member: Member) {
+    this.confirming = member.id;
+    this.confirmingCount = member.submission_count;
+  }
+
+  @action
+  cancelRemove() {
+    this.confirming = null;
+    this.confirmingCount = 0;
+  }
+
+  @action
+  async removeMember(member: Member) {
+    await this.run(
+      async () => {
+        await this.requestManager.request({
+          url: `/sets/${this.submissionSet.id}/members/${member.id}`,
+          method: 'DELETE',
+        });
+
+        this.confirming = null;
+        this.toast.show(member.you ? 'You have left the set.' : 'Member removed.', 'success');
+      },
+      { leaving: member.you },
+    );
+  }
+
+  @action
+  async removeSubmission(entry: SetSubmission) {
+    await this.run(async () => {
+      await this.requestManager.request({
+        url: `/sets/${this.submissionSet.id}/submissions/${entry.submission.id}`,
+        method: 'DELETE',
+      });
+
+      this.toast.show('Taken out of the set.', 'success');
+    });
+  }
+
+  @action
+  async deleteSet() {
+    await this.run(
+      async () => {
+        await this.requestManager.request({ url: `/sets/${this.submissionSet.id}`, method: 'DELETE' });
+
+        this.toast.show('Set deleted.', 'success');
+      },
+      { leaving: true },
+    );
+  }
+
+  @action
+  async copyInvitation(member: Member) {
+    if (!member.invitation_url) return;
+
+    await navigator.clipboard.writeText(member.invitation_url);
+    this.toast.show('Invitation link copied.', 'success');
+  }
+
+  // Every write here changes what the page is showing — who is on the
+  // roster, what is in the set — so the page is re-read rather than
+  // patched in six different ways. Leaving is the exception: the page is
+  // no longer readable by the person who just left.
+  async run(
+    work: () => Promise<void>,
+    { leaving = false, onError = undefined as ((m: string) => void) | undefined } = {},
+  ) {
+    if (this.busy) return;
+
+    this.busy = true;
+    this.pageError = null;
+
+    try {
+      await work();
+
+      await (leaving ? this.router.transitionTo('sets') : this.router.refresh());
+    } catch (e) {
+      const text = errorMessage(e) ?? 'That did not work. Try again.';
+
+      (onError ?? ((m: string) => (this.pageError = m)))(text);
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  <template>
+    {{pageTitle this.submissionSet.name}}
+
+    <Breadcrumb
+      @items={{array
+        (hash label="Home" route="index")
+        (hash label="Sets" route="sets")
+        (hash label=this.submissionSet.name)
+      }}
+    />
+
+    <div class="d-flex justify-content-between align-items-start gap-3 mb-4">
+      <div class="flex-grow-1">
+        {{#if this.renaming}}
+          <form class="row g-2 align-items-end" {{on "submit" this.rename}}>
+            <div class="col-sm-6">
+              {{#let (uniqueId) as |id|}}
+                <label for={{id}} class="form-label">Set name</label>
+                <input id={{id}} type="text" class="form-control" value={{this.name}} {{on "input" this.updateName}} />
+              {{/let}}
+            </div>
+
+            <div class="col-auto">
+              <button type="submit" class="btn btn-primary" disabled={{this.busy}}>Save</button>
+            </div>
+
+            <div class="col-auto">
+              <button type="button" class="btn btn-link" {{on "click" this.cancelRename}}>Cancel</button>
+            </div>
+          </form>
+        {{else}}
+          <h1 class="display-6 mb-1">
+            {{this.submissionSet.name}}
+
+            {{#if this.submissionSet.owned}}
+              <button
+                type="button"
+                class="btn btn-link align-baseline p-0 ms-2 fs-6"
+                data-test-rename
+                {{on "click" this.startRename}}
+              >Rename</button>
+            {{/if}}
+          </h1>
+
+          <p class="text-body-secondary small mb-0">
+            Created by
+            {{this.submissionSet.owner_uid}}
+            on
+            {{formatDatetime this.submissionSet.created_at}}
+          </p>
+        {{/if}}
+      </div>
+
+      {{#if this.submissionSet.owned}}
+        <div class="text-end">
+          <button
+            type="button"
+            class="btn btn-warning"
+            disabled={{this.deleteDisabled}}
+            title={{this.deleteHint}}
+            data-test-delete
+            {{on "click" this.deleteSet}}
+          >
+            Delete set
+          </button>
+
+          {{#if this.deleteHint}}
+            <p class="form-text mb-0 delete-hint">{{this.deleteHint}}</p>
+          {{/if}}
+        </div>
+      {{/if}}
+    </div>
+
+    {{#if this.pageError}}
+      <div class="alert alert-warning" data-test-error>{{this.pageError}}</div>
+    {{/if}}
+
+    <section class="mb-5" data-test-members>
+      <h2 class="h4">People</h2>
+
+      <p class="text-body-secondary small">
+        Everyone here can see the submissions in this set. Anyone can invite; each person decides which of their own
+        submissions to put in, and removing somebody takes theirs out with them.
+      </p>
+
+      <div class="table-responsive mb-3">
+        <table class="table align-middle">
+          <thead>
+            <tr>
+              <th scope="col">Account</th>
+              <th scope="col">Invited to</th>
+              <th scope="col">State</th>
+              <th scope="col"><span class="visually-hidden">Actions</span></th>
+            </tr>
+          </thead>
+
+          <tbody>
+            {{#each this.submissionSet.members as |member|}}
+              <tr>
+                <td>
+                  {{#if member.uid}}
+                    {{member.uid}}
+                  {{else}}
+                    <span class="text-body-secondary">—</span>
+                  {{/if}}
+
+                  {{#if member.owner}}
+                    <span class="badge text-bg-secondary ms-1">owner</span>
+                  {{/if}}
+
+                  {{#if member.you}}
+                    <span class="badge text-bg-secondary ms-1">you</span>
+                  {{/if}}
+                </td>
+
+                <td class="text-body-secondary">
+                  {{#if member.email}}
+                    {{member.email}}
+                  {{else}}
+                    <span class="text-body-tertiary">—</span>
+                  {{/if}}
+
+                  {{#if (eq member.invited_address_match "different")}}
+                    {{! Not an error. Somebody forwarded the invitation, or
+                    the account is registered elsewhere — either way the
+                    roster is where it gets seen rather than guessed at. }}
+                    <div class="small text-warning-emphasis">
+                      Accepted by an account registered at a different address.
+                    </div>
+                  {{else if (eq member.invited_address_match "unknown")}}
+                    <div class="small text-body-secondary">
+                      That account has no address on file, so this could not be checked.
+                    </div>
+                  {{/if}}
+
+                  {{#if (eq member.mail_deliverable false)}}
+                    <div class="small text-warning-emphasis">
+                      Mail to this address is not being sent from this environment. Send them the link instead.
+                    </div>
+                  {{/if}}
+                </td>
+
+                <td>
+                  {{#if (eq member.status "accepted")}}
+                    <span class="text-body-secondary small">Joined {{formatDatetime member.joined_at}}</span>
+                  {{else if (eq member.status "expired")}}
+                    <span class="badge text-bg-danger">Invitation expired</span>
+                  {{else}}
+                    <span class="badge text-bg-secondary">Invited</span>
+                    <div class="small text-body-secondary">
+                      until
+                      {{formatDatetime member.invitation_expires_at}}
+                    </div>
+                  {{/if}}
+                </td>
+
+                <td class="text-end">
+                  {{#if (eq this.confirming member.id)}}
+                    <div class="small text-body-secondary mb-1">
+                      {{#if member.you}}
+                        Leave this set?
+                      {{else}}
+                        Remove
+                        {{if member.uid member.uid member.email}}?
+                      {{/if}}
+
+                      {{#if this.confirmingCount}}
+                        {{if member.you "Your" "Their"}}
+                        {{this.confirmingCount}}
+                        {{if (eq this.confirmingCount 1) "submission" "submissions"}}
+                        will be taken out of the set.
+                      {{/if}}
+                    </div>
+
+                    <button
+                      type="button"
+                      class="btn btn-warning btn-sm me-1"
+                      disabled={{this.busy}}
+                      {{on "click" (fn this.removeMember member)}}
+                    >
+                      {{if member.you "Leave" "Remove"}}
+                    </button>
+
+                    <button type="button" class="btn btn-link btn-sm" {{on "click" this.cancelRemove}}>Cancel</button>
+                  {{else}}
+                    {{#unless (eq member.status "accepted")}}
+                      <button
+                        type="button"
+                        class="btn btn-outline-secondary btn-sm me-1"
+                        disabled={{this.busy}}
+                        aria-label={{concat "Copy the invitation link for " member.email}}
+                        {{on "click" (fn this.copyInvitation member)}}
+                      >
+                        Copy link
+                      </button>
+
+                      <button
+                        type="button"
+                        class="btn btn-outline-secondary btn-sm me-1"
+                        disabled={{this.busy}}
+                        aria-label={{concat "Send the invitation to " member.email " again"}}
+                        {{on "click" (fn this.resend member)}}
+                      >
+                        Send again
+                      </button>
+                    {{/unless}}
+
+                    {{#if member.removable}}
+                      <button
+                        type="button"
+                        class="btn btn-outline-secondary btn-sm"
+                        disabled={{this.busy}}
+                        aria-label={{if
+                          member.you
+                          "Leave this set"
+                          (concat "Remove " (if member.uid member.uid member.email))
+                        }}
+                        {{on "click" (fn this.askToRemove member)}}
+                      >
+                        {{if member.you "Leave" "Remove"}}
+                      </button>
+                    {{/if}}
+                  {{/if}}
+                </td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      </div>
+
+      <form {{on "submit" this.invite}}>
+        <div class="row g-2 align-items-end">
+          <div class="col-sm-6 col-lg-4">
+            {{#let (uniqueId) as |id|}}
+              <label for={{id}} class="form-label">Invite by email</label>
+
+              <input
+                id={{id}}
+                type="email"
+                class="form-control {{if this.inviteError 'is-invalid'}}"
+                placeholder="colleague@example.org"
+                value={{this.email}}
+                {{on "input" this.updateEmail}}
+              />
+
+              {{#if this.inviteError}}
+                <div class="invalid-feedback d-block" data-test-invite-error>{{this.inviteError}}</div>
+              {{/if}}
+            {{/let}}
+          </div>
+
+          <div class="col-auto">
+            <button type="submit" class="btn btn-primary" disabled={{this.inviteDisabled}}>Invite</button>
+          </div>
+        </div>
+
+        <p class="form-text">
+          They do not need a DDBJ Account yet — the mail explains how to make one. Nothing is shared with them until
+          they open the link.
+        </p>
+      </form>
+    </section>
+
+    <section data-test-submissions>
+      <h2 class="h4">Submissions</h2>
+
+      {{#if this.submissionSet.submission_count}}
+        <div class="table-responsive">
+          <table class="table align-middle">
+            <thead>
+              <tr>
+                <th scope="col">Submission</th>
+                <th scope="col">Database</th>
+                <th scope="col">Owner</th>
+                <th scope="col">State</th>
+                <th scope="col"><span class="visually-hidden">Actions</span></th>
+              </tr>
+            </thead>
+
+            <tbody>
+              {{#each this.submissionSet.submissions as |entry|}}
+                <tr>
+                  <td>
+                    <LinkTo @route="request" @model={{entry.submission.id}}>{{submissionLabel entry}}</LinkTo>
+
+                    {{#if entry.submission.first_accession}}
+                      <div class="small text-body-secondary">
+                        {{entry.submission.first_accession}}
+                        {{#if (gt entry.submission.accession_count 1)}}
+                          ({{entry.submission.accession_count}}
+                          accessions)
+                        {{/if}}
+                      </div>
+                    {{/if}}
+                  </td>
+
+                  <td>{{dbLabel entry.submission.db}}</td>
+                  <td>{{entry.owner_uid}}</td>
+
+                  <td>
+                    <span class="badge {{stateBadgeClass entry}}">{{entryLabel entry}}</span>
+                  </td>
+
+                  <td class="text-end">
+                    {{#if entry.owned}}
+                      <button
+                        type="button"
+                        class="btn btn-outline-secondary btn-sm"
+                        disabled={{this.busy}}
+                        aria-label={{concat "Take " (submissionLabel entry) " out of this set"}}
+                        {{on "click" (fn this.removeSubmission entry)}}
+                      >
+                        Take out
+                      </button>
+                    {{/if}}
+                  </td>
+                </tr>
+              {{/each}}
+            </tbody>
+          </table>
+        </div>
+
+        <Pagination
+          @route="set"
+          @models={{array this.submissionSet.id}}
+          @current={{@controller.page}}
+          @total={{@model.totalPages}}
+        />
+      {{else}}
+        <div class="border rounded p-4 text-center">
+          <p class="mb-1 fw-semibold">Nothing has been put in this set yet.</p>
+
+          <p class="text-body-secondary small mb-0">
+            Open one of
+            <LinkTo @route="index">your submissions</LinkTo>
+            and add it from there — putting a submission in a set is its owner's own decision.
+          </p>
+        </div>
+      {{/if}}
+    </section>
+  </template>
+}

--- a/web/app/templates/sets.gts
+++ b/web/app/templates/sets.gts
@@ -1,0 +1,151 @@
+import Component from '@glimmer/component';
+import { LinkTo } from '@ember/routing';
+import { action } from '@ember/object';
+import { on } from '@ember/modifier';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { array, hash, uniqueId } from '@ember/helper';
+import { pageTitle } from 'ember-page-title';
+
+import Breadcrumb from 'repository/components/breadcrumb';
+import { errorMessage } from 'repository/utils/error-message';
+
+import type { RequestManager } from '@warp-drive/core';
+import type RouterService from '@ember/routing/router-service';
+import type ToastService from 'repository/services/toast';
+import type { components } from 'schema/openapi';
+
+type SetSummary = components['schemas']['SetSummary'];
+
+interface Signature {
+  Args: {
+    model: SetSummary[];
+  };
+}
+
+export default class extends Component<Signature> {
+  @service declare requestManager: RequestManager;
+  @service declare router: RouterService;
+  @service declare toast: ToastService;
+
+  @tracked name = '';
+  @tracked busy = false;
+  @tracked error: string | null = null;
+
+  get submitDisabled() {
+    return this.busy || this.name.trim().length === 0;
+  }
+
+  @action
+  updateName(e: Event) {
+    this.name = (e.target as HTMLInputElement).value;
+  }
+
+  @action
+  async create(e: Event) {
+    e.preventDefault();
+
+    if (this.submitDisabled) return;
+
+    this.busy = true;
+    this.error = null;
+
+    try {
+      const { content } = await this.requestManager.request<SetSummary>({
+        url: '/sets',
+        method: 'POST',
+        data: { set: { name: this.name.trim() } },
+      });
+
+      this.name = '';
+      this.toast.show('Set created.', 'success');
+
+      await this.router.transitionTo('set', content.id);
+    } catch (e) {
+      // On the field, not in a modal over the page: what lands here is
+      // about the value still sitting in the box.
+      this.error = errorMessage(e) ?? 'Could not create the set. Try again.';
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  <template>
+    {{pageTitle "Sets"}}
+
+    <Breadcrumb @items={{array (hash label="Home" route="index") (hash label="Sets")}} />
+
+    <h1 class="display-6 mb-3">Sets</h1>
+
+    <p class="text-body-secondary prose mb-4">
+      A set is submissions that belong together — the ones behind a paper, a study, a piece of work — and the people
+      they belong to. Everyone in a set can see the submissions in it and how far along they are. What goes in stays
+      each person's own decision.
+    </p>
+
+    {{#if @model.length}}
+      <div class="list-group mb-4" data-test-sets>
+        {{#each @model as |set|}}
+          <LinkTo @route="set" @model={{set.id}} class="list-group-item list-group-item-action">
+            <div class="d-flex justify-content-between align-items-start">
+              <div>
+                <div class="fw-semibold">{{set.name}}</div>
+
+                <div class="small text-body-secondary">
+                  Created by
+                  {{set.owner_uid}}
+                </div>
+              </div>
+
+              <div class="text-end small text-body-secondary">
+                <div>{{set.member_count}} {{if (eq set.member_count 1) "member" "members"}}</div>
+                <div>{{set.submission_count}} {{if (eq set.submission_count 1) "submission" "submissions"}}</div>
+
+                {{#if set.invited_count}}
+                  <div>{{set.invited_count}} invited</div>
+                {{/if}}
+              </div>
+            </div>
+          </LinkTo>
+        {{/each}}
+      </div>
+    {{else}}
+      {{! First run rather than a filtered empty: nothing has ever been
+      here, so the words are about what will appear and how to start. }}
+      <div class="border rounded p-4 mb-4 text-center">
+        <p class="mb-1 fw-semibold">You are not in any set yet.</p>
+
+        <p class="text-body-secondary small mb-0">
+          Make one below, then invite the people you are working with and add your submissions to it.
+        </p>
+      </div>
+    {{/if}}
+
+    <form {{on "submit" this.create}}>
+      <div class="row g-2 align-items-end">
+        <div class="col-sm-6 col-lg-4">
+          {{#let (uniqueId) as |id|}}
+            <label for={{id}} class="form-label">New set</label>
+
+            <input
+              id={{id}}
+              type="text"
+              class="form-control {{if this.error 'is-invalid'}}"
+              placeholder="e.g. Deep sea metagenome 2026"
+              value={{this.name}}
+              {{on "input" this.updateName}}
+            />
+
+            {{#if this.error}}
+              <div class="invalid-feedback d-block" data-test-error>{{this.error}}</div>
+            {{/if}}
+          {{/let}}
+        </div>
+
+        <div class="col-auto">
+          <button type="submit" class="btn btn-primary" disabled={{this.submitDisabled}}>Create</button>
+        </div>
+      </div>
+    </form>
+  </template>
+}

--- a/web/app/utils/error-message.ts
+++ b/web/app/utils/error-message.ts
@@ -1,0 +1,11 @@
+// The sentence the server wrote for whoever is reading it.
+//
+// Rails answers a refusal it has words for with `{"error": "..."}` (see
+// PublicError on that side) and everything else with the status alone, so
+// what comes back here is either something worth putting on the screen or
+// nothing at all — never a stack trace or a SQL statement.
+export function errorMessage(error: unknown): string | undefined {
+  const content = (error as { content?: { error?: string } } | undefined)?.content;
+
+  return content?.error;
+}

--- a/web/app/utils/request-state.ts
+++ b/web/app/utils/request-state.ts
@@ -15,9 +15,24 @@ export interface RequestState {
   tone: Tone;
   // Short enough for a table cell: "Ready for you to submit".
   label: string;
+
+  // The same fact about somebody else's submission. Every word on this
+  // screen is written to the submitter, which reads as an instruction
+  // when a colleague is the one looking — see `stateLabel`. Absent where
+  // the label says nothing about who is being addressed.
+  sharedLabel?: string;
+
   badge: string;
   heading: string;
   body: string;
+}
+
+// "Ready for you to submit" over a colleague's row is a lie about whose
+// move it is.
+export function stateLabel(request: StatefulRequest, { owned }: { owned: boolean }) {
+  const state = requestState(request);
+
+  return owned ? state.label : (state.sharedLabel ?? state.label);
 }
 
 const TONE_CLASSES: Record<Tone, { border: string; badge: string }> = {
@@ -53,6 +68,7 @@ export function requestState(request: StatefulRequest): RequestState {
     return {
       tone: 'waiting',
       label: 'You closed this',
+      sharedLabel: 'Closed by the submitter',
       badge: 'Closed by you',
       heading: 'You closed this request',
       body: 'It is kept, with its validation report and any messages, but it is no longer waiting on you. Reopen it if you want it back.',
@@ -98,6 +114,7 @@ export function requestState(request: StatefulRequest): RequestState {
     return {
       tone: 'action',
       label: 'Ready for you to submit',
+      sharedLabel: 'Ready to submit',
       badge: 'Action needed',
       heading: 'Your file passed validation and is ready to submit',
       body: 'Review the validation report below, then press Apply to hand it to DDBJ.',

--- a/web/app/utils/runtime-config.ts
+++ b/web/app/utils/runtime-config.ts
@@ -1,0 +1,52 @@
+// Values WebsController injects into the shell as meta tags, so the same
+// build can be served by every environment. Absent in a bare build, in
+// which case whatever depends on them is simply not shown rather than
+// naming a host we are not sure about.
+function meta(name: string): string | undefined {
+  return document.querySelector(`meta[name="${name}"]`)?.getAttribute('content') || undefined;
+}
+
+// DDBJ Account (Cloakman). Its front page rather than a deep link to the
+// registration form wherever somebody merely *might* need an account: the
+// front page also handles the cases they might actually be in, like having
+// one already under another address.
+export function accountURL(): string | undefined {
+  return meta('account-url');
+}
+
+// The registration form itself, for the one place that knows the reader
+// has no account: an invitation they cannot walk through without one.
+//
+// `returnTo` brings them back afterwards. Cloakman only honours return
+// addresses it has been told about, and ignores anything else rather than
+// refusing — a link that cannot be followed back is still a link that
+// creates the account.
+//
+// Relative to the configured base rather than root-absolute, so a
+// deployment served under a path prefix keeps it; and guarded, because
+// this runs inside a getter during render and a malformed meta tag must
+// not take the page down with it.
+export function signUpURL(returnTo: string): string | undefined {
+  const base = accountURL();
+  if (!base) return undefined;
+
+  try {
+    const url = new URL('account/new', base.endsWith('/') ? base : `${base}/`);
+    url.searchParams.set('return_to', returnTo);
+
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+export function identityProviderHost(): string | undefined {
+  const url = meta('identity-provider');
+  if (!url) return undefined;
+
+  try {
+    return new URL(url).host;
+  } catch {
+    return undefined;
+  }
+}

--- a/web/tests/acceptance/closure-test.gts
+++ b/web/tests/acceptance/closure-test.gts
@@ -40,6 +40,9 @@ function failedRequest(attrs: Partial<SubmissionRequest> = {}): SubmissionReques
     },
     unread_curator_message_count: 0,
     last_message_at: null,
+    sets: [],
+    owned: true,
+    owner_uid: 'test-user',
     ...attrs,
   };
 }

--- a/web/tests/acceptance/invitation-test.gts
+++ b/web/tests/acceptance/invitation-test.gts
@@ -1,0 +1,195 @@
+import { module, test } from 'qunit';
+import { visit, click, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'repository/tests/helpers';
+import { setupAuthentication } from 'repository/tests/helpers/setup-auth';
+
+import { http } from '../msw/http';
+import { worker } from '../msw/worker';
+
+import type { components } from 'schema/openapi';
+
+type Invitation = components['schemas']['Invitation'];
+
+const invitation: Invitation = {
+  set_name: 'Deep sea study',
+  invited_by: 'colleague',
+  email: 'newcomer@example.org',
+  expires_at: '2025-02-01T00:00:00.000Z',
+  status: 'open',
+};
+
+const joined = {
+  id: 7,
+  name: 'Deep sea study',
+  owner_uid: 'colleague',
+  owned: false,
+  created_at: '2025-01-01T00:00:00.000Z',
+  member_count: 2,
+  invited_count: 0,
+  submission_count: 0,
+};
+
+// WebsController injects this into the shell per environment; a test
+// build has no shell, so the one place that reads it has to be given one.
+function withAccountURL(hooks: NestedHooks, url = 'https://accounts.example.com/') {
+  let tag: HTMLMetaElement;
+
+  hooks.beforeEach(function () {
+    tag = document.createElement('meta');
+    tag.setAttribute('name', 'account-url');
+    tag.setAttribute('content', url);
+    document.head.append(tag);
+  });
+
+  hooks.afterEach(function () {
+    tag.remove();
+  });
+}
+
+module('Acceptance | invitation (no login yet)', function (hooks) {
+  setupApplicationTest(hooks);
+  withAccountURL(hooks);
+  // Deliberately no setupAuthentication: the whole point is that the page
+  // reads before the reader has an account, let alone a session.
+
+  test('says what the invitation is for, and offers both ways in', async function (assert) {
+    worker.use(
+      http.get('/invitations/{token}', ({ response }) => {
+        return response(200).json(invitation);
+      }),
+    );
+
+    await visit('/invitations/abc123');
+
+    assert.dom().includesText('colleague');
+    assert.dom().includesText('Deep sea study');
+    assert.dom('[data-test-login]').hasText('Log in with DDBJ Account');
+  });
+
+  test('an expired invitation says so instead of hiding', async function (assert) {
+    worker.use(
+      http.get('/invitations/{token}', ({ response }) => {
+        return response(200).json({ ...invitation, status: 'expired' });
+      }),
+    );
+
+    await visit('/invitations/abc123');
+
+    assert.dom('.alert').includesText('This invitation has expired');
+    assert.dom('[data-test-login]').doesNotExist();
+    assert.dom('[data-test-join]').doesNotExist();
+  });
+
+  // The token is kept after acceptance precisely so this page can say so
+  // — opening the mail again from another device used to be a 404.
+  test('a link somebody has already used says so instead of erroring', async function (assert) {
+    worker.use(
+      http.get('/invitations/{token}', ({ response }) => {
+        return response(200).json({ ...invitation, status: 'accepted', expires_at: null });
+      }),
+    );
+
+    await visit('/invitations/abc123');
+
+    assert.dom('.alert').includesText('already been used');
+    assert.dom('[data-test-join]').doesNotExist();
+  });
+
+  // An invitation token is a bearer credential. Handing it to DDBJ Account
+  // would put it in that application's logs and in the Referer of every
+  // link on its pages, so it waits here instead.
+  test('going off to create an account does not take the token along', async function (assert) {
+    worker.use(
+      http.get('/invitations/{token}', ({ response }) => {
+        return response(200).json(invitation);
+      }),
+    );
+
+    await visit('/invitations/abc123');
+
+    const href = document.querySelector('[data-test-sign-up]')?.getAttribute('href');
+
+    assert.ok(href, 'offers a way to create an account');
+    assert.notOk(href?.includes('abc123'), 'the token is not in the URL handed to DDBJ Account');
+    assert.ok(href?.includes('return_to='), 'but a way back is');
+  });
+});
+
+// Coming back from DDBJ Account. The token is not in the URL DDBJ Account
+// was given (it is a bearer credential), so this route picks it back up.
+module('Acceptance | invitation resume', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.afterEach(function () {
+    localStorage.removeItem('invitationToken');
+  });
+
+  test('picks the token back up and says the account is ready', async function (assert) {
+    worker.use(
+      http.get('/invitations/{token}', ({ response }) => {
+        return response(200).json(invitation);
+      }),
+    );
+
+    localStorage.setItem('invitationToken', JSON.stringify({ token: 'abc123', at: Date.now() }));
+
+    await visit('/invitation?signed_up=1');
+
+    assert.strictEqual(currentURL(), '/invitations/abc123?signed_up=1');
+    assert.dom('.alert-success').includesText('Your DDBJ Account is ready');
+
+    // Spent: a second return has nothing to resume.
+    assert.strictEqual(localStorage.getItem('invitationToken'), null);
+  });
+
+  // Creating an account is a round trip somebody can abandon. A token
+  // left in storage must not resume an invitation weeks later.
+  test('a token left over from an abandoned signup is not resumed', async function (assert) {
+    localStorage.setItem('invitationToken', JSON.stringify({ token: 'abc123', at: Date.now() - 60 * 60 * 1000 }));
+
+    await visit('/invitation');
+
+    assert.strictEqual(currentURL(), '/login');
+    assert.strictEqual(localStorage.getItem('invitationToken'), null);
+  });
+
+  test('with nothing waiting it goes to the front page rather than erroring', async function (assert) {
+    await visit('/invitation');
+
+    // The front page, which for somebody with no session is the sign-in
+    // screen. Either way it is a place, not an error.
+    assert.strictEqual(currentURL(), '/login');
+  });
+});
+
+module('Acceptance | invitation (already signed in)', function (hooks) {
+  setupApplicationTest(hooks);
+  setupAuthentication(hooks);
+
+  test('joining opens the set', async function (assert) {
+    worker.use(
+      http.get('/invitations/{token}', ({ response }) => {
+        return response(200).json(invitation);
+      }),
+
+      http.post('/invitations/{invitation_token}/acceptance', ({ response }) => {
+        return response(201).json(joined);
+      }),
+
+      http.get('/sets/{id}', ({ response }) => {
+        return response(200).json({
+          ...joined,
+          members: [],
+          submissions: [],
+          deletable: true,
+          delete_blocked_reason: null,
+        });
+      }),
+    );
+
+    await visit('/invitations/abc123');
+    await click('[data-test-join]');
+
+    assert.strictEqual(currentURL(), '/sets/7');
+  });
+});

--- a/web/tests/acceptance/reviewer-access-test.gts
+++ b/web/tests/acceptance/reviewer-access-test.gts
@@ -34,6 +34,9 @@ const request: SubmissionRequest = {
   },
   unread_curator_message_count: 0,
   last_message_at: null,
+  sets: [],
+  owned: true,
+  owner_uid: 'test-user',
   submission: {
     id: 10,
     source_id: 'PSUB000042',
@@ -123,6 +126,6 @@ module('Acceptance | reviewer access (submitter side)', function (hooks) {
     await click(enable);
 
     assert.dom('input[readonly]').hasValue('http://example.com/web/reviews/generated-token');
-    assert.dom('button.btn-outline-danger').hasText('Disable');
+    assert.dom('button.btn-warning').hasText('Disable');
   });
 });

--- a/web/tests/acceptance/set-membership-test.gts
+++ b/web/tests/acceptance/set-membership-test.gts
@@ -1,0 +1,170 @@
+import { module, test } from 'qunit';
+import { visit, click, fillIn } from '@ember/test-helpers';
+import { setupApplicationTest } from 'repository/tests/helpers';
+import { setupAuthentication } from 'repository/tests/helpers/setup-auth';
+
+import { http } from '../msw/http';
+import { worker } from '../msw/worker';
+
+import type { components } from 'schema/openapi';
+
+type SubmissionRequest = components['schemas']['SubmissionRequest'];
+type SetSummary = components['schemas']['SetSummary'];
+
+const now = '2025-01-01T00:00:00.000Z';
+
+const mine: SetSummary = {
+  id: 7,
+  name: 'Deep sea study',
+  owner_uid: 'test-user',
+  owned: true,
+  created_at: now,
+  member_count: 1,
+  invited_count: 0,
+  submission_count: 0,
+};
+
+function request(sets: SubmissionRequest['sets']): SubmissionRequest {
+  return {
+    id: 42,
+    db: 'st26',
+    status: 'validation_failed',
+    error_code: null,
+    error_message: null,
+    created_at: now,
+    closed_at: null,
+    closable: true,
+    owned: true,
+    owner_uid: 'test-user',
+    processing: false,
+    ddbj_record: { filename: 'test.json', url: 'http://example.com/test.json' },
+    validation: null,
+    submission: null,
+    progress: {
+      step: 'submitted',
+      failed: false,
+      closed: false,
+      row_count: 0,
+      accessioned_count: 0,
+      hold_date: null,
+    },
+    unread_curator_message_count: 0,
+    last_message_at: null,
+    sets,
+  };
+}
+
+module('Acceptance | putting a submission in a set', function (hooks) {
+  setupApplicationTest(hooks);
+  setupAuthentication(hooks);
+
+  // The server answers 204 with no body. Anything else empty-bodied
+  // reaches the fetch layer as a JSON parse error, which is how the first
+  // version of this shipped broken — the row went in and the screen said
+  // it had failed.
+  test('adding it says so, and does not report a failure', async function (assert) {
+    let added = false;
+
+    worker.use(
+      http.get('/sets', ({ response }) => {
+        return response(200).json([mine]);
+      }),
+
+      http.get('/submission_requests/{submission_request_id}/messages', ({ response }) => {
+        return response(200).json([]);
+      }),
+
+      http.get('/submission_requests/{id}', ({ response }) => {
+        return response(200).json(request(added ? [{ id: 7, name: 'Deep sea study' }] : []));
+      }),
+
+      http.post('/sets/{set_id}/submissions', ({ response }) => {
+        added = true;
+
+        return response(204).empty();
+      }),
+    );
+
+    await visit('/requests/42');
+    await fillIn('[data-test-sets] select', '7');
+    await click('[data-test-sets] button');
+
+    assert.true(added, 'the submission was posted to the set');
+    assert.dom('[data-test-sets] [data-test-error]').doesNotExist();
+    assert.dom('[data-test-sets]').includesText('Deep sea study');
+  });
+
+  test('taking it back out', async function (assert) {
+    let removed = false;
+
+    worker.use(
+      http.get('/sets', ({ response }) => {
+        return response(200).json([mine]);
+      }),
+
+      http.get('/submission_requests/{submission_request_id}/messages', ({ response }) => {
+        return response(200).json([]);
+      }),
+
+      http.get('/submission_requests/{id}', ({ response }) => {
+        return response(200).json(request(removed ? [] : [{ id: 7, name: 'Deep sea study' }]));
+      }),
+
+      http.delete('/sets/{set_id}/submissions/{submission_request_id}', ({ response }) => {
+        removed = true;
+
+        return response(204).empty();
+      }),
+    );
+
+    await visit('/requests/42');
+    await click('[aria-label="Take this submission out of Deep sea study"]');
+
+    assert.true(removed, 'the submission was taken out');
+    assert.dom('[data-test-sets]').includesText('not in any set');
+  });
+
+  // The panel used to render the list and nothing else here — no picker,
+  // no way on — which reads as "a submission belongs to one set". It does
+  // not.
+  test('being in all of your sets still says another one is possible', async function (assert) {
+    worker.use(
+      http.get('/sets', ({ response }) => {
+        return response(200).json([mine]);
+      }),
+
+      http.get('/submission_requests/{submission_request_id}/messages', ({ response }) => {
+        return response(200).json([]);
+      }),
+
+      http.get('/submission_requests/{id}', ({ response }) => {
+        return response(200).json(request([{ id: 7, name: 'Deep sea study' }]));
+      }),
+    );
+
+    await visit('/requests/42');
+
+    assert.dom('[data-test-sets] select').doesNotExist();
+    assert.dom('[data-test-sets]').includesText('can be in as many as it belongs in');
+  });
+
+  test('with a set it is not in yet, the picker says which kind of add this is', async function (assert) {
+    worker.use(
+      http.get('/sets', ({ response }) => {
+        return response(200).json([mine, { ...mine, id: 8, name: 'Another study' }]);
+      }),
+
+      http.get('/submission_requests/{submission_request_id}/messages', ({ response }) => {
+        return response(200).json([]);
+      }),
+
+      http.get('/submission_requests/{id}', ({ response }) => {
+        return response(200).json(request([{ id: 7, name: 'Deep sea study' }]));
+      }),
+    );
+
+    await visit('/requests/42');
+
+    assert.dom('[data-test-sets] label').hasText('Add to another set');
+  });
+});

--- a/web/tests/acceptance/sets-test.gts
+++ b/web/tests/acceptance/sets-test.gts
@@ -1,0 +1,332 @@
+import { module, test } from 'qunit';
+import { visit, click, fillIn, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'repository/tests/helpers';
+import { setupAuthentication } from 'repository/tests/helpers/setup-auth';
+
+import { http } from '../msw/http';
+import { worker } from '../msw/worker';
+
+import type { components } from 'schema/openapi';
+
+type Set = components['schemas']['Set'];
+type SetSummary = components['schemas']['SetSummary'];
+
+const now = '2025-01-01T00:00:00.000Z';
+
+const summary: SetSummary = {
+  id: 7,
+  name: 'Deep sea study',
+  owner_uid: 'test-user',
+  owned: true,
+  created_at: now,
+  member_count: 2,
+  invited_count: 1,
+  submission_count: 1,
+};
+
+const set: Set = {
+  ...summary,
+  deletable: false,
+  delete_blocked_reason:
+    'Take the submissions out and remove everyone else — including invitations nobody has used — first.',
+
+  members: [
+    {
+      id: 1,
+      email: null,
+      uid: 'test-user',
+      status: 'accepted',
+      owner: true,
+      you: true,
+      invited_by: 'test-user',
+      joined_at: now,
+      invitation_expires_at: null,
+      removable: false,
+      submission_count: 0,
+      invited_address_match: null,
+      invitation_url: null,
+      mail_deliverable: null,
+    },
+    {
+      id: 2,
+      email: 'colleague@example.org',
+      uid: 'colleague',
+      status: 'accepted',
+      owner: false,
+      you: false,
+      invited_by: 'test-user',
+      joined_at: now,
+      invitation_expires_at: null,
+      removable: true,
+      submission_count: 1,
+      invited_address_match: 'different',
+      invitation_url: null,
+      mail_deliverable: null,
+    },
+    {
+      id: 3,
+      email: 'newcomer@example.org',
+      uid: null,
+      status: 'open',
+      owner: false,
+      you: false,
+      invited_by: 'test-user',
+      joined_at: null,
+      invitation_expires_at: '2025-02-01T00:00:00.000Z',
+      removable: true,
+      submission_count: 0,
+      invited_address_match: null,
+      invitation_url: 'http://localhost:4200/web/invitations/tok123',
+      mail_deliverable: false,
+    },
+  ],
+
+  submissions: [
+    {
+      added_at: now,
+      owner_uid: 'colleague',
+      owned: false,
+
+      submission: {
+        id: 42,
+        db: 'bioproject',
+        status: 'applied',
+        created_at: now,
+        closed_at: null,
+        submission_id: 10,
+        source_id: 'PSUB000042',
+        first_accession: 'PRJDB1234',
+        accession_count: 1,
+        processing: false,
+        unread_curator_message_count: 0,
+
+        progress: {
+          step: 'curating',
+          failed: false,
+          closed: false,
+          row_count: 1,
+          accessioned_count: 1,
+          hold_date: null,
+        },
+      },
+    },
+  ],
+};
+
+module('Acceptance | sets', function (hooks) {
+  setupApplicationTest(hooks);
+  setupAuthentication(hooks);
+
+  test('the list says what a set is for when there are none yet', async function (assert) {
+    worker.use(
+      http.get('/sets', ({ response }) => {
+        return response(200).json([]);
+      }),
+    );
+
+    await visit('/sets');
+
+    assert.dom('[data-test-sets]').doesNotExist();
+    assert.dom().includesText('You are not in any set yet');
+  });
+
+  test('creating one opens it', async function (assert) {
+    worker.use(
+      http.get('/sets', ({ response }) => {
+        return response(200).json([]);
+      }),
+
+      http.post('/sets', ({ response }) => {
+        return response(201).json({ ...set, members: [set.members[0]!], submissions: [] });
+      }),
+
+      http.get('/sets/{id}', ({ response }) => {
+        return response(200).json({
+          ...set,
+          members: [set.members[0]!],
+          submissions: [],
+          submission_count: 0,
+          deletable: true,
+          delete_blocked_reason: null,
+        });
+      }),
+    );
+
+    await visit('/sets');
+    await fillIn('input[type="text"]', 'Deep sea study');
+    await click('button[type="submit"]');
+
+    assert.strictEqual(currentURL(), '/sets/7');
+    assert.dom().includesText('Deep sea study');
+  });
+
+  test('the roster shows who has joined, who has not, and who came in at another address', async function (assert) {
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => {
+        return response(200).json(set);
+      }),
+    );
+
+    await visit('/sets/7');
+
+    assert.dom('[data-test-members]').includesText('colleague');
+    assert.dom('[data-test-members]').includesText('newcomer@example.org');
+    assert.dom('[data-test-members]').includesText('Invited');
+    assert.dom('[data-test-members]').includesText('registered at a different address');
+  });
+
+  // Every deployed environment restricts outgoing mail while sending to
+  // real submitters is switched off. Without this the inviter has no way
+  // to know their invitation reached nobody.
+  test('an invitation whose mail goes nowhere says so, and offers the link', async function (assert) {
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => {
+        return response(200).json(set);
+      }),
+    );
+
+    await visit('/sets/7');
+
+    assert.dom('[data-test-members]').includesText('not being sent from this environment');
+    assert.dom('[aria-label="Copy the invitation link for newcomer@example.org"]').exists();
+  });
+
+  test('removing somebody says what goes with them, and asks first', async function (assert) {
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => {
+        return response(200).json(set);
+      }),
+    );
+
+    await visit('/sets/7');
+    await click('[aria-label="Remove colleague"]');
+
+    assert.dom('[data-test-members]').includesText('Their 1 submission will be taken out of the set');
+
+    // Nothing has been sent yet — it asked.
+    await click('[data-test-members] button.btn-link');
+
+    assert.dom('[data-test-members]').doesNotIncludeText('will be taken out of the set');
+  });
+
+  test('a row you may not remove offers no way to', async function (assert) {
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => {
+        return response(200).json(set);
+      }),
+    );
+
+    await visit('/sets/7');
+
+    // The owner's own row: nobody may remove them, and they cannot walk
+    // out of a set that would then have nobody to delete it.
+    assert.dom('[aria-label="Leave this set"]').doesNotExist();
+  });
+
+  test('the owner is told why a set cannot be deleted, rather than shown nothing', async function (assert) {
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => {
+        return response(200).json(set);
+      }),
+    );
+
+    await visit('/sets/7');
+
+    assert.dom('[data-test-delete]').isDisabled();
+    assert.dom().includesText('Take the submissions out and remove everyone else');
+  });
+
+  test('an empty set of your own can just be deleted', async function (assert) {
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => {
+        return response(200).json({
+          ...set,
+          members: [set.members[0]!],
+          submissions: [],
+          submission_count: 0,
+          deletable: true,
+          delete_blocked_reason: null,
+        });
+      }),
+    );
+
+    await visit('/sets/7');
+
+    assert.dom('[data-test-delete]').isNotDisabled();
+    assert.dom().doesNotIncludeText('Take the submissions out and remove everyone else');
+  });
+
+  test('the owner can rename it', async function (assert) {
+    let name = set.name;
+
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => {
+        return response(200).json({ ...set, name });
+      }),
+
+      http.patch('/sets/{id}', ({ response }) => {
+        name = 'Renamed study';
+
+        return response(200).json({ ...set, name });
+      }),
+    );
+
+    await visit('/sets/7');
+    await click('[data-test-rename]');
+    await fillIn('input[type="text"]', 'Renamed study');
+    await click('button[type="submit"]');
+
+    assert.dom('h1').includesText('Renamed study');
+  });
+
+  test('a refused invitation lands on the field, not in a modal over the page', async function (assert) {
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => {
+        return response(200).json(set);
+      }),
+
+      http.post('/sets/{set_id}/members', ({ response }) => {
+        return response(422).json({ error: 'Email is already a member of this set' });
+      }),
+    );
+
+    await visit('/sets/7');
+    await fillIn('input[type="email"]', 'colleague@example.org');
+    await click('button[type="submit"]');
+
+    assert.dom('[data-test-invite-error]').includesText('already a member');
+    assert.dom('.modal.show').doesNotExist();
+  });
+
+  test('a submission somebody else put in is listed but not removable', async function (assert) {
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => {
+        return response(200).json(set);
+      }),
+    );
+
+    await visit('/sets/7');
+
+    assert.dom('[data-test-submissions]').includesText('PSUB000042');
+    assert.dom('[data-test-submissions]').includesText('colleague');
+    assert.dom('[data-test-submissions] button').doesNotExist();
+  });
+
+  // The server says whose it is — the client cannot work it out, because
+  // under a proxy login the account it believes it is is not the account
+  // the server acts as.
+  test('your own submission in a set can be taken back out', async function (assert) {
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => {
+        return response(200).json({
+          ...set,
+          submissions: [{ ...set.submissions[0]!, owner_uid: 'test-user', owned: true }],
+        });
+      }),
+    );
+
+    await visit('/sets/7');
+
+    assert.dom('[aria-label="Take PSUB000042 out of this set"]').exists();
+  });
+});

--- a/web/tests/acceptance/shared-submission-test.gts
+++ b/web/tests/acceptance/shared-submission-test.gts
@@ -1,0 +1,115 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'repository/tests/helpers';
+import { setupAuthentication } from 'repository/tests/helpers/setup-auth';
+
+import { http } from '../msw/http';
+import { worker } from '../msw/worker';
+
+import type { components } from 'schema/openapi';
+
+type SubmissionRequest = components['schemas']['SubmissionRequest'];
+
+const now = '2025-01-01T00:00:00.000Z';
+
+// What the server sends for a submission you can read through a set
+// somebody else put it in: no conversation, nothing to press.
+const shared: SubmissionRequest = {
+  id: 42,
+  db: 'bioproject',
+  status: 'ready_to_apply',
+  error_code: null,
+  error_message: null,
+  created_at: now,
+  closed_at: null,
+  closable: false,
+  owned: false,
+  owner_uid: 'colleague',
+  processing: false,
+  ddbj_record: { filename: 'test.json', url: 'http://example.com/test.json' },
+  validation: {
+    id: 1,
+    progress: 'finished',
+    created_at: now,
+    finished_at: now,
+    validity: 'invalid',
+
+    details: [
+      {
+        entry_id: 'entry-1',
+        severity: 'error',
+        code: 'TRD_R0001',
+        message: 'Something is wrong with entry-1.',
+      },
+    ],
+  },
+  submission: null,
+  progress: {
+    step: 'curating',
+    failed: false,
+    closed: false,
+    row_count: 1,
+    accessioned_count: 0,
+    hold_date: null,
+  },
+  unread_curator_message_count: 0,
+  last_message_at: null,
+  sets: [{ id: 7, name: 'Deep sea study' }],
+};
+
+module('Acceptance | a submission shared into a set', function (hooks) {
+  setupApplicationTest(hooks);
+  setupAuthentication(hooks);
+
+  test('is readable, but nothing on it is yours to press', async function (assert) {
+    worker.use(
+      http.get('/submission_requests/{id}', ({ response }) => {
+        return response(200).json(shared);
+      }),
+    );
+
+    await visit('/requests/42');
+
+    // Where it has got to is the point of being able to see it at all.
+    assert.dom().includesText('BioProject');
+
+    // Sending, closing, the conversation, and the sharing controls all
+    // belong to whoever submitted it.
+    assert.dom('[data-test-send]').doesNotExist();
+    assert.dom('[data-test-close]').doesNotExist();
+    assert.dom('[data-test-messages]').doesNotExist();
+    assert.dom().doesNotIncludeText('Share with a reviewer');
+
+    // And nothing addresses them as the submitter. The panel is stated
+    // about somebody; the validation report — which opens "this is still
+    // your draft" — is not shown at all.
+    assert.dom('[data-test-shared-state]').includesText("colleague's submission");
+    assert.dom('[data-test-state]').doesNotExist();
+    assert.dom().doesNotIncludeText('still your draft');
+    assert.dom().doesNotIncludeText('ready to submit');
+  });
+
+  test('your own carries all of it', async function (assert) {
+    worker.use(
+      http.get('/submission_requests/{id}', ({ response }) => {
+        return response(200).json({ ...shared, owned: true, closable: true });
+      }),
+
+      http.get('/submission_requests/{submission_request_id}/messages', ({ response }) => {
+        return response(200).json([]);
+      }),
+    );
+
+    await visit('/requests/42');
+
+    assert.dom('[data-test-send]').exists();
+    assert.dom('[data-test-close]').exists();
+    assert.dom().includesText('Share with a reviewer');
+
+    // The other half of the assertion above: the report IS shown to the
+    // submitter, second person and all, so its absence there means
+    // something.
+    assert.dom('[data-test-state]').exists();
+    assert.dom().includesText('still your draft');
+  });
+});

--- a/web/tests/acceptance/submission-messages-test.gts
+++ b/web/tests/acceptance/submission-messages-test.gts
@@ -37,6 +37,9 @@ const request: components['schemas']['SubmissionRequest'] = {
   },
   unread_curator_message_count: 0,
   last_message_at: '2025-01-02T09:30:00.000Z',
+  sets: [],
+  owned: true,
+  owner_uid: 'test-user',
   submission: {
     id: 10,
     source_id: null,

--- a/web/tests/acceptance/submission-request-test.gts
+++ b/web/tests/acceptance/submission-request-test.gts
@@ -67,6 +67,9 @@ module('Acceptance | submission request', function (hooks) {
 
       unread_curator_message_count: 0,
       last_message_at: null,
+      sets: [],
+      owned: true,
+      owner_uid: 'test-user',
     };
 
     worker.use(

--- a/web/tests/acceptance/validation-report-test.gts
+++ b/web/tests/acceptance/validation-report-test.gts
@@ -29,6 +29,9 @@ function requestWith(details: Detail[]): SubmissionRequest {
     closable: true,
     processing: false,
     last_message_at: null,
+    sets: [],
+    owned: true,
+    owner_uid: 'test-user',
     unread_curator_message_count: 0,
     ddbj_record: { filename: 'test.json', url: 'http://example.com/test.json' },
     validation: {
@@ -163,7 +166,7 @@ module('Acceptance | validation report', function (hooks) {
     assert.dom('details').doesNotIncludeText('Validation report');
   });
 
-  // A group mixing file-level and entry-level findings collects fewer
+  // A set mixing file-level and entry-level findings collects fewer
   // than three ids, and without this reads as though those were all of
   // them.
   test('the examples say when they are only some of the records', async function (assert) {

--- a/web/tests/msw/handlers.ts
+++ b/web/tests/msw/handlers.ts
@@ -23,6 +23,13 @@ export const handlers = [
     return response(200).json({ requests: [] });
   }),
 
+  // The request detail page offers "add to a set", which needs to know
+  // which sets the reader is in; default to none so tests that don't
+  // care about sets don't have to stub it.
+  http.get('/sets', ({ response }) => {
+    return response(200).json([]);
+  }),
+
   // The request detail page loads the reviewer-access state; default to
   // disabled so tests that don't care about it don't have to stub it.
   http.get('/submission_requests/{submission_request_id}/reviewer_access', ({ response }) => {


### PR DESCRIPTION
A **set** is submissions that belong together — the ones behind a paper,
a study, a piece of work — and the people they belong to. Everyone in a
set can read the submissions in it; what goes in stays each person's own
decision.

Named after the submissions rather than after the people, on purpose. A
lab is a group, and bundling submissions at the granularity of a lab has
no use. What is worth bundling is a set of submissions that mean
something together — whatever granularity that turns out to be — and the
people fall out of it, rather than the set being a picture of an
organisation.

The Ruby class is `SubmissionSet` because Ruby owns the constant `Set`.
Everything a person sees — URLs, JSON, screens, mail — says "set".

## The shape

Two axes, kept as two tables that meet only through the set: who is in it
(`submission_set_members`) and what is in it (`submission_set_inclusions`).

**Putting your own submission in a set is the whole permission story.**
There is no separate grant to keep in step, and nothing to reconcile when
somebody leaves: taking them off the roster takes their submissions with
them, because the permission was never anywhere else.

Membership is many-to-many. A BioProject is a hub — the sets hanging off
one are different collaborations rather than one.

## Invitations

They go to an email address, because the person being invited often has
no DDBJ Account yet; that is why the address rather than the uid.

What is checked on the way in is **the token in the mailed link, not the
address**. Somebody who signs up under a different address would
otherwise reach a dead end with nothing on screen to explain it. The
price is that a forwarded mail lets somebody else in, so the row records
which account accepted and the roster says so whenever it does not match
the address invited. Forwarding an invitation to a colleague is a real
thing people do; the answer is to make it visible, not to refuse it.

The token is kept after acceptance, so re-opening the mail from another
device says "this has already been used" rather than answering with a
404.

## Reading, and what it does not carry

`SubmissionRequest#show` widens to `readable_by`. **Every other endpoint
taking a request id stays owner-scoped**, and `set_sharing_boundary_test`
is what would notice a refactor helpfully unifying them.

A member reads somebody else's submission and its accessions. They do not
get the curator conversation, the reviewer share link, closing, applying,
or the other sets it is in. The payload says which of the two the reader
is (`owned`), and the screen states things in the third person rather
than telling a colleague their file is ready to submit.

## Removal means removal

Removing a member takes out their submissions **and the invitations they
sent**. Without the second half, somebody asked to leave walks back in
through a link they mailed themselves a month earlier — and removal, the
only revocation this design has, would revoke nothing.

Every write that adds to a set takes the set's lock and re-checks
membership inside it. Serialising the remover alone is not enough: the
queued writer still believes it is a member when it runs.

**One thing removal does not yet reach is the files** — see below.

## Mail that goes nowhere

Every deployed environment restricts outgoing mail while sending to real
submitters is switched off, which would make this feature look like it
works and reach nobody. The roster reports `mail_deliverable` and offers
the invitation link to copy, so it works by hand either way.

## Fixes that came out of reviewing this

- **A 500 answered with the SQL that caused it**, and a `find_by!` 404
  with its WHERE clause — on an unauthenticated endpoint. Exception
  messages now reach the body only when written for a reader
  (`PublicError`).
- **Lost races returned 500** (unique index, foreign key). Now 422, and
  out of Sentry.
- **`submission_id` was `nullable: true`** — OpenAPI 3.0 syntax that is
  not a keyword in the 3.1 document this is, so it had been declaring a
  nullable field non-null.
- Set writes are refused under proxy login: the row records who did it,
  and under a proxy that would name the person being helped.

This PR changes **no existing client behaviour**. Everything above is
either new surface or an error path that was previously a 500.

## Tests

`bin/rails test:all` 1260 runs / 0 failures. rubocop and brakeman clean.
`pnpm lint` and `pnpm test` (68) clean in `web/`.

## Not in this PR

- **Authenticated downloads.** An Active Storage URL is a bearer
  credential with no expiry, so a member who opened a submission keeps
  its blob URL after being removed. That predates sets — a reviewer share
  link has always worked the same way — but sets are the first place the
  code *promises* revocation, so it should be fixed properly rather than
  papered over with a TTL. The fix is `draw_routes = false` plus our own
  controller, and it is its own change: four ways in (JWT, API key, admin
  session, reviewer token), direct uploads and the Disk service routes to
  re-provide, and a per-attachment authorisation table to get right.
- **The conversation is still per-submission.** Set-wide messaging is the
  next feature piece; the copy here deliberately promises only what
  exists.
- **Reviewer sharing is still per-submission.** Sharing a whole set —
  and, more likely, selecting accessions across one — comes after.
- No pagination on `/api/sets` (the submissions *inside* one are
  paginated).

## Order

ddbj/cloakman#435 adds the `return_to` this uses to bring somebody back
after they create an account. Merge that first for the round trip to work
on the first deploy; in the other order nothing breaks — Cloakman ignores
a return address it does not recognise, so people simply land on its
front page until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)