### PR TITLE
セッションを捨ててよいのは 401 のときだけ

### DIFF
--- a/web/app/routes/application.ts
+++ b/web/app/routes/application.ts
@@ -20,11 +20,17 @@ export default class ApplicationRoute extends Route {
     try {
       await this.currentUser.restore();
     } catch (err) {
-      if (err instanceof LoginError) {
-        this.router.transitionTo('index');
-      } else {
-        throw err;
-      }
+      // A token the server rejected is a token gone, and the routes that
+      // need one send their own visitor to the sign-in screen
+      // (`ensureLogin`) — so there is nothing to do here but let the
+      // transition carry on without a session.
+      if (err instanceof LoginError) return;
+
+      // Anything else means we could not ask, not that the answer was
+      // no. The service says so in a banner; the boot continues, because
+      // taking the whole page away over one request that failed leaves
+      // somebody with nothing to retry from.
+      if (!this.currentUser.serverUnreachable) throw err;
     }
   }
 

--- a/web/app/services/current-user.ts
+++ b/web/app/services/current-user.ts
@@ -34,6 +34,13 @@ export default class CurrentUserService extends Service {
   // part of it that actually costs them something.
   @tracked sessionExpired = false;
 
+  // Set when the session could not be checked at all — the API down, a
+  // proxy in the way, a laptop off the network. A different thing from
+  // `sessionExpired` and it must not be told as one: the token is still
+  // good, and saying "you are signed out" would send somebody through an
+  // OAuth round trip to fix a problem that is not theirs.
+  @tracked serverUnreachable = false;
+
   previousTransition?: Transition;
 
   get isLoggedIn() {
@@ -179,10 +186,26 @@ export default class CurrentUserService extends Service {
     try {
       const { content } = await this.requestManager.request<Me>({
         url: '/me',
+
+        // The error route is the report here — a modal on top of it says
+        // the same thing twice.
+        options: { reportErrors: false },
       });
 
       this.user = new User(content.uid, content.api_key, content.admin);
-    } catch {
+    } catch (e) {
+      // Only the server saying the token is no good throws the token
+      // away. Anything else — the API down, a proxy in front of it, a
+      // laptop off the network — is a failure to ask rather than an
+      // answer, and discarding a JWT on one signs somebody out of a
+      // session that was never over. There is no second copy: the way
+      // back is the whole OAuth round trip.
+      if (status(e) !== 401) {
+        this.serverUnreachable = true;
+
+        throw e;
+      }
+
       this.clear();
       localStorage.removeItem('token');
 
@@ -193,4 +216,8 @@ export default class CurrentUserService extends Service {
   clear() {
     this.token = this.user = this.proxyUid = undefined;
   }
+}
+
+function status(error: unknown): number | undefined {
+  return (error as { status?: number } | undefined)?.status;
 }

--- a/web/app/templates/application.gts
+++ b/web/app/templates/application.gts
@@ -130,6 +130,20 @@ export default class extends Component {
       </div>
     {{/if}}
 
+    {{! Not "signed out": the token is still good, we simply could not
+    ask. Telling somebody to log in again over a server that is down
+    sends them through an OAuth round trip that cannot help. }}
+    {{#if this.currentUser.serverUnreachable}}
+      <div class="alert alert-warning border-0 rounded-0 mb-0 py-2" role="alert" data-test-unreachable>
+        <div class="container d-flex align-items-center gap-3 flex-wrap">
+          <span>
+            <strong>Could not reach the server.</strong>
+            <span class="text-body-secondary">You are still signed in — try again in a moment.</span>
+          </span>
+        </div>
+      </div>
+    {{/if}}
+
     <AttentionBanner />
 
     {{#if this.loading.isLoading}}

--- a/web/tests/acceptance/login-test.gts
+++ b/web/tests/acceptance/login-test.gts
@@ -3,6 +3,10 @@ import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'repository/tests/helpers';
 import { setupAuthentication } from 'repository/tests/helpers/setup-auth';
 
+import { HttpResponse, http as mswHttp } from 'msw';
+
+import ENV from 'repository/config/environment';
+
 import { http } from '../msw/http';
 import { worker } from '../msw/worker';
 
@@ -54,6 +58,32 @@ module('Acceptance | sign-in (authenticated)', function (hooks) {
 
     assert.strictEqual(currentURL(), '/');
     assert.dom('h1').hasText('My submissions');
+  });
+
+  // The token is the only copy of the session — getting another means the
+  // whole OAuth round trip — so it is discarded only when the server says
+  // it is no good. A dev server that is down, a proxy in the way, a
+  // laptop off the network: none of those are an answer about the token,
+  // and each of them used to sign the person out for the rest of the day.
+  test('a server that cannot answer does not sign anybody out', async function (assert) {
+    worker.use(
+      mswHttp.get(`${ENV.apiURL}/me`, () => HttpResponse.json({ error: 'Internal server error' }, { status: 500 })),
+    );
+
+    await visit('/');
+
+    assert.strictEqual(localStorage.getItem('token'), 'test-token', 'the token is still there');
+    assert.dom('[data-test-unreachable]').includesText('Could not reach the server');
+    assert.dom('[role="alert"]').doesNotIncludeText('You are signed out');
+  });
+
+  // 401 is an answer about the token, and the only one that discards it.
+  test('a 401 from /me does discard the token', async function (assert) {
+    worker.use(http.get('/me', ({ response }) => response(401).json({ error: 'Unauthorized' })));
+
+    await visit('/');
+
+    assert.strictEqual(localStorage.getItem('token'), null);
   });
 
   // 401 means the session ended somewhere else. A modal would cover the


### PR DESCRIPTION
`/me` がどう失敗しても token を捨てていたので、dev サーバが落ちている間にアプリを開くとログアウトしていました。答えが返ってこないことは token についての答えではないので、401 のときだけ捨てます。

それ以外は「訊けなかった」というバナー（`serverUnreachable`）を出し、ページは取り上げません。

ベースは #2016（`reportErrors` を使うため）。#2016 がマージされたら main に付け替えます。

- `/me` の 500 で token が残ること、`You are signed out` を出さないことをテストで固定
- 401 では従来どおり捨てることも固定
- ApplicationRoute の `transitionTo('index')` を削除（`ensureLogin` があるので不要、かつ boot 中の遷移で router が落ちる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)