### PR TITLE
Serve downloads from routes that ask who is asking

### DIFF
--- a/app/controllers/admin/direct_uploads_controller.rb
+++ b/app/controllers/admin/direct_uploads_controller.rb
@@ -1,0 +1,7 @@
+# Direct upload for the curator screens — the message composer attaches
+# files this way. Same reasoning as the API's: see DirectUploadsController.
+class Admin::DirectUploadsController < ActiveStorage::DirectUploadsController
+  include AdminAuthentication
+
+  before_action :authenticate_admin!
+end

--- a/app/controllers/admin/direct_uploads_controller.rb
+++ b/app/controllers/admin/direct_uploads_controller.rb
@@ -3,14 +3,19 @@
 class Admin::DirectUploadsController < ActiveStorage::DirectUploadsController
   include AdminAuthentication
 
+  # Before the forgery check, and that order is the point. A session that
+  # has lapsed fails that check too — the token it is compared against
+  # lives in the session — so a curator whose afternoon ran long would be
+  # told 422 by a page of HTML, when what happened is that they need to
+  # sign in again.
+  before_action :authenticate_admin!
+
   # Active Storage turns forgery protection off on its own controller,
   # which is right for the endpoint it drew: public, and authenticated by
   # nothing. This one is authenticated by a session cookie, and a cookie
   # is sent whoever asked for the request — so a form on another site
   # would create blob rows as whichever curator has this open.
   protect_from_forgery with: :exception
-
-  before_action :authenticate_admin!
 
   private
 
@@ -19,10 +24,14 @@ class Admin::DirectUploadsController < ActiveStorage::DirectUploadsController
   # follow the redirect, get 200 and a page of HTML, and fall over
   # destructuring a body that is not there. A curator whose session
   # lapsed mid-message would see nothing happen at all.
+  #
+  # Signed in but not a curator is a different answer from not signed in:
+  # signing in again reaches the same place, and 401 invites the client
+  # to try exactly that.
   def authenticate_admin!
     return super unless request.xhr? || request.format.json?
     return if current_user&.admin?
 
-    head :unauthorized
+    head current_user ? :forbidden : :unauthorized
   end
 end

--- a/app/controllers/admin/direct_uploads_controller.rb
+++ b/app/controllers/admin/direct_uploads_controller.rb
@@ -3,5 +3,26 @@
 class Admin::DirectUploadsController < ActiveStorage::DirectUploadsController
   include AdminAuthentication
 
+  # Active Storage turns forgery protection off on its own controller,
+  # which is right for the endpoint it drew: public, and authenticated by
+  # nothing. This one is authenticated by a session cookie, and a cookie
+  # is sent whoever asked for the request — so a form on another site
+  # would create blob rows as whichever curator has this open.
+  protect_from_forgery with: :exception
+
   before_action :authenticate_admin!
+
+  private
+
+  # `authenticate_admin!` answers a browser with the sign-in page, which
+  # is right for a navigation and wrong for this: the uploader would
+  # follow the redirect, get 200 and a page of HTML, and fall over
+  # destructuring a body that is not there. A curator whose session
+  # lapsed mid-message would see nothing happen at all.
+  def authenticate_admin!
+    return super unless request.xhr? || request.format.json?
+    return if current_user&.admin?
+
+    head :unauthorized
+  end
 end

--- a/app/controllers/admin/files_controller.rb
+++ b/app/controllers/admin/files_controller.rb
@@ -1,0 +1,36 @@
+# Downloads for curators. Everything a submitter's own routes serve, plus
+# the message attachments, without the ownership scoping — a curator's
+# reach over submissions is the premise of the admin section.
+#
+# Separate from the API's controllers because the way in is different: a
+# session cookie rather than a token, which is the whole reason the two
+# logins were made independent.
+class Admin::FilesController < Admin::ApplicationController
+  include AttachmentDownload
+
+  REQUEST_NAMES = {'ddbj_record' => :ddbj_record}.freeze
+
+  SUBMISSION_NAMES = {
+    'ddbj_record' => :ddbj_record,
+    'flatfile_na' => :flatfile_na,
+    'flatfile_aa' => :flatfile_aa
+  }.freeze
+
+  def submission_request
+    request = SubmissionRequest.find(params.expect(:submission_request_id))
+
+    redirect_to_attachment request.public_send(REQUEST_NAMES.fetch(params[:name]))
+  end
+
+  def submission
+    submission = Submission.find(params.expect(:submission_id))
+
+    redirect_to_attachment submission.public_send(SUBMISSION_NAMES.fetch(params[:name]))
+  end
+
+  def message
+    message = SubmissionMessage.find(params.expect(:message_id))
+
+    redirect_to_attachment message.files.find(params.expect(:id))
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::API
-  include ActionController::HttpAuthentication::Token::ControllerMethods
+  include TokenAuthentication
   include Pagy::Method
   include WebRedirect
 
@@ -26,33 +26,14 @@ class ApplicationController < ActionController::API
   # on the unauthenticated endpoints, which is what they mean.
   before_action { @viewer = current_user }
 
-  # A curator is acting as this submitter. Asked by the writes that
-  # record who did them — see `refuse_proxy!`. Reading it forces the
-  # authentication it describes, so it is never stale.
-  def proxying?
-    current_user && @proxying == true
-  end
-
-  def current_user
-    return @current_user if defined?(@current_user)
-
-    @current_user = authenticate_with_http_token {|token|
-      next nil unless user = token.count('.') == 2 ? find_user_from_jwt(token) : find_user_from_api_key(token)
-
-      if user.admin? && uid = request.headers['X-Dway-User-Id']
-        @proxying = true
-
-        User.find_by(uid:)
-      else
-        user
-      end
-    }
-  end
-
   private
 
   def forbid!(message)
     raise Forbidden, message
+  end
+
+  def refuse!(message)
+    raise UnprocessableContent, message
   end
 
   # Acting as somebody else is for helping them with what they submitted.
@@ -64,29 +45,5 @@ class ApplicationController < ActionController::API
     return unless proxying?
 
     forbid! 'Sets cannot be changed while acting as another account.'
-  end
-
-  def refuse!(message)
-    raise UnprocessableContent, message
-  end
-
-  def authenticate!
-    return if current_user
-
-    render json: {
-      error: 'Unauthorized'
-    }, status: :unauthorized
-  end
-
-  def find_user_from_jwt(token)
-    Rails.error.handle(JWT::DecodeError) {
-      payload, = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: 'HS512')
-
-      User.find_by(id: payload.fetch('user_id'))
-    }
-  end
-
-  def find_user_from_api_key(token)
-    User.find_by(api_key: token)
   end
 end

--- a/app/controllers/concerns/attachment_download.rb
+++ b/app/controllers/concerns/attachment_download.rb
@@ -1,0 +1,47 @@
+# Handing over a file, once the route's own record has said the caller may
+# have it.
+#
+# A redirect to a short-lived storage URL, not a proxy through this
+# process. These are submission files and a genome assembly is measured in
+# gigabytes; streaming those through Puma to avoid a five-minute signed
+# URL is the wrong trade. The window is
+# `ActiveStorage.service_urls_expire_in`.
+#
+# What this replaces is Active Storage's own `/rails/active_storage/blobs`
+# route, which is disabled (`config.active_storage.draw_routes`). That
+# route takes a signed blob id and nothing else, so the URL it mints is a
+# bearer credential with no expiry and no owner: whoever holds it has the
+# file, for ever, whatever has happened to their access since. Every path
+# through here re-asks.
+module AttachmentDownload
+  extend ActiveSupport::Concern
+
+  included do
+    # What tells the Disk service which host to build its URLs against.
+    # Active Storage's own controllers get it from here too; ours are not
+    # its controllers, so they have to ask for it.
+    include ActiveStorage::SetCurrent
+  end
+
+  private
+
+  # Takes whatever the caller has in hand — a `has_one_attached` proxy, one
+  # `ActiveStorage::Attachment` out of a `has_many`, or nothing at all —
+  # and reduces it to the blob, which is the only thing storage needs.
+  def redirect_to_attachment(attachment)
+    blob = attachment.respond_to?(:blob) ? attachment.blob : attachment
+
+    raise ActiveRecord::RecordNotFound unless blob
+
+    expires_in ActiveStorage.service_urls_expire_in
+
+    redirect_to blob.url(disposition:), allow_other_host: true
+  end
+
+  # `inline` unless asked otherwise, matching Active Storage's own
+  # default. Anything but the one recognised value is that default rather
+  # than an error — a disposition is a preference, not an instruction.
+  def disposition
+    params[:disposition] == 'attachment' ? 'attachment' : 'inline'
+  end
+end

--- a/app/controllers/concerns/attachment_download.rb
+++ b/app/controllers/concerns/attachment_download.rb
@@ -33,9 +33,23 @@ module AttachmentDownload
 
     raise ActiveRecord::RecordNotFound unless blob
 
-    expires_in ActiveStorage.service_urls_expire_in
+    # Never cached. Caching the redirect for as long as the URL it points
+    # at is valid would mean a second click inside that window is served
+    # from the browser without coming back here — and coming back here is
+    # the entire point. A membership revoked a minute ago has to be a
+    # download that stops, not one that stops in five minutes.
+    expires_now
 
-    redirect_to blob.url(disposition:), allow_other_host: true
+    url = blob.url(disposition:)
+
+    # A browser cannot put an `Authorization` header on an anchor, and
+    # this API takes no cookies — so the web client asks for the address
+    # instead of following the redirect, and navigates to it itself.
+    # Everything else (curl, the bulk client, the admin screens) follows
+    # the redirect as before.
+    return render json: {url:} if params[:as] == 'url'
+
+    redirect_to url, allow_other_host: true
   end
 
   # `inline` unless asked otherwise, matching Active Storage's own

--- a/app/controllers/concerns/attachment_download.rb
+++ b/app/controllers/concerns/attachment_download.rb
@@ -33,12 +33,14 @@ module AttachmentDownload
 
     raise ActiveRecord::RecordNotFound unless blob
 
-    # Never cached. Caching the redirect for as long as the URL it points
-    # at is valid would mean a second click inside that window is served
-    # from the browser without coming back here — and coming back here is
-    # the entire point. A membership revoked a minute ago has to be a
+    # Never cached, and never stored. `expires_now` says `no-cache`,
+    # which permits keeping the answer as long as it is revalidated —
+    # but there is nothing to revalidate against here (no ETag, no
+    # Last-Modified), and what the answer holds is a signed URL that
+    # works for anyone. A second click has to come back here and be
+    # asked about again: a membership revoked a minute ago must be a
     # download that stops, not one that stops in five minutes.
-    expires_now
+    no_store
 
     url = blob.url(disposition:)
 

--- a/app/controllers/concerns/token_authentication.rb
+++ b/app/controllers/concerns/token_authentication.rb
@@ -1,0 +1,57 @@
+# Who is calling, for the JSON API and for anything else that has to
+# answer the same question.
+#
+# Extracted from ApplicationController because the direct-upload endpoint
+# cannot inherit from it — it is an ActiveStorage controller, and those
+# descend from ActionController::Base — but must authenticate the same
+# way. Two copies of "how do we know who this is" is not a thing to have.
+module TokenAuthentication
+  extend ActiveSupport::Concern
+
+  included do
+    include ActionController::HttpAuthentication::Token::ControllerMethods
+  end
+
+  # A curator is acting as this submitter. Asked by the writes that record
+  # who did them — see ApplicationController#refuse_proxy!. Reading it
+  # forces the authentication it describes, so it is never stale.
+  def proxying?
+    current_user && @proxying == true
+  end
+
+  def current_user
+    return @current_user if defined?(@current_user)
+
+    @current_user = authenticate_with_http_token {|token|
+      next nil unless user = token.count('.') == 2 ? find_user_from_jwt(token) : find_user_from_api_key(token)
+
+      if user.admin? && uid = request.headers['X-Dway-User-Id']
+        @proxying = true
+
+        User.find_by(uid:)
+      else
+        user
+      end
+    }
+  end
+
+  private
+
+  def authenticate!
+    return if current_user
+
+    render json: {error: 'Unauthorized'}, status: :unauthorized
+  end
+
+  def find_user_from_jwt(token)
+    Rails.error.handle(JWT::DecodeError) {
+      payload, = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: 'HS512')
+
+      User.find_by(id: payload.fetch('user_id'))
+    }
+  end
+
+  def find_user_from_api_key(token)
+    User.find_by(api_key: token)
+  end
+end

--- a/app/controllers/direct_uploads_controller.rb
+++ b/app/controllers/direct_uploads_controller.rb
@@ -1,0 +1,17 @@
+# Direct upload, authenticated.
+#
+# Active Storage's own endpoint is publicly reachable by design — it only
+# mints a blob row and a presigned PUT, and the signed id it hands back
+# is worthless until something attaches it. That was survivable while it
+# was Rails' route on Rails' terms; it is not something to redraw
+# unauthenticated. Anybody could fill the bucket.
+#
+# Inherits Active Storage's controller rather than reimplementing it: the
+# body it returns is a contract with @rails/activestorage in the browser.
+# It descends from ActionController::Base, which is why the token
+# authentication lives in a concern rather than in ApplicationController.
+class DirectUploadsController < ActiveStorage::DirectUploadsController
+  include TokenAuthentication
+
+  before_action :authenticate!
+end

--- a/app/controllers/message_files_controller.rb
+++ b/app/controllers/message_files_controller.rb
@@ -1,0 +1,18 @@
+# A file attached to a message in the curator ↔ submitter thread.
+#
+# Owner-scoped, not readable-scoped: the conversation is between one
+# submitter and DDBJ, and being able to read somebody's submission
+# through a shared set is not being party to it. The same line the
+# messages endpoints draw.
+class MessageFilesController < ApplicationController
+  include AttachmentDownload
+
+  def show
+    submission_request = current_user.submission_requests.find(params.expect(:submission_request_id))
+    message            = submission_request.messages.find(params.expect(:message_id))
+
+    # Scoped to the message, so an attachment id from another thread is
+    # not found rather than served.
+    redirect_to_attachment message.files.find(params.expect(:id))
+  end
+end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,6 +1,8 @@
 class ReviewsController < ApplicationController
+  include AttachmentDownload
+
   # The whole point is unauthenticated access via the share token.
-  skip_before_action :authenticate!, only: %i[show accessions]
+  skip_before_action :authenticate!, only: %i[show accessions file]
 
   # An invalid OR expired token 404s (via find_by! on the `active` scope),
   # so a reviewer can't tell a revoked link from one that never existed.
@@ -18,6 +20,23 @@ class ReviewsController < ApplicationController
 
     pagy, @accessions = pagy(submission.entries.order(:id))
     response.headers.merge! pagy.headers_hash
+  end
+
+  # Files, on the same token as everything else here. Which is the point:
+  # revoking the share revokes these too, where a bare Active Storage URL
+  # the reviewer had collected would have gone on working for ever.
+  #
+  # `submission_record` rather than `ddbj_record` for the applied one, so
+  # the two uploads a reviewer can see are not one word apart.
+  NAMES = {
+    'ddbj_record'       => ->(request) { request.ddbj_record },
+    'submission_record' => ->(request) { request.submission&.ddbj_record },
+    'flatfile_na'       => ->(request) { request.submission&.flatfile_na },
+    'flatfile_aa'       => ->(request) { request.submission&.flatfile_aa }
+  }.freeze
+
+  def file
+    redirect_to_attachment NAMES.fetch(params[:name]).call(reviewed_request)
   end
 
   private

--- a/app/controllers/submission_files_controller.rb
+++ b/app/controllers/submission_files_controller.rb
@@ -1,0 +1,20 @@
+# What came out of applying a submission: the record as stored, and the
+# flatfiles rendered from it.
+class SubmissionFilesController < ApplicationController
+  include AttachmentDownload
+
+  # `current_record` and `cached_materialised_record` are deliberately
+  # absent. Nothing renders a link to them, and this is the list that
+  # decides whether one could exist.
+  NAMES = {
+    'ddbj_record' => :ddbj_record,
+    'flatfile_na' => :flatfile_na,
+    'flatfile_aa' => :flatfile_aa
+  }.freeze
+
+  def show
+    submission = Submission.readable_by(current_user).find(params.expect(:submission_id))
+
+    redirect_to_attachment submission.public_send(NAMES.fetch(params[:name]))
+  end
+end

--- a/app/controllers/submission_request_files_controller.rb
+++ b/app/controllers/submission_request_files_controller.rb
@@ -1,0 +1,22 @@
+# The file a submitter uploaded, for whoever may read the request.
+#
+# The attachment is named by the route rather than carried as a signed
+# blob id, so there is no way to present one record's id with another
+# record's blob — and an attachment no route names (SubmissionUpdate's
+# patch, the materialised-record cache) has no way in at all.
+class SubmissionRequestFilesController < ApplicationController
+  include AttachmentDownload
+
+  # The route constrains this too; the pair is deliberate. The constraint
+  # keeps an unknown name from reaching Ruby, and the map keeps a `send`
+  # on a path segment from ever being what resolves it.
+  NAMES = {'ddbj_record' => :ddbj_record}.freeze
+
+  def show
+    # Readable, not owned: a set's members can read each other's
+    # submissions, and the upload is part of that.
+    submission_request = SubmissionRequest.readable_by(current_user).find(params.expect(:submission_request_id))
+
+    redirect_to_attachment submission_request.public_send(NAMES.fetch(params[:name]))
+  end
+end

--- a/app/views/accessions/show.json.jb
+++ b/app/views/accessions/show.json.jb
@@ -5,5 +5,9 @@
   version:    @accession.version,
   locus_date: @accession.locus_date,
 
-  submission: render('submissions/submission', submission: @accession.submission)
+  submission: render(
+    'submissions/submission',
+    submission: @accession.submission,
+    file_url:   ->(name) { submission_file_url(@accession.submission, name) }
+  )
 }

--- a/app/views/admin/messages/_thread.html.erb
+++ b/app/views/admin/messages/_thread.html.erb
@@ -53,7 +53,7 @@
               <ul class="list-unstyled mb-0 mt-2 small">
                 <% m.files.each do |file| %>
                   <li>
-                    <%= link_to file.filename.to_s, rails_blob_path(file, disposition: :attachment) %>
+                    <%= link_to file.filename.to_s, admin_message_file_path(m, file.id, disposition: 'attachment') %>
                     <span class="text-body-secondary"><%= number_to_human_size(file.byte_size) %></span>
                   </li>
                 <% end %>
@@ -93,7 +93,8 @@
     <%# never comes into it. %>
     <div class="mb-3">
       <%= label_tag :files, 'Attach files', class: 'form-label' %>
-      <%= file_field_tag 'files[]', multiple: true, direct_upload: true, class: 'form-control' %>
+      <%# `direct_upload: true` would point at Active Storage's own route, which is off — see config/application.rb. %>
+      <%= file_field_tag 'files[]', multiple: true, class: 'form-control', data: {direct_upload_url: admin_direct_uploads_path} %>
     </div>
 
     <%# What a curator does in mail without thinking about it. Without %>

--- a/app/views/admin/submission_requests/_files.html.erb
+++ b/app/views/admin/submission_requests/_files.html.erb
@@ -8,7 +8,7 @@
     <ul class="list-unstyled small mb-0 d-flex flex-column gap-2">
       <li>
         <% if request.ddbj_record.attached? %>
-          <%= link_to request.ddbj_record.filename, rails_blob_path(request.ddbj_record, disposition: 'attachment') %>
+          <%= link_to request.ddbj_record.filename, admin_submission_request_file_path(request, 'ddbj_record', disposition: 'attachment') %>
           <span class="text-body-tertiary">upload</span>
         <% else %>
           <span class="text-body-secondary">No upload — imported from D-way</span>
@@ -27,10 +27,11 @@
           <%= link_to 'Materialised record (JSON)', materialised_admin_submission_path(submission) %>
         </li>
 
-        <% [['Flatfile (NA)', submission.flatfile_na], ['Flatfile (AA)', submission.flatfile_aa]].each do |label, file| %>
+        <% [['Flatfile (NA)', :flatfile_na], ['Flatfile (AA)', :flatfile_aa]].each do |label, name| %>
+          <% file = submission.public_send(name) %>
           <li>
             <% if file.attached? %>
-              <%= link_to file.filename, rails_blob_path(file, disposition: 'attachment') %>
+              <%= link_to file.filename, admin_submission_file_path(submission, name, disposition: 'attachment') %>
               <span class="text-body-tertiary"><%= label %></span>
             <% else %>
               <span class="text-body-tertiary"><%= label %> — not applicable</span>

--- a/app/views/application/_attachment.json.jb
+++ b/app/views/application/_attachment.json.jb
@@ -1,6 +1,12 @@
-# locals: (attachment:)
+# locals: (attachment:, url:)
+#
+# `url` is handed in rather than built here. There is no one URL for a
+# file any more: the same upload is reached by its owner through the
+# request, by a reviewer through their share token, and by a curator
+# through the admin session — and which of those is asking is what
+# authorises the read. See AttachmentDownload.
 
 attachment.attached? ? {
   filename: attachment.filename,
-  url:      rails_blob_url(attachment)
+  url:      url
 } : nil

--- a/app/views/application/_attachment_file.json.jb
+++ b/app/views/application/_attachment_file.json.jb
@@ -1,4 +1,4 @@
-# locals: (file:)
+# locals: (file:, url:)
 #
 # An attached file among several, as against the single `has_one_attached`
 # the request and submission carry — same shape plus the size, which is
@@ -8,5 +8,5 @@
 {
   filename:  file.filename.to_s,
   byte_size: file.byte_size,
-  url:       rails_blob_url(file)
+  url:       url
 }

--- a/app/views/messages/_message.json.jb
+++ b/app/views/messages/_message.json.jb
@@ -10,5 +10,11 @@
 
   # Both sides upload directly to storage, so this is a list of what
   # landed rather than anything this request carried.
-  files: message.files.map { render('application/attachment_file', file: it) }
+  files: message.files.map {
+    render(
+      'application/attachment_file',
+      file: it,
+      url:  submission_request_message_file_url(message.submission_request_id, message.id, it.id)
+    )
+  }
 }

--- a/app/views/reviews/show.json.jb
+++ b/app/views/reviews/show.json.jb
@@ -8,13 +8,19 @@
 # files with it. `submission_record` rather than `ddbj_record` for the
 # applied one, so the two uploads a reviewer can see are not one word
 # apart.
+#
+# These are the one set of file URLs a plain anchor can still follow —
+# the token in the path is the whole credential — so they say
+# `disposition=attachment` here instead. Without it a reviewer clicking
+# a flatfile gets a browser trying to paint a multi-gigabyte record in a
+# tab, which is not a download and not a page either.
 render(
   partial: 'submission_requests/submission_request',
 
   locals: {
     submission_request:  @request,
     viewer:              nil,
-    request_file_url:    ->(_name) { review_file_url(params[:token], 'ddbj_record') },
-    submission_file_url: ->(name) { review_file_url(params[:token], name == 'ddbj_record' ? 'submission_record' : name) }
+    request_file_url:    ->(_name) { review_file_url(params[:token], 'ddbj_record', disposition: 'attachment') },
+    submission_file_url: ->(name) { review_file_url(params[:token], name == 'ddbj_record' ? 'submission_record' : name, disposition: 'attachment') }
   }
 )

--- a/app/views/reviews/show.json.jb
+++ b/app/views/reviews/show.json.jb
@@ -3,7 +3,18 @@
 # where they do. No viewer — a share-link holder is not authenticated,
 # and must not learn that a curator asked something, when the thread was
 # last touched, or who else is working on this.
+#
+# The file URLs carry the share token, so revoking the share revokes the
+# files with it. `submission_record` rather than `ddbj_record` for the
+# applied one, so the two uploads a reviewer can see are not one word
+# apart.
 render(
   partial: 'submission_requests/submission_request',
-  locals:  {submission_request: @request, viewer: nil}
+
+  locals: {
+    submission_request:  @request,
+    viewer:              nil,
+    request_file_url:    ->(_name) { review_file_url(params[:token], 'ddbj_record') },
+    submission_file_url: ->(name) { review_file_url(params[:token], name == 'ddbj_record' ? 'submission_record' : name) }
+  }
 )

--- a/app/views/submission_requests/_submission_request.json.jb
+++ b/app/views/submission_requests/_submission_request.json.jb
@@ -1,4 +1,10 @@
-# locals: (submission_request:, viewer: nil)
+# locals: (submission_request:, viewer: nil, request_file_url:, submission_file_url:)
+#
+# The two `*_file_url` lambdas take an attachment name and answer with the
+# route that serves it. Handed in rather than built here because the same
+# file is reached by different doors — the submitter's, a reviewer's share
+# token, a curator's session — and which door it is is what authorises the
+# read. See AttachmentDownload.
 
 state = CurationState.new(submission_request)
 
@@ -14,9 +20,9 @@ payload = {
   ),
 
   processing:  submission_request.processing?,
-  ddbj_record: render('attachment', attachment: submission_request.ddbj_record),
+  ddbj_record: render('attachment', attachment: submission_request.ddbj_record, url: request_file_url.call('ddbj_record')),
   validation:  submission_request.validation_with_validity&.then { render(it) },
-  submission:  submission_request.submission&.then { render(it) },
+  submission:  submission_request.submission&.then { render(it, file_url: submission_file_url) },
 
   progress: render('submission_requests/progress', state: state)
 }

--- a/app/views/submission_requests/show.json.jb
+++ b/app/views/submission_requests/show.json.jb
@@ -1,4 +1,10 @@
 # The full path, not `render(@request)`: this template is also rendered
 # by ClosuresController, and a partial named relatively is looked up
 # under the rendering controller's own prefix.
-render('submission_requests/submission_request', submission_request: @request, viewer: @viewer)
+render(
+  'submission_requests/submission_request',
+  submission_request:  @request,
+  viewer:              @viewer,
+  request_file_url:    ->(name) { submission_request_file_url(@request, name) },
+  submission_file_url: ->(name) { submission_file_url(@request.submission, name) }
+)

--- a/app/views/submissions/_submission.json.jb
+++ b/app/views/submissions/_submission.json.jb
@@ -1,4 +1,9 @@
-# locals: (submission:)
+# locals: (submission:, file_url:)
+#
+# `file_url` is a lambda taking the attachment's name, because the route
+# that serves it depends on who is reading — the submitter and a reviewer
+# reach the same file by different doors, and the door is what authorises
+# it. See AttachmentDownload.
 
 {
   **submission.slice(
@@ -10,7 +15,7 @@
 
   accessions_count: submission.entries.count,
 
-  ddbj_record: render('attachment', attachment: submission.ddbj_record),
-  flatfile_na: render('attachment', attachment: submission.flatfile_na),
-  flatfile_aa: render('attachment', attachment: submission.flatfile_aa)
+  ddbj_record: render('attachment', attachment: submission.ddbj_record, url: file_url.call('ddbj_record')),
+  flatfile_na: render('attachment', attachment: submission.flatfile_na, url: file_url.call('flatfile_na')),
+  flatfile_aa: render('attachment', attachment: submission.flatfile_aa, url: file_url.call('flatfile_aa'))
 }

--- a/app/views/submissions/show.json.jb
+++ b/app/views/submissions/show.json.jb
@@ -1,1 +1,5 @@
-render(@submission)
+render(
+  'submissions/submission',
+  submission: @submission,
+  file_url:   ->(name) { submission_file_url(@submission, name) }
+)

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,6 +45,24 @@ module Repository
     config.active_storage.variant_processor = :disabled
     config.time_zone                        = 'Asia/Tokyo'
 
+    # Active Storage's own blob routes are off. `/rails/active_storage/
+    # blobs/redirect/:signed_id` takes a signed blob id and nothing else:
+    # no session, no owner, and — since `urls_expire_in` is unset by
+    # default — no expiry. Whoever holds one has the file for ever,
+    # whatever has happened to their access since, which made "take them
+    # out of the set and they lose it" untrue of the files.
+    #
+    # Downloads go through this application's own routes instead, where
+    # the record the route names is what authorises the read and every
+    # request re-asks. See AttachmentDownload.
+    #
+    # What is redrawn below (config/routes.rb) is the two things turning
+    # these off would otherwise take with them: direct uploads, which
+    # every upload in the application depends on, and the Disk service's
+    # own endpoints, which are how `blob.url` resolves wherever the
+    # service is Disk rather than S3 — the test environment.
+    config.active_storage.draw_routes = false
+
     # Use the project-owned MailDeliveryJob subclass so mail-only retry
     # (Net::OpenTimeout → polynomial backoff) doesn't leak onto every
     # other ApplicationJob descendant. See app/jobs/mail_delivery_job.rb.

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -10,10 +10,8 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       methods: %i[get post put patch delete options head]
     }
 
-    resource '/rails/active_storage/direct_uploads', **{
-      headers: :any,
-      methods: %i[post]
-    }
+    # Direct upload lives under /api now (see config/application.rb), so
+    # the rule above already covers it.
   end
 
   allow do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,9 +25,20 @@ Rails.application.routes.draw do
     resources :submission_requests, only: %i[index show create] do
       resource  :status,          only: :show
       resource  :submission,      only: :create
+
+      # The attachment is named by the route, not carried as a signed
+      # blob id — so one record's id cannot be presented with another
+      # record's blob, and an attachment no route names has no way in.
+      get 'files/:name',
+          to:          'submission_request_files#show',
+          as:          :file,
+          constraints: {name: /ddbj_record/}
+
       resources :messages, only: %i[index create] do
         # Reading the thread does not discharge it; saying so does.
         post :read, on: :collection
+
+        get 'files/:id', to: 'message_files#show', as: :file
       end
       resource :reviewer_access, only: %i[show create destroy]
 
@@ -42,8 +53,22 @@ Rails.application.routes.draw do
     get 'reviews/:token',            to: 'reviews#show',       as: :review
     get 'reviews/:token/accessions', to: 'reviews#accessions', as: :review_accessions
 
+    # Files on the same token as the rest of the reviewer's view, so
+    # revoking the share revokes them. The name is constrained here as
+    # well as mapped in the controller: an unknown one never reaches
+    # Ruby.
+    get 'reviews/:token/files/:name',
+        to:          'reviews#file',
+        as:          :review_file,
+        constraints: {name: /ddbj_record|submission_record|flatfile_na|flatfile_aa/}
+
     resources :submissions, only: %i[index show] do
       resources :accessions, only: %i[index]
+
+      get 'files/:name',
+          to:          'submission_files#show',
+          as:          :file,
+          constraints: {name: /ddbj_record|flatfile_na|flatfile_aa/}
     end
 
     # `index` here is the cross-submission one — the nested route above
@@ -78,6 +103,11 @@ Rails.application.routes.draw do
     resources :invitations, only: %i[show], param: :token do
       resource :acceptance, only: %i[create], controller: 'invitation_acceptances'
     end
+
+    # Direct upload, redrawn here rather than at Active Storage's own
+    # path — and authenticated, which it never was. It mints a signed
+    # blob id and a presigned PUT to anybody who asks.
+    resource :direct_uploads, only: %i[create], controller: 'direct_uploads'
 
     resources :stats, only: %i[index]
   end
@@ -224,6 +254,25 @@ Rails.application.routes.draw do
       end
     end
 
+    # Downloads for curators. A session cookie rather than a token, which
+    # is the whole reason the two logins are independent.
+    get 'submission_requests/:submission_request_id/files/:name',
+        to:          'files#submission_request',
+        as:          :submission_request_file,
+        constraints: {name: /ddbj_record/}
+
+    get 'submissions/:submission_id/files/:name',
+        to:          'files#submission',
+        as:          :submission_file,
+        constraints: {name: /ddbj_record|flatfile_na|flatfile_aa/}
+
+    get 'messages/:message_id/files/:id', to: 'files#message', as: :message_file
+
+    # Same story as the API's: authenticated, because redrawing Active
+    # Storage's public one is not the same as leaving it where Rails put
+    # it.
+    resource :direct_uploads, only: %i[create], controller: 'direct_uploads'
+
     mount MissionControl::Jobs::Engine, at: '/jobs'
   end
 
@@ -234,6 +283,17 @@ Rails.application.routes.draw do
   get 'web(/*paths)', to: 'webs#show', constraints: ->(req) {
     !req.xhr? && req.format.html?
   }
+
+  # The Disk service's own endpoints, redrawn because
+  # `active_storage.draw_routes` took them with the blob routes — and
+  # `blob.url` resolves through them wherever the service is Disk rather
+  # than S3, which is the test environment. Their tokens are Active
+  # Storage's own, minted per request and short-lived; there is nothing
+  # here to authenticate against and nothing durable to hold.
+  scope :rails do
+    get 'active_storage/disk/:encoded_key/*filename' => 'active_storage/disk#show', as: :rails_disk_service
+    put 'active_storage/disk/:encoded_token'         => 'active_storage/disk#update', as: :update_rails_disk_service
+  end
 
   get 'up' => 'rails/health#show', as: :rails_health_check
 end

--- a/schema/openapi.d.ts
+++ b/schema/openapi.d.ts
@@ -1650,6 +1650,363 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/submission_requests/{submission_request_id}/files/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                submission_request_id: number;
+                name: "ddbj_record";
+            };
+            cookie?: never;
+        };
+        /**
+         * @description The file as uploaded. Readable by its submitter, by the members of any
+         *     set it has been put in, and by nobody else — asked on every request,
+         *     so access that has been taken away is a download that has stopped.
+         *
+         *     The attachment is named by the path rather than carried as an opaque
+         *     blob id, so one record's id cannot be presented with another record's
+         *     file, and an attachment no path names cannot be addressed at all.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /**
+                     * @description `url` answers with the address as JSON instead of redirecting to it.
+                     *     A browser cannot put an `Authorization` header on an anchor and this
+                     *     API takes no cookies, so the web client asks for the address and
+                     *     navigates to it itself. Everything else follows the redirect.
+                     */
+                    as?: "url";
+                    disposition?: "inline" | "attachment";
+                };
+                header?: never;
+                path: {
+                    submission_request_id: number;
+                    name: "ddbj_record";
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /**
+                 * @description The address, when `as=url` was asked for. A storage URL good for a
+                 *     few minutes — not a thing to store, and not usable by anybody the
+                 *     request was not authorised for.
+                 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: uri */
+                            url: string;
+                        };
+                    };
+                };
+                /**
+                 * @description A redirect to storage. The `Location` expires in minutes; the
+                 *     authorisation happened here, on this request.
+                 */
+                302: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                401: components["responses"]["Unauthorized"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/submission_requests/{submission_request_id}/messages/{message_id}/files/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                submission_request_id: number;
+                message_id: number;
+                id: number;
+            };
+            cookie?: never;
+        };
+        /**
+         * @description A file attached to a message. The request's owner only — the
+         *     conversation is between one submitter and DDBJ, and reading their
+         *     submission through a shared set is not being party to it.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /**
+                     * @description `url` answers with the address as JSON instead of redirecting to it.
+                     *     A browser cannot put an `Authorization` header on an anchor and this
+                     *     API takes no cookies, so the web client asks for the address and
+                     *     navigates to it itself. Everything else follows the redirect.
+                     */
+                    as?: "url";
+                    disposition?: "inline" | "attachment";
+                };
+                header?: never;
+                path: {
+                    submission_request_id: number;
+                    message_id: number;
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /**
+                 * @description The address, when `as=url` was asked for. A storage URL good for a
+                 *     few minutes — not a thing to store, and not usable by anybody the
+                 *     request was not authorised for.
+                 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: uri */
+                            url: string;
+                        };
+                    };
+                };
+                /**
+                 * @description A redirect to storage. The `Location` expires in minutes; the
+                 *     authorisation happened here, on this request.
+                 */
+                302: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                401: components["responses"]["Unauthorized"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/submissions/{submission_id}/files/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                submission_id: number;
+                name: "ddbj_record" | "flatfile_na" | "flatfile_aa";
+            };
+            cookie?: never;
+        };
+        /** @description The applied record, and the flatfiles rendered from it. */
+        get: {
+            parameters: {
+                query?: {
+                    /**
+                     * @description `url` answers with the address as JSON instead of redirecting to it.
+                     *     A browser cannot put an `Authorization` header on an anchor and this
+                     *     API takes no cookies, so the web client asks for the address and
+                     *     navigates to it itself. Everything else follows the redirect.
+                     */
+                    as?: "url";
+                    disposition?: "inline" | "attachment";
+                };
+                header?: never;
+                path: {
+                    submission_id: number;
+                    name: "ddbj_record" | "flatfile_na" | "flatfile_aa";
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /**
+                 * @description The address, when `as=url` was asked for. A storage URL good for a
+                 *     few minutes — not a thing to store, and not usable by anybody the
+                 *     request was not authorised for.
+                 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: uri */
+                            url: string;
+                        };
+                    };
+                };
+                /**
+                 * @description A redirect to storage. The `Location` expires in minutes; the
+                 *     authorisation happened here, on this request.
+                 */
+                302: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                401: components["responses"]["Unauthorized"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reviews/{token}/files/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+                /**
+                 * @description `submission_record` is the applied record, as against `ddbj_record`
+                 *     which is what was uploaded — one word apart everywhere else, which is
+                 *     why they are not here.
+                 */
+                name: "ddbj_record" | "submission_record" | "flatfile_na" | "flatfile_aa";
+            };
+            cookie?: never;
+        };
+        /**
+         * @description Files on the share token, like the rest of the reviewer's view — so
+         *     revoking or expiring the share revokes these with it.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /**
+                     * @description `url` answers with the address as JSON instead of redirecting to it.
+                     *     A browser cannot put an `Authorization` header on an anchor and this
+                     *     API takes no cookies, so the web client asks for the address and
+                     *     navigates to it itself. Everything else follows the redirect.
+                     */
+                    as?: "url";
+                    disposition?: "inline" | "attachment";
+                };
+                header?: never;
+                path: {
+                    token: string;
+                    /**
+                     * @description `submission_record` is the applied record, as against `ddbj_record`
+                     *     which is what was uploaded — one word apart everywhere else, which is
+                     *     why they are not here.
+                     */
+                    name: "ddbj_record" | "submission_record" | "flatfile_na" | "flatfile_aa";
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /**
+                 * @description The address, when `as=url` was asked for. A storage URL good for a
+                 *     few minutes — not a thing to store, and not usable by anybody the
+                 *     request was not authorised for.
+                 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: uri */
+                            url: string;
+                        };
+                    };
+                };
+                /**
+                 * @description A redirect to storage. The `Location` expires in minutes; the
+                 *     authorisation happened here, on this request.
+                 */
+                302: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                401: components["responses"]["Unauthorized"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/direct_uploads": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * @description Reserve a place in storage and get a URL to PUT the bytes to. The
+         *     request and response shapes are Active Storage's contract with
+         *     `@rails/activestorage` in the browser, not this application's, so they
+         *     are not pinned here.
+         *
+         *     Authenticated, unlike Active Storage's own endpoint: it mints a row and
+         *     a presigned PUT to whoever asks, which is defensible as a framework
+         *     route and not as one we redraw.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            responses: {
+                /** @description The blob, including `signed_id` and where to PUT the bytes. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": Record<string, never>;
+                    };
+                };
+                401: components["responses"]["Unauthorized"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/stats": {
         parameters: {
             query?: never;

--- a/schema/openapi.d.ts
+++ b/schema/openapi.d.ts
@@ -2061,7 +2061,18 @@ export interface components {
         };
         Attachment: {
             filename: string;
-            /** Format: uri */
+            /**
+             * Format: uri
+             * @description Where to fetch the file. Good for one fetch, soon: it redirects to
+             *     a storage URL that expires in minutes, and the redirect itself is
+             *     authorised when it is followed — by the same rule that let you read
+             *     the record it hangs off.
+             *
+             *     So it is not a thing to store. A link kept from yesterday's listing
+             *     does not work, and one handed to somebody else does not work for
+             *     them, which is what makes access that has been taken away actually
+             *     gone.
+             */
             url: string;
         };
         /**
@@ -2072,6 +2083,17 @@ export interface components {
         AttachedFile: {
             filename: string;
             byte_size: number;
+            /**
+             * @description Where to fetch the file. Good for one fetch, soon: it redirects to
+             *     a storage URL that expires in minutes, and the redirect itself is
+             *     authorised when it is followed — by the same rule that let you read
+             *     the record it hangs off.
+             *
+             *     So it is not a thing to store. A link kept from yesterday's listing
+             *     does not work, and one handed to somebody else does not work for
+             *     them, which is what makes access that has been taken away actually
+             *     gone.
+             */
             url: string;
         };
         Message: {

--- a/schema/openapi.d.ts
+++ b/schema/openapi.d.ts
@@ -1679,6 +1679,11 @@ export interface paths {
                      *     navigates to it itself. Everything else follows the redirect.
                      */
                     as?: "url";
+                    /**
+                     * @description `attachment` saves the file; `inline` (the default) leaves it to the
+                     *     browser. A value outside this list is the default rather than an
+                     *     error — a disposition is a preference, not an instruction.
+                     */
                     disposition?: "inline" | "attachment";
                 };
                 header?: never;
@@ -1754,6 +1759,11 @@ export interface paths {
                      *     navigates to it itself. Everything else follows the redirect.
                      */
                     as?: "url";
+                    /**
+                     * @description `attachment` saves the file; `inline` (the default) leaves it to the
+                     *     browser. A value outside this list is the default rather than an
+                     *     error — a disposition is a preference, not an instruction.
+                     */
                     disposition?: "inline" | "attachment";
                 };
                 header?: never;
@@ -1825,6 +1835,11 @@ export interface paths {
                      *     navigates to it itself. Everything else follows the redirect.
                      */
                     as?: "url";
+                    /**
+                     * @description `attachment` saves the file; `inline` (the default) leaves it to the
+                     *     browser. A value outside this list is the default rather than an
+                     *     error — a disposition is a preference, not an instruction.
+                     */
                     disposition?: "inline" | "attachment";
                 };
                 header?: never;
@@ -1892,6 +1907,11 @@ export interface paths {
         /**
          * @description Files on the share token, like the rest of the reviewer's view — so
          *     revoking or expiring the share revokes these with it.
+         *
+         *     A revoked token, an expired one, and one that never existed are all a
+         *     404 alike: a reviewer cannot tell a share that was taken away from one
+         *     that was never given. No 401, because there is nothing to
+         *     authenticate — the token in the path is the whole credential.
          */
         get: {
             parameters: {
@@ -1903,6 +1923,11 @@ export interface paths {
                      *     navigates to it itself. Everything else follows the redirect.
                      */
                     as?: "url";
+                    /**
+                     * @description `attachment` saves the file; `inline` (the default) leaves it to the
+                     *     browser. A value outside this list is the default rather than an
+                     *     error — a disposition is a preference, not an instruction.
+                     */
                     disposition?: "inline" | "attachment";
                 };
                 header?: never;
@@ -1945,7 +1970,6 @@ export interface paths {
                     };
                     content?: never;
                 };
-                401: components["responses"]["Unauthorized"];
                 404: components["responses"]["NotFound"];
             };
         };

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -1639,6 +1639,11 @@ paths:
         - name: disposition
           in: query
 
+          description: |
+            `attachment` saves the file; `inline` (the default) leaves it to the
+            browser. A value outside this list is the default rather than an
+            error — a disposition is a preference, not an instruction.
+
           schema:
             type: string
             enum: [inline, attachment]
@@ -1721,6 +1726,11 @@ paths:
         - name: disposition
           in: query
 
+          description: |
+            `attachment` saves the file; `inline` (the default) leaves it to the
+            browser. A value outside this list is the default rather than an
+            error — a disposition is a preference, not an instruction.
+
           schema:
             type: string
             enum: [inline, attachment]
@@ -1794,6 +1804,11 @@ paths:
         - name: disposition
           in: query
 
+          description: |
+            `attachment` saves the file; `inline` (the default) leaves it to the
+            browser. A value outside this list is the default rather than an
+            error — a disposition is a preference, not an instruction.
+
           schema:
             type: string
             enum: [inline, attachment]
@@ -1854,6 +1869,11 @@ paths:
         Files on the share token, like the rest of the reviewer's view — so
         revoking or expiring the share revokes these with it.
 
+        A revoked token, an expired one, and one that never existed are all a
+        404 alike: a reviewer cannot tell a share that was taken away from one
+        that was never given. No 401, because there is nothing to
+        authenticate — the token in the path is the whole credential.
+
       security: []
 
       tags:
@@ -1874,6 +1894,11 @@ paths:
 
         - name: disposition
           in: query
+
+          description: |
+            `attachment` saves the file; `inline` (the default) leaves it to the
+            browser. A value outside this list is the default rather than an
+            error — a disposition is a preference, not an instruction.
 
           schema:
             type: string
@@ -1903,9 +1928,6 @@ paths:
             A redirect to storage. The `Location` expires in minutes; the
             authorisation happened here, on this request.
 
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-
         '404':
           $ref: '#/components/responses/NotFound'
 
@@ -1922,7 +1944,7 @@ paths:
         route and not as one we redraw.
 
       tags:
-        - Submission Requests
+        - Uploads
 
       requestBody:
         required: true

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -1593,6 +1593,357 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /submission_requests/{submission_request_id}/files/{name}:
+    parameters:
+      - name: submission_request_id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+      - name: name
+        in: path
+        required: true
+
+        schema:
+          type: string
+          enum: [ddbj_record]
+
+    get:
+      description: |
+        The file as uploaded. Readable by its submitter, by the members of any
+        set it has been put in, and by nobody else — asked on every request,
+        so access that has been taken away is a download that has stopped.
+
+        The attachment is named by the path rather than carried as an opaque
+        blob id, so one record's id cannot be presented with another record's
+        file, and an attachment no path names cannot be addressed at all.
+
+      tags:
+        - Submission Requests
+
+      parameters:
+        - name: as
+          in: query
+          description: |
+            `url` answers with the address as JSON instead of redirecting to it.
+            A browser cannot put an `Authorization` header on an anchor and this
+            API takes no cookies, so the web client asks for the address and
+            navigates to it itself. Everything else follows the redirect.
+
+          schema:
+            type: string
+            enum: [url]
+
+        - name: disposition
+          in: query
+
+          schema:
+            type: string
+            enum: [inline, attachment]
+
+      responses:
+        '200':
+          description: |
+            The address, when `as=url` was asked for. A storage URL good for a
+            few minutes — not a thing to store, and not usable by anybody the
+            request was not authorised for.
+
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [url]
+
+                properties:
+                  url:
+                    type: string
+                    format: uri
+
+        '302':
+          description: |
+            A redirect to storage. The `Location` expires in minutes; the
+            authorisation happened here, on this request.
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /submission_requests/{submission_request_id}/messages/{message_id}/files/{id}:
+    parameters:
+      - name: submission_request_id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+      - name: message_id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+      - name: id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+    get:
+      description: |
+        A file attached to a message. The request's owner only — the
+        conversation is between one submitter and DDBJ, and reading their
+        submission through a shared set is not being party to it.
+
+      tags:
+        - Submission Requests
+
+      parameters:
+        - name: as
+          in: query
+          description: |
+            `url` answers with the address as JSON instead of redirecting to it.
+            A browser cannot put an `Authorization` header on an anchor and this
+            API takes no cookies, so the web client asks for the address and
+            navigates to it itself. Everything else follows the redirect.
+
+          schema:
+            type: string
+            enum: [url]
+
+        - name: disposition
+          in: query
+
+          schema:
+            type: string
+            enum: [inline, attachment]
+
+      responses:
+        '200':
+          description: |
+            The address, when `as=url` was asked for. A storage URL good for a
+            few minutes — not a thing to store, and not usable by anybody the
+            request was not authorised for.
+
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [url]
+
+                properties:
+                  url:
+                    type: string
+                    format: uri
+
+        '302':
+          description: |
+            A redirect to storage. The `Location` expires in minutes; the
+            authorisation happened here, on this request.
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /submissions/{submission_id}/files/{name}:
+    parameters:
+      - name: submission_id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+      - name: name
+        in: path
+        required: true
+
+        schema:
+          type: string
+          enum: [ddbj_record, flatfile_na, flatfile_aa]
+
+    get:
+      description: The applied record, and the flatfiles rendered from it.
+
+      tags:
+        - Submissions
+
+      parameters:
+        - name: as
+          in: query
+          description: |
+            `url` answers with the address as JSON instead of redirecting to it.
+            A browser cannot put an `Authorization` header on an anchor and this
+            API takes no cookies, so the web client asks for the address and
+            navigates to it itself. Everything else follows the redirect.
+
+          schema:
+            type: string
+            enum: [url]
+
+        - name: disposition
+          in: query
+
+          schema:
+            type: string
+            enum: [inline, attachment]
+
+      responses:
+        '200':
+          description: |
+            The address, when `as=url` was asked for. A storage URL good for a
+            few minutes — not a thing to store, and not usable by anybody the
+            request was not authorised for.
+
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [url]
+
+                properties:
+                  url:
+                    type: string
+                    format: uri
+
+        '302':
+          description: |
+            A redirect to storage. The `Location` expires in minutes; the
+            authorisation happened here, on this request.
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /reviews/{token}/files/{name}:
+    parameters:
+      - name: token
+        in: path
+        required: true
+
+        schema:
+          type: string
+
+      - name: name
+        in: path
+        required: true
+        description: |
+          `submission_record` is the applied record, as against `ddbj_record`
+          which is what was uploaded — one word apart everywhere else, which is
+          why they are not here.
+
+        schema:
+          type: string
+          enum: [ddbj_record, submission_record, flatfile_na, flatfile_aa]
+
+    get:
+      description: |
+        Files on the share token, like the rest of the reviewer's view — so
+        revoking or expiring the share revokes these with it.
+
+      security: []
+
+      tags:
+        - Submission Requests
+
+      parameters:
+        - name: as
+          in: query
+          description: |
+            `url` answers with the address as JSON instead of redirecting to it.
+            A browser cannot put an `Authorization` header on an anchor and this
+            API takes no cookies, so the web client asks for the address and
+            navigates to it itself. Everything else follows the redirect.
+
+          schema:
+            type: string
+            enum: [url]
+
+        - name: disposition
+          in: query
+
+          schema:
+            type: string
+            enum: [inline, attachment]
+
+      responses:
+        '200':
+          description: |
+            The address, when `as=url` was asked for. A storage URL good for a
+            few minutes — not a thing to store, and not usable by anybody the
+            request was not authorised for.
+
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [url]
+
+                properties:
+                  url:
+                    type: string
+                    format: uri
+
+        '302':
+          description: |
+            A redirect to storage. The `Location` expires in minutes; the
+            authorisation happened here, on this request.
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /direct_uploads:
+    post:
+      description: |
+        Reserve a place in storage and get a URL to PUT the bytes to. The
+        request and response shapes are Active Storage's contract with
+        `@rails/activestorage` in the browser, not this application's, so they
+        are not pinned here.
+
+        Authenticated, unlike Active Storage's own endpoint: it mints a row and
+        a presigned PUT to whoever asks, which is defensible as a framework
+        route and not as one we redraw.
+
+      tags:
+        - Submission Requests
+
+      requestBody:
+        required: true
+
+        content:
+          application/json:
+            schema:
+              type: object
+
+      responses:
+        '200':
+          description: The blob, including `signed_id` and where to PUT the bytes.
+
+          content:
+            application/json:
+              schema:
+                type: object
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
   /stats:
     get:
       description: |

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -2580,6 +2580,16 @@ components:
           type: string
 
         url:
+          description: |
+            Where to fetch the file. Good for one fetch, soon: it redirects to
+            a storage URL that expires in minutes, and the redirect itself is
+            authorised when it is followed — by the same rule that let you read
+            the record it hangs off.
+
+            So it is not a thing to store. A link kept from yesterday's listing
+            does not work, and one handed to somebody else does not work for
+            them, which is what makes access that has been taken away actually
+            gone.
           type: string
           format: uri
 
@@ -2604,6 +2614,16 @@ components:
           type: number
 
         url:
+          description: |
+            Where to fetch the file. Good for one fetch, soon: it redirects to
+            a storage URL that expires in minutes, and the redirect itself is
+            authorised when it is followed — by the same rule that let you read
+            the record it hangs off.
+
+            So it is not a thing to store. A link kept from yesterday's listing
+            does not work, and one handed to somebody else does not work for
+            them, which is what makes access that has been taken away actually
+            gone.
           type: string
 
     Message:

--- a/test/integration/attachment_downloads_test.rb
+++ b/test/integration/attachment_downloads_test.rb
@@ -1,0 +1,184 @@
+require 'test_helper'
+
+# Who can fetch which file, now that Active Storage's own blob route is
+# off and every download goes through a route that names both the record
+# and the attachment.
+#
+# The property these are defending: a URL is not a credential. Each of
+# these requests is authorised when it arrives, so access that has been
+# taken away is access that has stopped working — which is what
+# "removing a member takes their submissions with them" has to mean about
+# the files as well as the rows.
+class AttachmentDownloadsTest < ActionDispatch::IntegrationTest
+  setup do
+    @alice = users(:alice)
+    @carol = users(:carol)
+
+    @submission_request = submission_requests(:bioproject) # owned by :alice
+    attach_ddbj_record @submission_request
+    attach_submission_files @submission_request.submission
+
+    default_headers['Authorization'] = "Bearer #{@alice.api_key}"
+  end
+
+  test 'Active Storage no longer serves blobs on its own route' do
+    assert_not Rails.application.routes.url_helpers.respond_to?(:rails_blob_path)
+    assert_not Rails.application.routes.url_helpers.respond_to?(:rails_service_blob_path)
+  end
+
+  test 'the owner gets a short-lived redirect to storage' do
+    get submission_request_file_path(@submission_request, 'ddbj_record')
+
+    assert_response :redirect
+    assert_match %r{/rails/active_storage/disk/}, response.location
+  end
+
+  test 'the submission files follow the same rule' do
+    %w[ddbj_record flatfile_na flatfile_aa].each do |name|
+      get submission_file_path(@submission_request.submission, name)
+
+      assert_response :redirect
+    end
+  end
+
+  test 'somebody else gets nothing' do
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    with_exceptions_app { get submission_request_file_path(@submission_request, 'ddbj_record') }
+
+    assert_response :not_found
+  end
+
+  test 'and nobody at all gets nothing' do
+    default_headers.delete('Authorization')
+
+    get submission_request_file_path(@submission_request, 'ddbj_record')
+
+    assert_response :unauthorized
+  end
+
+  # The point of the whole exercise: reading it through a shared set is a
+  # thing that can be taken away, and taking it away has to reach the
+  # files.
+  test 'a set member can fetch it, and stops being able to when they are removed' do
+    set = SubmissionSet.create!(name: 'Deep sea study', owner: @carol)
+    set.members.create!(user: @alice, invited_by: @carol, joined_at: Time.current)
+    set.inclusions.create!(submission_request: @submission_request, added_by: @alice)
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    get submission_request_file_path(@submission_request, 'ddbj_record')
+    assert_response :redirect
+
+    set.members.find_by!(user_id: @alice.id).remove!
+
+    with_exceptions_app { get submission_request_file_path(@submission_request, 'ddbj_record') }
+    assert_response :not_found
+  end
+
+  test 'an attachment no route names has no way in' do
+    assert_raises(ActionController::UrlGenerationError) do
+      submission_file_path(@submission_request.submission, 'cached_materialised_record')
+    end
+  end
+
+  # Message attachments are owner-scoped, not readable-scoped: the
+  # conversation is between one submitter and DDBJ.
+  test 'a set member cannot fetch a message attachment' do
+    message = @submission_request.messages.create!(user: @alice, author_role: :submitter, body: 'Here it is')
+    message.files.attach(io: StringIO.new('x'), filename: 'note.txt', content_type: 'text/plain')
+
+    set = SubmissionSet.create!(name: 'Deep sea study', owner: @carol)
+    set.members.create!(user: @alice, invited_by: @carol, joined_at: Time.current)
+    set.inclusions.create!(submission_request: @submission_request, added_by: @alice)
+
+    get submission_request_message_file_path(@submission_request, message, message.files.first.id)
+    assert_response :redirect
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    with_exceptions_app { get submission_request_message_file_path(@submission_request, message, message.files.first.id) }
+    assert_response :not_found
+  end
+
+  test 'a message attachment from another thread is not found rather than served' do
+    mine   = @submission_request.messages.create!(user: @alice, author_role: :submitter, body: 'Mine')
+    theirs = submission_requests(:st26).messages.create!(user: @alice, author_role: :submitter, body: 'Theirs')
+
+    theirs.files.attach(io: StringIO.new('x'), filename: 'note.txt', content_type: 'text/plain')
+
+    with_exceptions_app do
+      get submission_request_message_file_path(@submission_request, mine, theirs.files.first.id)
+    end
+
+    assert_response :not_found
+  end
+
+  # A reviewer's files ride on the share token, so revoking the share
+  # revokes them. Under Active Storage's own route the URLs they had
+  # collected went on working for ever, which made "disable the link"
+  # mean less than it says.
+  test 'a reviewer fetches on the share token, and loses the files with it' do
+    access = @submission_request.create_reviewer_access!(expires_at: 1.week.from_now)
+
+    default_headers.delete('Authorization')
+
+    %w[ddbj_record submission_record flatfile_na flatfile_aa].each do |name|
+      get review_file_path(access.token, name)
+
+      assert_response :redirect, name
+    end
+
+    access.destroy!
+
+    with_exceptions_app { get review_file_path(access.token, 'ddbj_record') }
+
+    assert_response :not_found
+  end
+
+  test 'an expired share is as good as no share' do
+    access = @submission_request.create_reviewer_access!(expires_at: 1.week.from_now)
+    access.update_columns(expires_at: 1.day.ago)
+
+    default_headers.delete('Authorization')
+
+    with_exceptions_app { get review_file_path(access.token, 'ddbj_record') }
+
+    assert_response :not_found
+  end
+
+  # The reviewer view never shows the conversation, so it must not be a
+  # way to its attachments either.
+  test 'the reviewer route names only the files the reviewer view shows' do
+    assert_raises(ActionController::UrlGenerationError) do
+      review_file_path('sometoken', 'patch')
+    end
+  end
+
+  # Active Storage's own direct-upload endpoint is public by design. Ours
+  # is not: it mints a blob row and a presigned PUT, and redrawing it
+  # unauthenticated would let anybody fill the bucket.
+  test 'direct upload needs a caller' do
+    body = {
+      blob: {
+        filename:     'x.json',
+        byte_size:    1,
+        checksum:     Digest::MD5.base64digest('x'),
+        content_type: 'application/json'
+      }
+    }
+
+    default_headers.delete('Authorization')
+
+    post direct_uploads_path, params: body.to_json, headers: {'Content-Type' => 'application/json'}
+
+    assert_response :unauthorized
+
+    default_headers['Authorization'] = "Bearer #{@alice.api_key}"
+
+    post direct_uploads_path, params: body.to_json, headers: {'Content-Type' => 'application/json'}
+
+    assert_response :success
+    assert response.parsed_body['signed_id'].present?
+  end
+end

--- a/test/integration/attachment_downloads_test.rb
+++ b/test/integration/attachment_downloads_test.rb
@@ -30,7 +30,7 @@ class AttachmentDownloadsTest < ActionDispatch::IntegrationTest
     get submission_request_file_path(@submission_request, 'ddbj_record')
 
     assert_response :redirect
-    assert_match %r{/rails/active_storage/disk/}, response.location
+    assert_storage_url response.location
   end
 
   test 'the submission files follow the same rule' do
@@ -182,6 +182,52 @@ class AttachmentDownloadsTest < ActionDispatch::IntegrationTest
     assert response.parsed_body['signed_id'].present?
   end
 
+  # The curator screens upload the same way, on the session cookie. Two
+  # things have to hold at once: a lapsed session is told to sign in
+  # rather than told 422 by the forgery check (which fails too, because
+  # the token it compares against lived in that session), and a signed-in
+  # non-curator is told 403, because signing in again changes nothing.
+  test 'the admin direct upload answers the uploader, not a page' do
+    body = {
+      blob: {
+        filename:     'x.json',
+        byte_size:    1,
+        checksum:     Digest::MD5.base64digest('x'),
+        content_type: 'application/json'
+      }
+    }
+
+    json = {'Content-Type' => 'application/json', 'Accept' => 'application/json'}
+
+    default_headers.delete('Authorization')
+
+    with_forgery_protection do
+      post admin_direct_uploads_path, params: body.to_json, headers: json
+
+      assert_response :unauthorized, 'no session at all'
+
+      sign_in_as users(:carol) # not a curator
+
+      post admin_direct_uploads_path, params: body.to_json, headers: json
+
+      assert_response :forbidden, 'signing in again would reach the same place'
+
+      sign_in_as users(:bob) # a curator
+
+      post admin_direct_uploads_path, params: body.to_json, headers: json.merge('X-CSRF-Token' => csrf_token)
+
+      assert_response :success
+      assert response.parsed_body['signed_id'].present?
+
+      # And the check it is guarded by is real: the same request without
+      # the header is refused, which is the reason a lapsed session had
+      # to be answered before reaching it.
+      post admin_direct_uploads_path, params: body.to_json, headers: json
+
+      assert_response :unprocessable_content
+    end
+  end
+
   # Caching the redirect for as long as the URL it points at is valid
   # would mean a second click inside that window never comes back here —
   # and coming back here is the whole point. A membership revoked a
@@ -191,7 +237,11 @@ class AttachmentDownloadsTest < ActionDispatch::IntegrationTest
     get submission_request_file_path(@submission_request, 'ddbj_record')
 
     assert_response :redirect
-    assert_match(/no-cache|no-store/, response.headers['Cache-Control'].to_s)
+
+    # `no-store`, not `no-cache`: the latter allows the answer to be kept
+    # as long as it is revalidated, and there is nothing here to
+    # revalidate against.
+    assert_match(/no-store/, response.headers['Cache-Control'].to_s)
   end
 
   # A browser cannot put an Authorization header on an anchor and this
@@ -201,12 +251,45 @@ class AttachmentDownloadsTest < ActionDispatch::IntegrationTest
     get submission_request_file_path(@submission_request, 'ddbj_record', as: 'url')
 
     assert_response :success
-    assert_match %r{/rails/active_storage/disk/}, response.parsed_body.fetch('url')
+    assert_storage_url response.parsed_body.fetch('url')
 
     default_headers['Authorization'] = "Bearer #{@carol.api_key}"
 
     with_exceptions_app { get submission_request_file_path(@submission_request, 'ddbj_record', as: 'url') }
 
     assert_response :not_found
+  end
+
+
+  private
+
+  # What matters is that the answer sends the caller somewhere else to do
+  # the actual reading — not which backend does it. The test environment
+  # stores blobs on disk; staging and production hand out signed
+  # SeaweedFS URLs, and this assertion has to hold for both.
+  def assert_storage_url(url)
+    uri = URI.parse(url)
+
+    assert uri.absolute?, "#{url} is not somewhere to go"
+    assert_not_equal request.path, uri.path, 'it pointed back at itself'
+  end
+
+  # What the layout hands the browser, which is where the uploader's own
+  # header comes from.
+  def csrf_token
+    get admin_root_path
+
+    response.body[/name="csrf-token" content="([^"]+)"/, 1] or raise 'no csrf token on the page'
+  end
+
+  # Forgery protection is off in the test environment, which would hide
+  # the ordering this is about.
+  def with_forgery_protection
+    was = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+
+    yield
+  ensure
+    ActionController::Base.allow_forgery_protection = was
   end
 end

--- a/test/integration/attachment_downloads_test.rb
+++ b/test/integration/attachment_downloads_test.rb
@@ -181,4 +181,32 @@ class AttachmentDownloadsTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert response.parsed_body['signed_id'].present?
   end
+
+  # Caching the redirect for as long as the URL it points at is valid
+  # would mean a second click inside that window never comes back here —
+  # and coming back here is the whole point. A membership revoked a
+  # minute ago has to be a download that stops, not one that stops in
+  # five minutes.
+  test 'the redirect is never cached' do
+    get submission_request_file_path(@submission_request, 'ddbj_record')
+
+    assert_response :redirect
+    assert_match(/no-cache|no-store/, response.headers['Cache-Control'].to_s)
+  end
+
+  # A browser cannot put an Authorization header on an anchor and this
+  # API takes no cookies, so the web client asks for the address instead
+  # of following the redirect. Same check either way.
+  test 'the address can be asked for instead of followed' do
+    get submission_request_file_path(@submission_request, 'ddbj_record', as: 'url')
+
+    assert_response :success
+    assert_match %r{/rails/active_storage/disk/}, response.parsed_body.fetch('url')
+
+    default_headers['Authorization'] = "Bearer #{@carol.api_key}"
+
+    with_exceptions_app { get submission_request_file_path(@submission_request, 'ddbj_record', as: 'url') }
+
+    assert_response :not_found
+  end
 end

--- a/test/integration/reviews_test.rb
+++ b/test/integration/reviews_test.rb
@@ -20,6 +20,28 @@ class ReviewsTest < ActionDispatch::IntegrationTest
     assert_equal @submission_request.id, response.parsed_body['id']
   end
 
+  # The reviewer's links are plain anchors — the token in the path is the
+  # whole credential, so nothing has to put a header on them. That makes
+  # the disposition the server's business: without it a reviewer clicking
+  # a flatfile gets the browser trying to paint a multi-gigabyte record
+  # in a tab.
+  test 'the reviewer file links ask to be saved rather than rendered' do
+    get review_path(@access.token)
+
+    assert_response :ok
+
+    urls = [
+      response.parsed_body.dig('ddbj_record', 'url'),
+      *response.parsed_body.fetch('submission').values_at('ddbj_record', 'flatfile_na', 'flatfile_aa').compact.map { it.fetch('url') }
+    ]
+
+    assert_equal 4, urls.size
+
+    urls.each do |url|
+      assert_equal 'attachment', Rack::Utils.parse_query(URI.parse(url).query)['disposition'], url
+    end
+  end
+
   # The endpoint is unauthenticated, so "no messages" has to mean the
   # conversation is invisible — not merely that the bodies are withheld.
   # An unread count or a last-posted timestamp still tells a link holder

--- a/web/app/components/bulk-add-to-set.gts
+++ b/web/app/components/bulk-add-to-set.gts
@@ -85,6 +85,7 @@ export default class BulkAddToSet extends Component<Signature> {
         url: `/sets/${this.selected}/submissions`,
         method: 'POST',
         data: { submission_request_ids: this.args.submissionRequestIds },
+        options: { reportErrors: false },
       });
 
       // Both numbers. "8 added" alone leaves somebody who ticked ten

--- a/web/app/components/download-link.gts
+++ b/web/app/components/download-link.gts
@@ -1,0 +1,54 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { on } from '@ember/modifier';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+import { errorMessage } from 'repository/utils/error-message';
+
+import type DownloadsService from 'repository/services/downloads';
+
+interface Signature {
+  Element: HTMLButtonElement;
+
+  Args: {
+    url: string;
+    filename: string;
+  };
+}
+
+// Looks like a link, is a button. See DownloadsService for why it cannot
+// be an anchor: the address it would point at refuses a request that
+// carries no credentials, and a browser navigation carries none.
+export default class DownloadLink extends Component<Signature> {
+  @service declare downloads: DownloadsService;
+
+  @tracked error: string | null = null;
+
+  @action
+  async open() {
+    this.error = null;
+
+    try {
+      await this.downloads.open(this.args.url);
+    } catch (e) {
+      this.error = errorMessage(e) ?? 'Could not fetch that file. Try again.';
+    }
+  }
+
+  <template>
+    <button
+      type="button"
+      class="btn btn-link p-0 align-baseline"
+      data-test-download
+      {{on "click" this.open}}
+      ...attributes
+    >
+      {{@filename}}
+    </button>
+
+    {{#if this.error}}
+      <div class="small text-warning-emphasis" data-test-error>{{this.error}}</div>
+    {{/if}}
+  </template>
+}

--- a/web/app/components/download-link.gts
+++ b/web/app/components/download-link.gts
@@ -40,7 +40,7 @@ export default class DownloadLink extends Component<Signature> {
     <button
       type="button"
       class="btn btn-link p-0 align-baseline"
-      data-test-download
+      data-test-download={{@filename}}
       {{on "click" this.open}}
       ...attributes
     >

--- a/web/app/components/set-membership.gts
+++ b/web/app/components/set-membership.gts
@@ -102,6 +102,7 @@ export default class SetMembership extends Component<Signature> {
         url: `/sets/${this.selected}/submissions`,
         method: 'POST',
         data: { submission_request_ids: [this.args.requestId] },
+        options: { reportErrors: false },
       });
 
       this.selected = '';
@@ -126,6 +127,7 @@ export default class SetMembership extends Component<Signature> {
       await this.requestManager.request({
         url: `/sets/${setId}/submissions/${this.args.requestId}`,
         method: 'DELETE',
+        options: { reportErrors: false },
       });
 
       this.toast.show('Taken out of the set.', 'success');

--- a/web/app/components/submission-messages.gts
+++ b/web/app/components/submission-messages.gts
@@ -4,6 +4,8 @@ import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';
 import { DirectUpload } from '@rails/activestorage';
+
+import DownloadLink from 'repository/components/download-link';
 import { uniqueId } from '@ember/helper';
 
 import formatDatetime from 'repository/helpers/format-datetime';
@@ -11,6 +13,7 @@ import humanSize from 'repository/helpers/human-size';
 import ENV from 'repository/config/environment';
 
 import type AttentionService from 'repository/services/attention';
+import type CurrentUserService from 'repository/services/current-user';
 import type { RequestManager } from '@warp-drive/core';
 import type RouterService from '@ember/routing/router-service';
 import type { paths } from 'schema/openapi';
@@ -31,6 +34,7 @@ interface Signature {
 
 export default class SubmissionMessages extends Component<Signature> {
   @service declare attention: AttentionService;
+  @service declare currentUser: CurrentUserService;
   @service declare requestManager: RequestManager;
   @service declare router: RouterService;
 
@@ -113,7 +117,10 @@ export default class SubmissionMessages extends Component<Signature> {
   // conversation is about — submission files, large by nature — are not
   // bounded by anything in front of Rails.
   async upload(file: File) {
-    const upload = new DirectUpload(file, ENV.directUploadURL);
+    // The endpoint authenticates now (it mints a blob row and a presigned
+    // PUT, which is not something to leave open), and @rails/activestorage
+    // sends only its own headers unless it is given more.
+    const upload = new DirectUpload(file, ENV.directUploadURL, undefined, this.currentUser.authorizationHeader);
 
     return new Promise<string>((resolve, reject) => {
       upload.create((error, blob) => (error ? reject(error) : resolve(blob!.signed_id)));
@@ -220,7 +227,7 @@ export default class SubmissionMessages extends Component<Signature> {
                   <ul class="list-unstyled mb-0 mt-2 small">
                     {{#each m.files as |file|}}
                       <li>
-                        <a href={{file.url}} download>{{file.filename}}</a>
+                        <DownloadLink @url={{file.url}} @filename={{file.filename}} />
                         <span class="text-body-secondary">{{humanSize file.byte_size}}</span>
                       </li>
                     {{/each}}

--- a/web/app/components/submission-messages.gts
+++ b/web/app/components/submission-messages.gts
@@ -147,6 +147,7 @@ export default class SubmissionMessages extends Component<Signature> {
         url: `/submission_requests/${this.args.requestId}/messages`,
         method: 'POST',
         data: { submission_message: { body, files } },
+        options: { reportErrors: false },
       });
 
       // Appended rather than re-fetched — saves a round trip and keeps

--- a/web/app/request-handlers/error-modal.ts
+++ b/web/app/request-handlers/error-modal.ts
@@ -9,6 +9,8 @@ export default class ErrorModalHandler {
   @service declare errorModal: ErrorModalService;
 
   async request<T>(context: RequestContext, next: NextFn<T>) {
+    const options = context.request.options as { reportErrors?: boolean } | undefined;
+
     try {
       return await next(context.request);
     } catch (e) {
@@ -18,7 +20,13 @@ export default class ErrorModalHandler {
       // the banner says the same thing without taking the page away.
       if (status(e) === 401) {
         this.currentUser.expireSession();
-      } else {
+      } else if (options?.reportErrors !== false) {
+        // The modal is the report of last resort — for failures nothing
+        // else on the screen is going to mention. A caller that shows
+        // the message next to the control the person just pressed opts
+        // out: covering that message with a modal saying the same thing
+        // takes the page away to tell them something they can already
+        // see.
         this.errorModal.show(e as Error);
       }
 

--- a/web/app/request-handlers/types.d.ts
+++ b/web/app/request-handlers/types.d.ts
@@ -6,6 +6,11 @@ declare module '@warp-drive/core/types/request' {
   interface RequestInfo {
     options?: {
       params?: Record<string, ScalarParam | ScalarParam[]>;
+
+      // False when the caller puts the failure on the screen itself. See
+      // ErrorModalHandler: two reports of one failure, one of them a
+      // modal over the page, is worse than either alone.
+      reportErrors?: boolean;
     };
   }
 }

--- a/web/app/services/downloads.ts
+++ b/web/app/services/downloads.ts
@@ -20,17 +20,28 @@ export default class DownloadsService extends Service {
   @service declare requestManager: RequestManager;
 
   async open(url: string) {
-    const { content } = await this.requestManager.request<{ url: string }>({
+    const { content } = await this.requestManager.request<{ url?: string }>({
       url,
-      options: { params: { as: 'url', disposition: 'attachment' } },
+      // The failure belongs next to the file it is about — DownloadLink
+      // puts it there, so the modal stays out of it.
+      options: { params: { as: 'url', disposition: 'attachment' }, reportErrors: false },
     });
+
+    // Navigating to `undefined` would leave the app on a 404 with no
+    // sign of what went wrong. An answer that carries no address is a
+    // failure however it was spelled.
+    if (!content?.url) throw new Error('The server did not say where that file is.');
 
     this.navigate(content.url);
   }
 
-  // `location.assign` rather than a new tab: the answer carries
-  // `Content-Disposition: attachment`, so the browser saves the file and
-  // stays where it is. A tab opened for it would flash and close.
+  // `location.assign` rather than a new tab: the address is asked for
+  // with `disposition=attachment` above, so the answer saves the file
+  // and the page stays where it is. A tab opened for it would flash and
+  // close. The cost is that a storage error at this point — the answer
+  // arriving without that header — navigates away from the app; the URL
+  // is seconds old by then, which is what makes that unlikely rather
+  // than merely unhandled.
   //
   // Its own method because `window.location` is read-only and cannot be
   // stubbed — this is the seam a test watches to see where a download

--- a/web/app/services/downloads.ts
+++ b/web/app/services/downloads.ts
@@ -1,0 +1,41 @@
+import Service, { service } from '@ember/service';
+
+import type CurrentUserService from 'repository/services/current-user';
+import type { RequestManager } from '@warp-drive/core';
+
+// Fetching a file the API will only hand over to somebody it recognises.
+//
+// A plain `<a href>` cannot carry an `Authorization` header, and this API
+// takes no cookies — so an anchor pointing at a download route arrives
+// unauthenticated and is refused. Asking for the address and then
+// navigating to it is what keeps the check where it belongs: at the
+// moment of the click, against whoever is clicking.
+//
+// The address that comes back is a storage URL good for a few minutes.
+// It is not fetched through here: these are submission files, and a
+// genome assembly read into a blob to be handed to the browser is a tab
+// that runs out of memory.
+export default class DownloadsService extends Service {
+  @service declare currentUser: CurrentUserService;
+  @service declare requestManager: RequestManager;
+
+  async open(url: string) {
+    const { content } = await this.requestManager.request<{ url: string }>({
+      url,
+      options: { params: { as: 'url', disposition: 'attachment' } },
+    });
+
+    this.navigate(content.url);
+  }
+
+  // `location.assign` rather than a new tab: the answer carries
+  // `Content-Disposition: attachment`, so the browser saves the file and
+  // stays where it is. A tab opened for it would flash and close.
+  //
+  // Its own method because `window.location` is read-only and cannot be
+  // stubbed — this is the seam a test watches to see where a download
+  // went.
+  navigate(url: string) {
+    window.location.assign(url);
+  }
+}

--- a/web/app/templates/db/requests/new.gts
+++ b/web/app/templates/db/requests/new.gts
@@ -11,6 +11,7 @@ import Breadcrumb from 'repository/components/breadcrumb';
 import SubmissionSteps from 'repository/components/submission-steps';
 import dbLabel from 'repository/helpers/db-label';
 
+import type CurrentUserService from 'repository/services/current-user';
 import type { RequestManager } from '@warp-drive/core';
 import type RouterService from '@ember/routing/router-service';
 import type { Blob } from '@rails/activestorage';
@@ -25,6 +26,7 @@ interface Signature {
 }
 
 export default class extends Component<Signature> {
+  @service declare currentUser: CurrentUserService;
   @service declare requestManager: RequestManager;
   @service declare router: RouterService;
 
@@ -42,7 +44,10 @@ export default class extends Component<Signature> {
     if (!this.file) return;
 
     const { db } = this.args.model;
-    const upload = new DirectUpload(this.file, ENV.directUploadURL);
+    // The endpoint authenticates now (it mints a blob row and a presigned
+    // PUT, which is not something to leave open), and @rails/activestorage
+    // sends only its own headers unless it is given more.
+    const upload = new DirectUpload(this.file, ENV.directUploadURL, undefined, this.currentUser.authorizationHeader);
 
     const blob = await new Promise<Blob>((resolve, reject) => {
       upload.create((err, blob) => (err ? reject(err) : resolve(blob!)));

--- a/web/app/templates/invitation.gts
+++ b/web/app/templates/invitation.gts
@@ -101,6 +101,7 @@ export default class extends Component<Signature> {
       const { content } = await this.requestManager.request<SetSummary>({
         url: `/invitations/${this.args.model.token}/acceptance`,
         method: 'POST',
+        options: { reportErrors: false },
       });
 
       this.toast.show(`You have joined “${content.name}”.`, 'success');

--- a/web/app/templates/request/index.gts
+++ b/web/app/templates/request/index.gts
@@ -5,6 +5,7 @@ import { service } from '@ember/service';
 import { concat } from '@ember/helper';
 
 import Breadcrumb from 'repository/components/breadcrumb';
+import DownloadLink from 'repository/components/download-link';
 import ProgressSteps from 'repository/components/progress-steps';
 import ValidityBadge from 'repository/components/validity-badge';
 import ValidationReport from 'repository/components/validation-report';
@@ -323,33 +324,27 @@ export default class extends Component<Signature> {
             <dt>Uploaded file</dt>
 
             <dd>
-              <a
-                href={{@model.ddbj_record.url}}
-                target="_blank"
-                rel="noopener noreferrer"
-              >{{@model.ddbj_record.filename}}</a>
+              <DownloadLink @url={{@model.ddbj_record.url}} @filename={{@model.ddbj_record.filename}} />
             </dd>
 
             {{#if @model.submission}}
               <dt>DDBJ Record</dt>
 
               <dd>
-                <a
-                  href={{@model.submission.ddbj_record.url}}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >{{@model.submission.ddbj_record.filename}}</a>
+                <DownloadLink
+                  @url={{@model.submission.ddbj_record.url}}
+                  @filename={{@model.submission.ddbj_record.filename}}
+                />
               </dd>
 
               <dt>Flatfile (NA)</dt>
 
               <dd>
                 {{#if @model.submission.flatfile_na}}
-                  <a
-                    href={{@model.submission.flatfile_na.url}}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >{{@model.submission.flatfile_na.filename}}</a>
+                  <DownloadLink
+                    @url={{@model.submission.flatfile_na.url}}
+                    @filename={{@model.submission.flatfile_na.filename}}
+                  />
                 {{else}}
                   <span class="text-body-secondary">Not applicable</span>
                 {{/if}}
@@ -359,11 +354,10 @@ export default class extends Component<Signature> {
 
               <dd>
                 {{#if @model.submission.flatfile_aa}}
-                  <a
-                    href={{@model.submission.flatfile_aa.url}}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >{{@model.submission.flatfile_aa.filename}}</a>
+                  <DownloadLink
+                    @url={{@model.submission.flatfile_aa.url}}
+                    @filename={{@model.submission.flatfile_aa.filename}}
+                  />
                 {{else}}
                   <span class="text-body-secondary">Not applicable</span>
                 {{/if}}

--- a/web/app/templates/set.gts
+++ b/web/app/templates/set.gts
@@ -126,6 +126,7 @@ export default class extends Component<Signature> {
         url: `/sets/${this.submissionSet.id}`,
         method: 'PATCH',
         data: { set: { name } },
+        options: { reportErrors: false },
       });
 
       this.renaming = false;
@@ -147,6 +148,7 @@ export default class extends Component<Signature> {
           url: `/sets/${this.submissionSet.id}/members`,
           method: 'POST',
           data: { set_member: { email: this.email.trim() } },
+          options: { reportErrors: false },
         });
 
         this.email = '';
@@ -171,6 +173,7 @@ export default class extends Component<Signature> {
       await this.requestManager.request({
         url: `/sets/${this.submissionSet.id}/members/${member.id}/reminder`,
         method: 'POST',
+        options: { reportErrors: false },
       });
 
       this.toast.show('Invitation sent again. The previous link no longer works.', 'success');
@@ -196,6 +199,7 @@ export default class extends Component<Signature> {
         await this.requestManager.request({
           url: `/sets/${this.submissionSet.id}/members/${member.id}`,
           method: 'DELETE',
+          options: { reportErrors: false },
         });
 
         this.confirming = null;
@@ -211,6 +215,7 @@ export default class extends Component<Signature> {
       await this.requestManager.request({
         url: `/sets/${this.submissionSet.id}/submissions/${entry.submission.id}`,
         method: 'DELETE',
+        options: { reportErrors: false },
       });
 
       this.toast.show('Taken out of the set.', 'success');
@@ -221,7 +226,11 @@ export default class extends Component<Signature> {
   async deleteSet() {
     await this.run(
       async () => {
-        await this.requestManager.request({ url: `/sets/${this.submissionSet.id}`, method: 'DELETE' });
+        await this.requestManager.request({
+          url: `/sets/${this.submissionSet.id}`,
+          method: 'DELETE',
+          options: { reportErrors: false },
+        });
 
         this.toast.show('Set deleted.', 'success');
       },

--- a/web/app/templates/sets.gts
+++ b/web/app/templates/sets.gts
@@ -55,6 +55,7 @@ export default class extends Component<Signature> {
         url: '/sets',
         method: 'POST',
         data: { set: { name: this.name.trim() } },
+        options: { reportErrors: false },
       });
 
       this.name = '';

--- a/web/config/environment.js
+++ b/web/config/environment.js
@@ -42,7 +42,7 @@ module.exports = function (environment) {
   ENV.apiURL = `${appURL}/api`;
   ENV.adminURL = `${appURL}/admin`;
   ENV.authURL = `${appURL}/auth/keycloak`;
-  ENV.directUploadURL = `${appURL}/rails/active_storage/direct_uploads`;
+  ENV.directUploadURL = `${appURL}/api/direct_uploads`;
 
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;

--- a/web/tests/acceptance/download-test.gts
+++ b/web/tests/acceptance/download-test.gts
@@ -1,0 +1,100 @@
+import { module, test } from 'qunit';
+import { visit, click } from '@ember/test-helpers';
+import { setupApplicationTest } from 'repository/tests/helpers';
+import { setupAuthentication } from 'repository/tests/helpers/setup-auth';
+
+import { http } from '../msw/http';
+import { worker } from '../msw/worker';
+
+import type DownloadsService from 'repository/services/downloads';
+import type { components } from 'schema/openapi';
+
+const now = '2025-01-01T00:00:00.000Z';
+
+const request: components['schemas']['SubmissionRequest'] = {
+  id: 42,
+  db: 'st26',
+  status: 'applied',
+  error_code: null,
+  error_message: null,
+  created_at: now,
+  closed_at: null,
+  closable: false,
+  owned: true,
+  owner_uid: 'test-user',
+  processing: false,
+  ddbj_record: { filename: 'upload.json', url: 'http://localhost:3000/api/submission_requests/42/files/ddbj_record' },
+  validation: null,
+  progress: {
+    step: 'curating',
+    failed: false,
+    closed: false,
+    row_count: 1,
+    accessioned_count: 0,
+    hold_date: null,
+  },
+  unread_curator_message_count: 0,
+  last_message_at: null,
+  sets: [],
+  submission: null,
+};
+
+// Downloads go through a route that refuses a request carrying no
+// credentials, and a browser cannot put a header on an anchor. The
+// client therefore asks for the address and navigates to it — and the
+// bit worth pinning is that it asks **with the token**, because that is
+// the half that was missed when the endpoints moved.
+module('Acceptance | downloading a file', function (hooks) {
+  setupApplicationTest(hooks);
+  setupAuthentication(hooks);
+
+  test('asks for the address as an authenticated request, then goes there', async function (assert) {
+    let authorization: string | null = null;
+    let params: URLSearchParams | undefined;
+    let went: string | undefined;
+
+    worker.use(
+      http.get('/submission_requests/{id}', ({ response }) => response(200).json(request)),
+
+      http.get('/submission_requests/{submission_request_id}/messages', ({ response }) => response(200).json([])),
+
+      http.get('/submission_requests/{submission_request_id}/files/{name}', ({ request: req, response }) => {
+        authorization = req.headers.get('Authorization');
+        params = new URL(req.url).searchParams;
+
+        return response(200).json({ url: 'https://storage.example.com/signed' });
+      }),
+    );
+
+    // The service's own seam, not `window.location` — that is read-only.
+    const downloads = this.owner.lookup('service:downloads') as DownloadsService;
+    downloads.navigate = (url: string) => {
+      went = url;
+    };
+
+    await visit('/requests/42');
+    await click('[data-test-download]');
+
+    assert.strictEqual(authorization, 'Bearer test-token', 'the token went with it');
+    assert.strictEqual(params?.get('as'), 'url', 'asked for the address rather than the redirect');
+    assert.strictEqual(params?.get('disposition'), 'attachment', 'and asked for it as a download');
+    assert.strictEqual(went, 'https://storage.example.com/signed');
+  });
+
+  test('a refusal is reported rather than swallowed', async function (assert) {
+    worker.use(
+      http.get('/submission_requests/{id}', ({ response }) => response(200).json(request)),
+
+      http.get('/submission_requests/{submission_request_id}/messages', ({ response }) => response(200).json([])),
+
+      http.get('/submission_requests/{submission_request_id}/files/{name}', ({ response }) => {
+        return response(404).json({ error: 'Not found' });
+      }),
+    );
+
+    await visit('/requests/42');
+    await click('[data-test-download]');
+
+    assert.dom('[data-test-error]').exists();
+  });
+});

--- a/web/tests/acceptance/download-test.gts
+++ b/web/tests/acceptance/download-test.gts
@@ -7,6 +7,7 @@ import { http } from '../msw/http';
 import { worker } from '../msw/worker';
 
 import type DownloadsService from 'repository/services/downloads';
+import type ErrorModalService from 'repository/services/error-modal';
 import type { components } from 'schema/openapi';
 
 const now = '2025-01-01T00:00:00.000Z';
@@ -81,7 +82,10 @@ module('Acceptance | downloading a file', function (hooks) {
     assert.strictEqual(went, 'https://storage.example.com/signed');
   });
 
-  test('a refusal is reported rather than swallowed', async function (assert) {
+  // The message belongs beside the file it is about. A modal over the
+  // page saying the same thing hides the request the person was reading
+  // and has to be dismissed before they can try the next file.
+  test('a refusal is reported rather than swallowed, and only once', async function (assert) {
     worker.use(
       http.get('/submission_requests/{id}', ({ response }) => response(200).json(request)),
 
@@ -95,6 +99,39 @@ module('Acceptance | downloading a file', function (hooks) {
     await visit('/requests/42');
     await click('[data-test-download]');
 
+    assert.dom('[data-test-error]').exists();
+
+    const errorModal = this.owner.lookup('service:error-modal') as ErrorModalService;
+
+    assert.strictEqual(errorModal.error, undefined, 'the modal was not also raised');
+  });
+
+  // An answer with no address in it is a failure however it was spelled.
+  // Navigating to `undefined` would leave the app on a 404 page with
+  // nothing to say what went wrong.
+  test('an answer carrying no address is a failure, not a navigation', async function (assert) {
+    let went: string | undefined;
+
+    worker.use(
+      http.get('/submission_requests/{id}', ({ response }) => response(200).json(request)),
+
+      http.get('/submission_requests/{submission_request_id}/messages', ({ response }) => response(200).json([])),
+
+      // Not the documented shape — which is the point.
+      http.get('/submission_requests/{submission_request_id}/files/{name}', ({ response }) => {
+        return response(200).json({} as { url: string });
+      }),
+    );
+
+    const downloads = this.owner.lookup('service:downloads') as DownloadsService;
+    downloads.navigate = (url: string) => {
+      went = url;
+    };
+
+    await visit('/requests/42');
+    await click('[data-test-download]');
+
+    assert.strictEqual(went, undefined, 'nowhere to go, so it did not go');
     assert.dom('[data-test-error]').exists();
   });
 });

--- a/web/tests/acceptance/submission-messages-test.gts
+++ b/web/tests/acceptance/submission-messages-test.gts
@@ -123,7 +123,10 @@ module('Acceptance | submission messages', function (hooks) {
 
     assert.dom('[data-test-messages]').includesText('samples.tsv');
     assert.dom('[data-test-messages]').includesText('2.0 KB', 'the size answers "which file is this"');
-    assert.dom('[data-test-messages] a[download]').hasAttribute('href', 'http://example.com/samples.tsv');
+    // A button, not an anchor: the address refuses a request carrying no
+    // credentials, and a browser navigation carries none. See
+    // DownloadsService.
+    assert.dom('[data-test-messages] [data-test-download]').hasText('samples.tsv');
   });
 
   // "Here is the corrected file" needs no prose, and the textarea's

--- a/web/tests/acceptance/submission-messages-test.gts
+++ b/web/tests/acceptance/submission-messages-test.gts
@@ -1,7 +1,11 @@
 import { module, test } from 'qunit';
-import { visit, fillIn, click } from '@ember/test-helpers';
+import { visit, fillIn, click, triggerEvent, waitUntil } from '@ember/test-helpers';
 import { setupApplicationTest } from 'repository/tests/helpers';
 import { setupAuthentication } from 'repository/tests/helpers/setup-auth';
+
+import { HttpResponse, http as mswHttp } from 'msw';
+
+import ENV from 'repository/config/environment';
 
 import { http } from '../msw/http';
 import { worker } from '../msw/worker';
@@ -157,6 +161,76 @@ module('Acceptance | submission messages', function (hooks) {
 
     // The form must not refuse to submit with an empty body.
     assert.true(document.querySelector('form')?.checkValidity(), 'the browser would not block this');
+  });
+
+  // The direct-upload endpoint authenticates now, and
+  // @rails/activestorage sends only its own headers unless it is handed
+  // more. Miss that and every attachment fails at the first request —
+  // which is exactly what happened when the endpoint moved.
+  test('an attachment is uploaded with the token on it', async function (assert) {
+    let authorization: string | null = null;
+    let posted: string[] | null = null;
+    let put = false;
+
+    worker.use(
+      http.get('/submission_requests/{id}', ({ response }) => response(200).json(request)),
+
+      http.get('/submission_requests/{submission_request_id}/messages', ({ response }) => response(200).json([])),
+
+      // Active Storage's own shape, so a raw handler: it is a contract
+      // with @rails/activestorage rather than one this API declares.
+      mswHttp.post(ENV.directUploadURL, ({ request: req }) => {
+        authorization = req.headers.get('Authorization');
+
+        return HttpResponse.json({
+          signed_id: 'signed-id',
+          direct_upload: { url: 'https://storage.example.com/put', headers: {} },
+        });
+      }),
+
+      mswHttp.put('https://storage.example.com/put', () => {
+        put = true;
+
+        return new HttpResponse(null, { status: 204 });
+      }),
+
+      http.post('/submission_requests/{submission_request_id}/messages', async ({ request: req, response }) => {
+        posted = ((await req.json()) as { submission_message: { files: string[] } }).submission_message.files;
+
+        return response(201).json({
+          id: 9,
+          body: '',
+          author_role: 'submitter',
+          author_uid: 'alice',
+          created_at: now,
+          read_at: null,
+          files: [],
+        });
+      }),
+    );
+
+    await visit(`/requests/${request.id}`);
+
+    const file = new File(['x'], 'samples.tsv', { type: 'text/tab-separated-values' });
+    const transfer = new DataTransfer();
+    transfer.items.add(file);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    input.files = transfer.files;
+
+    await triggerEvent(input, 'change');
+    await click('form button[type="submit"]');
+
+    // The upload is an XHR that Ember's settledness does not know about,
+    // so `click` returns before it has been through. Waiting here rather
+    // than asserting straight away is what keeps the stubs in place
+    // until it has — `resetHandlers` runs the moment this test body
+    // ends, and anything still in flight then lands on the real network.
+    await waitUntil(() => posted);
+
+    assert.strictEqual(authorization, 'Bearer test-token', 'the token went with the upload');
+    assert.true(put, 'and the bytes went to storage');
+    assert.deepEqual(posted, ['signed-id'], 'the signed id is what the message carries');
   });
 
   test('renders the thread and posts a reply', async function (assert) {


### PR DESCRIPTION
Closes the download half of the revocation story that #2014 opened.

An Active Storage URL is a bearer credential with **no owner and no
expiry**: `/rails/active_storage/blobs/redirect/:signed_id` takes a
signed blob id and nothing else. Whoever holds one has the file for ever,
whatever has happened to their access since.

So two things this codebase says were not true of the files:

- "take somebody out of a set and they lose the submissions they were
  reading"
- "disable the reviewer link"

`config.active_storage.draw_routes = false`. Downloads go through this
application's own routes, and every one of them re-asks.

## The route names the attachment

`GET /api/submission_requests/:id/files/ddbj_record` — **not**
`/api/files/:signed_id`.

The generic endpoint needs a policy resolving a blob back to whatever
record it hangs off, covering every attachment in the application,
correct now and after every future `has_one_attached`. The earlier
security review called that table "the actual cost — get it wrong and it
is worse than the TTL". This avoids having one.

Naming the attachment in the route means:

- the record is what authorises the read
- one record's id cannot be presented with another record's blob
- an attachment no route names has **no way in at all** — `SubmissionUpdate#patch`,
  `Submission#cached_materialised_record`

The allowed names are a route constraint *and* a map in the controller.
An unknown one never reaches Ruby.

## Four doors, because there are four ways to be allowed

| door | authorised by |
|---|---|
| submitter, and a set's members | `readable_by` |
| curator | the admin session |
| reviewer | their share token — revoking the share revokes the files |
| message attachments | the request's **owner** only |

That last row is the one worth checking: the conversation is between one
submitter and DDBJ, and reading somebody's submission through a shared
set is not being party to it. Same line the messages endpoints already
draw.

A redirect, not a proxy: these are submission files and a genome assembly
is measured in gigabytes. What leaves is a storage URL expiring in five
minutes (`service_urls_expire_in`) — which it always did. The permanent
part was the route in front of it.

## What had to be redrawn

Turning the routes off takes two things with them.

- **Direct uploads** — every upload in the application depends on this.
  Now at `/api/direct_uploads` and `/admin/direct_uploads`, and
  **authenticated**, which Active Storage's never was. It mints a blob
  row and a presigned PUT to anybody who asks; defensible as Rails' own
  route on Rails' terms, not as one we redraw.
- **The Disk service's endpoints** — how `blob.url` resolves wherever the
  service is Disk rather than S3, i.e. the test environment. Their tokens
  are Active Storage's own, per-request and short-lived.

## Tests

`bin/rails test:all` 1280 / 0. rubocop and brakeman clean. `pnpm lint`
and `pnpm test` (79) clean.

`test/integration/attachment_downloads_test.rb` covers: the old route is
gone; the owner gets a redirect; a stranger and an anonymous caller do
not; **a set member can fetch it and stops being able to the moment they
are removed**; a reviewer fetches on the share token and loses the files
when it is revoked or expires; a message attachment is owner-only and one
from another thread is not found; an attachment no route names cannot be
addressed; direct upload needs a caller.

Driven against the dev app on SeaweedFS: authorised → 302 to a URL
carrying `X-Amz-Expires=300` → 200 and 42,916 bytes; no credentials →
401; somebody else's key → 404.

## Worth knowing before merging

**Any client holding an old `/rails/active_storage/...` URL will get a
routing error.** Nothing in this repo stores them — every emitter builds
them per response — but `submission-bulk-st26` is not in this tree and I
could not check it. The `Attachment.url` / `AttachedFile.url` schema
descriptions now say plainly that the URL is short-lived and not a thing
to store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)