### PR TITLE
セットに会話を持たせる

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -10,7 +10,7 @@ module Admin
 
     before_action :authenticate_admin!
 
-    helper_method :my_queue_count
+    helper_method :my_queue_count, :set_queue_count
 
     private
 
@@ -66,6 +66,14 @@ module Admin
     # add up without double-counting.
     def my_queue_count
       @my_queue_count ||= MyQueue.new(current_user).count
+    end
+
+    # The set axis's share of it, for the nav item that leads there. One
+    # more aggregate query on a screen that already runs four, and the
+    # alternative is a tab that says nothing about whether anybody is
+    # waiting behind it.
+    def set_queue_count
+      @set_queue_count ||= SubmissionSet.needing_curator(current_user).count
     end
   end
 end

--- a/app/controllers/admin/files_controller.rb
+++ b/app/controllers/admin/files_controller.rb
@@ -33,4 +33,10 @@ class Admin::FilesController < Admin::ApplicationController
 
     redirect_to_attachment message.files.find(params.expect(:id))
   end
+
+  def set_message
+    message = SubmissionSetMessage.find(params.expect(:message_id))
+
+    redirect_to_attachment message.files.find(params.expect(:id))
+  end
 end

--- a/app/controllers/admin/messages_controller.rb
+++ b/app/controllers/admin/messages_controller.rb
@@ -5,6 +5,8 @@ module Admin
   # Redirects back to the Messages tab the form lives on, so sending a
   # reply does not bounce the curator off the thread they were reading.
   class MessagesController < ApplicationController
+    include AttachmentSignedIds
+
     # "I know about this." The other way a thread is discharged — a reply
     # a curator has read and does not need to answer would otherwise sit
     # in their queue for ever, which is the trap the old open-marks-read
@@ -81,16 +83,6 @@ module Admin
     # else in the params is dropped rather than refused: copying somebody
     # in is a courtesy on top of the message, and it must not be able to
     # stop the message being sent.
-    # Signed ids only. A malformed shape — `files[a]=b` arrives as
-    # Parameters rather than an Array — would otherwise reach the model
-    # write and come back as a 500, and an id that fails verification is
-    # a bad request rather than a fault.
-    def signed_ids(raw)
-      return [] unless raw.is_a?(Array)
-
-      raw.compact_blank.filter_map { it if it.is_a?(String) }
-    end
-
     def cc_users
       ids = Array(params[:cc_user_ids]).map(&:to_i)
 

--- a/app/controllers/admin/my_queue_controller.rb
+++ b/app/controllers/admin/my_queue_controller.rb
@@ -28,6 +28,9 @@ module Admin
       @set_unread = SubmissionSet.curator_unread_counts(current_user, @sets.map(&:id))
       @set_counts = SubmissionSet.counts_for(@sets.map(&:id))
 
+      # Since when, so the row and the order it is in are the same fact.
+      @waiting_since = SubmissionSet.waiting_since(@sets.map(&:id))
+
       @total = @requests + @set_count
     end
 

--- a/app/controllers/admin/my_queue_controller.rb
+++ b/app/controllers/admin/my_queue_controller.rb
@@ -18,7 +18,17 @@ module Admin
       queue = MyQueue.new(current_user)
 
       @sections = queue.sections.map { present(it) }
-      @total    = @sections.sum(&:count)
+      @requests = @sections.sum(&:count)
+
+      # The other axis. Not a section: the three above are one thing
+      # split by this curator's relationship to it, and a set has no
+      # assignee for that split to be about.
+      @sets       = queue.sets.limit(PER_SECTION).to_a
+      @set_count  = queue.set_count
+      @set_unread = SubmissionSet.curator_unread_counts(current_user, @sets.map(&:id))
+      @set_counts = SubmissionSet.counts_for(@sets.map(&:id))
+
+      @total = @requests + @set_count
     end
 
     private

--- a/app/controllers/admin/set_messages_controller.rb
+++ b/app/controllers/admin/set_messages_controller.rb
@@ -33,7 +33,7 @@ module Admin
       @set.subscribe!(current_user)
       @set.mark_read_by!(current_user, as: :curator, through: params[:through_id])
 
-      redirect_to admin_set_path(@set), notice: "Message sent to the #{@set.users.size} members of this set."
+      redirect_to admin_set_path(@set), notice: "Message sent to #{helpers.pluralize(@set.users.size, 'member')} of this set."
     end
 
     # "I know about this." A member's message a curator has read and does

--- a/app/controllers/admin/set_messages_controller.rb
+++ b/app/controllers/admin/set_messages_controller.rb
@@ -1,0 +1,57 @@
+module Admin
+  # Curator side of a set's thread. Member side is the public API's
+  # SetMessagesController.
+  class SetMessagesController < ApplicationController
+    before_action :load_set
+
+    def create
+      body  = params.dig(:submission_set_message, :body).to_s.strip
+      files = signed_ids(params[:files])
+
+      if body.blank? && files.empty?
+        redirect_to admin_set_path(@set), alert: 'Write something or attach a file.'
+        return
+      end
+
+      message = @set.messages.create!(user: current_user, author_role: :curator, body:, files:)
+
+      # Everyone in the set hears about it — see
+      # SubmissionSetMessageMailer for what that costs at size.
+      SubmissionSetMessageMailer.with(message:).notify_members.deliver_later
+
+      # And the colleagues following it, who would otherwise learn
+      # nothing: answering settles the thread, so it leaves their queue
+      # at the same moment it stops needing anyone.
+      if @set.followers_to_notify(message).any?
+        SubmissionSetMessageMailer.with(message:).followed_activity.deliver_later
+      end
+
+      # Answering is having dealt with what was asked, and it follows the
+      # set from here on — including for a curator who had stopped.
+      @set.subscribe!(current_user)
+      @set.mark_read_by!(current_user, through: params[:through_id])
+
+      redirect_to admin_set_path(@set), notice: "Message sent to the #{@set.users.size} members of this set."
+    end
+
+    # "I know about this." A member's message a curator has read and does
+    # not need to answer would otherwise sit in their queue for ever.
+    def read
+      @set.mark_read_by!(current_user, through: params[:through_id])
+
+      redirect_to admin_set_path(@set), notice: 'Marked as read.'
+    end
+
+    private
+
+    def load_set = @set = SubmissionSet.find(params.expect(:set_id))
+
+    # Signed ids only — a malformed shape is a bad request rather than a
+    # 500 at the model write.
+    def signed_ids(raw)
+      return [] unless raw.is_a?(Array)
+
+      raw.compact_blank.filter_map { it if it.is_a?(String) }
+    end
+  end
+end

--- a/app/controllers/admin/set_messages_controller.rb
+++ b/app/controllers/admin/set_messages_controller.rb
@@ -2,6 +2,8 @@ module Admin
   # Curator side of a set's thread. Member side is the public API's
   # SetMessagesController.
   class SetMessagesController < ApplicationController
+    include AttachmentSignedIds
+
     before_action :load_set
 
     def create
@@ -29,7 +31,7 @@ module Admin
       # Answering is having dealt with what was asked, and it follows the
       # set from here on — including for a curator who had stopped.
       @set.subscribe!(current_user)
-      @set.mark_read_by!(current_user, through: params[:through_id])
+      @set.mark_read_by!(current_user, as: :curator, through: params[:through_id])
 
       redirect_to admin_set_path(@set), notice: "Message sent to the #{@set.users.size} members of this set."
     end
@@ -37,21 +39,19 @@ module Admin
     # "I know about this." A member's message a curator has read and does
     # not need to answer would otherwise sit in their queue for ever.
     def read
-      @set.mark_read_by!(current_user, through: params[:through_id])
-
-      redirect_to admin_set_path(@set), notice: 'Marked as read.'
+      # Reported from what actually happened: a `through_id` from a stale
+      # tab names a message that is not in this thread, which marks
+      # nothing — and saying "Marked as read." over a badge that is still
+      # there is worse than saying nothing.
+      if @set.mark_read_by!(current_user, as: :curator, through: params[:through_id])
+        redirect_to admin_set_path(@set), notice: 'Marked as read.'
+      else
+        redirect_to admin_set_path(@set), alert: 'Nothing was marked — this page was drawn before the thread moved. Reload and look again.'
+      end
     end
 
     private
 
     def load_set = @set = SubmissionSet.find(params.expect(:set_id))
-
-    # Signed ids only — a malformed shape is a bad request rather than a
-    # 500 at the model write.
-    def signed_ids(raw)
-      return [] unless raw.is_a?(Array)
-
-      raw.compact_blank.filter_map { it if it.is_a?(String) }
-    end
   end
 end

--- a/app/controllers/admin/set_subscriptions_controller.rb
+++ b/app/controllers/admin/set_subscriptions_controller.rb
@@ -1,0 +1,25 @@
+module Admin
+  # Following a set's thread, per curator. The set-axis twin of
+  # Admin::SubscriptionsController, and singular for the same reason:
+  # what is being created is this curator's relationship to this set,
+  # which has no id of its own.
+  class SetSubscriptionsController < ApplicationController
+    before_action :load_set
+
+    def create
+      @set.subscribe! current_user
+
+      redirect_to admin_set_path(@set), notice: 'Following this set.'
+    end
+
+    def destroy
+      @set.unsubscribe! current_user
+
+      redirect_to admin_set_path(@set), notice: 'No longer following this set.'
+    end
+
+    private
+
+    def load_set = @set = SubmissionSet.find(params.expect(:set_id))
+  end
+end

--- a/app/controllers/admin/sets_controller.rb
+++ b/app/controllers/admin/sets_controller.rb
@@ -16,18 +16,34 @@ module Admin
   class SetsController < ApplicationController
     include Pagy::Method
 
+    helper_method :waiting?, :following?
+
     # Two filters and no search. A set is found by the conversation it is
     # having — which is the only reason a curator is on this screen —
     # and there are not enough of them for a name to be the way in.
+    #
+    # The two are independent, not a three-way switch: "which of the ones
+    # I follow still need me?" is the obvious question to ask of this
+    # screen, and a single slot would answer it with the wrong list
+    # rather than say it cannot.
     def index
       @waiting = SubmissionSet.needing_curator(current_user).count
       @total   = SubmissionSet.count
 
+      # `where(id:)` twice rather than two `merge`s: merging relations
+      # that both constrain `id` REPLACES the first condition rather than
+      # narrowing it, so asking both questions used to silently answer
+      # only the second.
       scope = SubmissionSet.includes(:owner).order(updated_at: :desc)
-      scope = scope.merge(SubmissionSet.needing_curator(current_user)) if params[:filter] == 'waiting'
-      scope = scope.merge(SubmissionSet.followed_by(current_user))     if params[:filter] == 'following'
+      scope = scope.where(id: SubmissionSet.needing_curator(current_user).select(:id)) if waiting?
+      scope = scope.where(id: SubmissionSet.followed_by(current_user).select(:id))     if following?
 
       @pagy, @sets = pagy(scope)
+
+      # A page past the end renders an empty table under a filter bar
+      # counting the rows that are there — the screen contradicting
+      # itself. Reachable by hand and by carrying a page number back.
+      return if redirect_out_of_range_page(@pagy)
 
       ids = @sets.map(&:id)
 
@@ -36,14 +52,31 @@ module Admin
       @last_posts = SubmissionSetMessage.where(submission_set_id: ids).group(:submission_set_id).maximum(:created_at)
     end
 
+
     def show
       @set = SubmissionSet.includes(:owner).find(params.expect(:id))
 
       # The thread renders each message's attachments as well as its
       # author — `:user` alone leaves a pair of queries per message.
-      @messages   = @set.messages.includes(:user, files_attachments: :blob).to_a
-      @members    = @set.members.ordered.includes(:user, :invited_by).to_a
-      @inclusions = @set.inclusions.includes(submission_request: [:user, {submission: :project}]).order(:created_at)
+      @messages = @set.messages.includes(:user, files_attachments: :blob).to_a
+      @members  = @set.members.ordered.includes(:user, :invited_by).to_a
+
+      # Paginated: a set holds however much it holds, and a three-year
+      # study is hundreds of submissions. The member's own view of the
+      # same list paginates for the same reason.
+      @pagy, @inclusions = pagy(
+        @set.inclusions.includes(submission_request: [:user, {submission: :project}]).order(:created_at, :id)
+      )
+
+      redirect_out_of_range_page(@pagy)
     end
+
+    private
+
+    # Unrecognised values mean nothing rather than something: a `filter`
+    # the screen does not know used to render the whole list with no
+    # button lit, silently ignoring what it was asked for.
+    def waiting?   = params[:waiting].present?
+    def following? = params[:following].present?
   end
 end

--- a/app/controllers/admin/sets_controller.rb
+++ b/app/controllers/admin/sets_controller.rb
@@ -1,0 +1,49 @@
+module Admin
+  # The set axis: conversations about a bundle of submissions rather than
+  # about one of them.
+  #
+  # A second axis is a real cost — unread and following are now asked in
+  # two places — and it is paid for by the alternative: a question about
+  # twelve submissions written into twelve request threads arrives in a
+  # curator's queue twelve times, so answering it means answering it
+  # twelve times. The duplication the submitter avoided by asking once
+  # would simply have been handed to whoever answers.
+  #
+  # There is no assignment here. A set has no state to move through and
+  # nothing to hand over but the conversation, so "who is dealing with
+  # this" is answered by who is following it — which is a thing curators
+  # already read on the request axis.
+  class SetsController < ApplicationController
+    include Pagy::Method
+
+    # Two filters and no search. A set is found by the conversation it is
+    # having — which is the only reason a curator is on this screen —
+    # and there are not enough of them for a name to be the way in.
+    def index
+      @waiting = SubmissionSet.needing_curator(current_user).count
+      @total   = SubmissionSet.count
+
+      scope = SubmissionSet.includes(:owner).order(updated_at: :desc)
+      scope = scope.merge(SubmissionSet.needing_curator(current_user)) if params[:filter] == 'waiting'
+      scope = scope.merge(SubmissionSet.followed_by(current_user))     if params[:filter] == 'following'
+
+      @pagy, @sets = pagy(scope)
+
+      ids = @sets.map(&:id)
+
+      @counts     = SubmissionSet.counts_for(ids)
+      @unread     = SubmissionSet.curator_unread_counts(current_user, ids)
+      @last_posts = SubmissionSetMessage.where(submission_set_id: ids).group(:submission_set_id).maximum(:created_at)
+    end
+
+    def show
+      @set = SubmissionSet.includes(:owner).find(params.expect(:id))
+
+      # The thread renders each message's attachments as well as its
+      # author — `:user` alone leaves a pair of queries per message.
+      @messages   = @set.messages.includes(:user, files_attachments: :blob).to_a
+      @members    = @set.members.ordered.includes(:user, :invited_by).to_a
+      @inclusions = @set.inclusions.includes(submission_request: [:user, {submission: :project}]).order(:created_at)
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,13 +37,14 @@ class ApplicationController < ActionController::API
   end
 
   # Acting as somebody else is for helping them with what they submitted.
-  # It does not extend to deciding who they collaborate with: a set
-  # membership and an invitation both record who did it, and under a
-  # proxy that record would name the person being helped rather than the
-  # curator doing the helping. Reading is untouched.
+  # It does not extend to deciding who they collaborate with, or to
+  # speaking in their name: a set membership, an invitation and a message
+  # all record who did it, and under a proxy that record would name the
+  # person being helped rather than the curator doing the helping.
+  # Reading is untouched.
   def refuse_proxy!
     return unless proxying?
 
-    forbid! 'Sets cannot be changed while acting as another account.'
+    forbid! 'A set cannot be written to while acting as another account.'
   end
 end

--- a/app/controllers/attentions_controller.rb
+++ b/app/controllers/attentions_controller.rb
@@ -17,5 +17,12 @@ class AttentionsController < ApplicationController
       .needs_submitter_action
       .includes(:submission)
       .order(id: :desc)
+
+    # The set axis, as one number rather than as entries in the band.
+    # The band is about the submitter's own submissions and says so in
+    # every word of it; a set conversation is a different kind of thing
+    # and belongs where sets are — which is what the nav badge this feeds
+    # is for.
+    @sets_waiting = SubmissionSet.waiting_on_member(current_user).count
   end
 end

--- a/app/controllers/concerns/attachment_signed_ids.rb
+++ b/app/controllers/concerns/attachment_signed_ids.rb
@@ -1,0 +1,22 @@
+# What a client sends when it has already put the bytes in storage.
+#
+# Both sides of both conversations upload directly and then post the
+# signed ids, so all four message endpoints receive the same shape and
+# have to be equally careful with it: a malformed one (`files[a]=b`
+# arrives as Parameters rather than an Array) would otherwise reach the
+# model write and come back as a 500.
+#
+# An id that fails verification is a bad request rather than a fault —
+# see config/initializers/rambulance.rb, which maps the signature error
+# so that stays true past this point.
+module AttachmentSignedIds
+  extend ActiveSupport::Concern
+
+  private
+
+  def signed_ids(raw)
+    return [] unless raw.is_a?(Array)
+
+    raw.compact_blank.filter_map { it if it.is_a?(String) }
+  end
+end

--- a/app/controllers/concerns/set_contents.rb
+++ b/app/controllers/concerns/set_contents.rb
@@ -57,7 +57,7 @@ module SetContents
         .group(:submission_request_id)
         .count
 
-    @counts = self.class.set_counts([@set.id])
+    @counts = self.class.set_counts([@set.id], viewer: current_user)
 
     # How much goes with each member if they are removed. Counted here
     # rather than in the browser: the submissions on screen are one page
@@ -71,16 +71,11 @@ module SetContents
   end
 
   class_methods do
-    # Three COUNTs over however many sets are being rendered, rather
-    # than loading the rows to call `size` on them. Keyed by set id in
-    # both the one-set and the many-set case, so the partial that
-    # reads them does not have to know which it is looking at.
-    def set_counts(ids)
-      {
-        members:     SubmissionSetMember.joined.where(submission_set_id: ids).group(:submission_set_id).count,
-        invited:     SubmissionSetMember.pending.where(submission_set_id: ids).group(:submission_set_id).count,
-        submissions: SubmissionSetInclusion.where(submission_set_id: ids).group(:submission_set_id).count
-      }
+    # Kept here as one call so the partial that reads them does not have
+    # to know whether it is looking at one set or a page of them. The
+    # counting itself belongs to the model.
+    def set_counts(ids, viewer:)
+      SubmissionSet.counts_for(ids).merge(unread: SubmissionSet.member_unread_counts(viewer, ids))
     end
   end
 end

--- a/app/controllers/invitation_acceptances_controller.rb
+++ b/app/controllers/invitation_acceptances_controller.rb
@@ -37,7 +37,7 @@ class InvitationAcceptancesController < ApplicationController
       member.accept!(current_user)
     end
 
-    @counts = self.class.set_counts([@set.id])
+    @counts = self.class.set_counts([@set.id], viewer: current_user)
 
     render status: :created
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,6 @@
 class MessagesController < ApplicationController
+  include AttachmentSignedIds
+
   before_action :load_submission_request
 
   # Reading the thread no longer marks it read. "I have seen this" and "I
@@ -52,14 +54,6 @@ class MessagesController < ApplicationController
   end
 
   private
-
-  # Signed ids only — see the admin controller for why the shape is
-  # checked rather than trusted.
-  def signed_ids(raw)
-    return [] unless raw.is_a?(Array)
-
-    raw.compact_blank.filter_map { it if it.is_a?(String) }
-  end
 
   # Cheap UPDATE — at most touches the un-stamped tail of the thread.
   #

--- a/app/controllers/set_message_files_controller.rb
+++ b/app/controllers/set_message_files_controller.rb
@@ -1,0 +1,16 @@
+# A file attached to a message in a set's thread.
+#
+# Membership-scoped, unlike the per-request thread's attachments: this
+# conversation is the set's, and everybody on the roster is party to it.
+class SetMessageFilesController < ApplicationController
+  include AttachmentDownload
+
+  def show
+    set     = SubmissionSet.joined_by(current_user).find(params.expect(:set_id))
+    message = set.messages.find(params.expect(:message_id))
+
+    # Scoped to the message, so an attachment id from another thread is
+    # not found rather than served.
+    redirect_to_attachment message.files.find(params.expect(:id))
+  end
+end

--- a/app/controllers/set_messages_controller.rb
+++ b/app/controllers/set_messages_controller.rb
@@ -7,8 +7,12 @@
 # one submitter and DDBJ (see MessageFilesController for the same line).
 class SetMessagesController < ApplicationController
   include SetContents
+  include AttachmentSignedIds
 
-  before_action :refuse_proxy!, only: %i[create]
+  # Both writes: `read` moves a marker on the member's own roster row,
+  # which is that person's reminder and not a curator's to discharge
+  # while acting as them.
+  before_action :refuse_proxy!, only: %i[create read]
   before_action :load_set
 
   def index
@@ -33,9 +37,14 @@ class SetMessagesController < ApplicationController
 
     # Writing is having dealt with what was there — the same rule as the
     # request thread, and only through what was already on screen.
-    @set.mark_read_by!(current_user, through: @message.id)
+    @set.mark_read_by!(current_user, as: :member, through: @message.id)
 
+    # Both directions. The curators following it are being asked
+    # something; the rest of the set is being told, because a message to
+    # a set is to the people in it as much as to DDBJ — which is what the
+    # screen promises when it says everyone here gets it.
     SubmissionSetMessageMailer.with(message: @message).notify_curators.deliver_later
+    SubmissionSetMessageMailer.with(message: @message).notify_members.deliver_later
 
     render :show, status: :created
   end
@@ -43,21 +52,12 @@ class SetMessagesController < ApplicationController
   # "Nothing to answer here." A curator's note that needs no reply would
   # otherwise sit in every member's queue for ever.
   def read
-    @set.mark_read_by!(current_user, through: params[:through_id])
+    @set.mark_read_by!(current_user, as: :member, through: params[:through_id])
 
     head :no_content
   end
 
   private
-
-  # Signed ids only — a malformed shape (`files[a]=b` arrives as
-  # Parameters rather than an Array) is a bad request rather than a 500
-  # at the model write.
-  def signed_ids(raw)
-    return [] unless raw.is_a?(Array)
-
-    raw.compact_blank.filter_map { it if it.is_a?(String) }
-  end
 
   # A set you are not in is not visible as a set you are not in.
   def load_set

--- a/app/controllers/set_messages_controller.rb
+++ b/app/controllers/set_messages_controller.rb
@@ -1,0 +1,66 @@
+# The set's own thread, from a member's side. Curator side is
+# Admin::SetMessagesController.
+#
+# Every member reads and writes it — being on the roster is the whole
+# permission, as with everything else a set carries. What it deliberately
+# does NOT carry is the per-submission conversations: those stay between
+# one submitter and DDBJ (see MessageFilesController for the same line).
+class SetMessagesController < ApplicationController
+  include SetContents
+
+  before_action :refuse_proxy!, only: %i[create]
+  before_action :load_set
+
+  def index
+    @messages = @set.messages.includes(:user, files_attachments: :blob).to_a
+  end
+
+  def create
+    attrs = params.expect(submission_set_message: [:body, {files: []}])
+
+    # Under the set's lock, and asked again inside it: a removal that
+    # committed after the membership check would otherwise leave a
+    # message from somebody no longer here, in a thread they can no
+    # longer see.
+    @message = within_submission_set_membership(@set) {
+      @set.messages.create!(
+        user:        current_user,
+        author_role: :member,
+        body:        attrs[:body].to_s.strip,
+        files:       signed_ids(attrs[:files])
+      )
+    }
+
+    # Writing is having dealt with what was there — the same rule as the
+    # request thread, and only through what was already on screen.
+    @set.mark_read_by!(current_user, through: @message.id)
+
+    SubmissionSetMessageMailer.with(message: @message).notify_curators.deliver_later
+
+    render :show, status: :created
+  end
+
+  # "Nothing to answer here." A curator's note that needs no reply would
+  # otherwise sit in every member's queue for ever.
+  def read
+    @set.mark_read_by!(current_user, through: params[:through_id])
+
+    head :no_content
+  end
+
+  private
+
+  # Signed ids only — a malformed shape (`files[a]=b` arrives as
+  # Parameters rather than an Array) is a bad request rather than a 500
+  # at the model write.
+  def signed_ids(raw)
+    return [] unless raw.is_a?(Array)
+
+    raw.compact_blank.filter_map { it if it.is_a?(String) }
+  end
+
+  # A set you are not in is not visible as a set you are not in.
+  def load_set
+    @set = SubmissionSet.joined_by(current_user).find(params.expect(:set_id))
+  end
+end

--- a/app/controllers/sets_controller.rb
+++ b/app/controllers/sets_controller.rb
@@ -10,7 +10,7 @@ class SetsController < ApplicationController
     # Counted, not loaded. `preload` here would instantiate every join row
     # in every set the reader belongs to in order to print three
     # integers each.
-    @counts = self.class.set_counts(@sets.map(&:id))
+    @counts = self.class.set_counts(@sets.map(&:id), viewer: current_user)
   end
 
   def show

--- a/app/mailers/submission_set_message_mailer.rb
+++ b/app/mailers/submission_set_message_mailer.rb
@@ -2,22 +2,35 @@
 # web UI, as everywhere else here — these mails are notification only.
 #
 # The set-axis twin of SubmissionMessageMailer, with one difference worth
-# knowing about: a curator's message goes to **every member of the set**.
-# That is what "everyone in the set is party to this conversation" means
+# knowing about: a message reaches **everyone in the set**, whoever wrote
+# it. That is what "everyone here is party to this conversation" means
 # for mail, and it is the thing that stops scaling first — a set with a
 # dozen members is a mailing list. If that becomes a complaint, the fix
 # is a per-member setting, not narrowing who can see the thread.
 class SubmissionSetMessageMailer < ApplicationMailer
-  # Curator → the set.
+  # To the set: everyone on the roster except whoever wrote it.
+  #
+  # One action for both kinds of author. A member writing to the set is
+  # writing to the people in it as much as to DDBJ — the screen says so —
+  # and a thread where half the messages notify nobody would be a
+  # conversation that only works in one direction.
   def notify_members
     @message = params[:message]
     @set     = @message.set
-    @curator = @message.user
+    @author  = @message.user
 
-    recipients = @set.users.filter_map { recipient_for(it) }
+    recipients = @set.users.filter_map { recipient_for(it) unless it.id == @message.user_id }
     return if recipients.empty?
 
-    mail(to: recipients, subject: "[DDBJ Repository] New curator message on the set “#{@set.name}”")
+    # Bcc: the roster shows each member the address they were invited at,
+    # which is not necessarily the address their account carries. Putting
+    # the account addresses in To would hand every member something the
+    # set never asked them for.
+    mail(
+      to:      recipient_for_self,
+      bcc:     recipients,
+      subject: "[DDBJ Repository] New message on the set “#{@set.name}”"
+    )
   end
 
   # A member → the curators following this set. Nobody following means no
@@ -27,7 +40,7 @@ class SubmissionSetMessageMailer < ApplicationMailer
     @message = params[:message]
     @set     = @message.set
 
-    recipients = @set.followers.filter_map { recipient_for(it) }
+    recipients = @set.followers_to_notify(@message).filter_map { recipient_for(it) }
     return if recipients.empty?
 
     mail(to: recipients, subject: "[DDBJ Repository] #{@message.user.uid} wrote on the set “#{@set.name}”")
@@ -49,4 +62,11 @@ class SubmissionSetMessageMailer < ApplicationMailer
       subject: "[DDBJ Repository] #{@message.user.uid} replied on the set “#{@set.name}”"
     )
   end
+
+  private
+
+  # A Bcc-only mail still needs somewhere to be addressed, and the
+  # honest answer is us: this went to the set, and the copy in our own
+  # mailbox is the record that it did.
+  def recipient_for_self = self.class.default[:from]
 end

--- a/app/mailers/submission_set_message_mailer.rb
+++ b/app/mailers/submission_set_message_mailer.rb
@@ -1,0 +1,52 @@
+# Notifies the other side of a set's conversation. Replies happen in the
+# web UI, as everywhere else here — these mails are notification only.
+#
+# The set-axis twin of SubmissionMessageMailer, with one difference worth
+# knowing about: a curator's message goes to **every member of the set**.
+# That is what "everyone in the set is party to this conversation" means
+# for mail, and it is the thing that stops scaling first — a set with a
+# dozen members is a mailing list. If that becomes a complaint, the fix
+# is a per-member setting, not narrowing who can see the thread.
+class SubmissionSetMessageMailer < ApplicationMailer
+  # Curator → the set.
+  def notify_members
+    @message = params[:message]
+    @set     = @message.set
+    @curator = @message.user
+
+    recipients = @set.users.filter_map { recipient_for(it) }
+    return if recipients.empty?
+
+    mail(to: recipients, subject: "[DDBJ Repository] New curator message on the set “#{@set.name}”")
+  end
+
+  # A member → the curators following this set. Nobody following means no
+  # mail: the set reaches the queue on its own, which is how a thread
+  # nobody has answered yet is found in the first place.
+  def notify_curators
+    @message = params[:message]
+    @set     = @message.set
+
+    recipients = @set.followers.filter_map { recipient_for(it) }
+    return if recipients.empty?
+
+    mail(to: recipients, subject: "[DDBJ Repository] #{@message.user.uid} wrote on the set “#{@set.name}”")
+  end
+
+  # Something happened on a set you follow. Answering settles the thread
+  # and takes it out of every curator's queue at the same moment, so
+  # without this a curator following a set would never learn that a
+  # colleague had answered.
+  def followed_activity
+    @message = params[:message]
+    @set     = @message.set
+
+    recipients = @set.followers_to_notify(@message).filter_map { recipient_for(it) }
+    return if recipients.empty?
+
+    mail(
+      to:      recipients,
+      subject: "[DDBJ Repository] #{@message.user.uid} replied on the set “#{@set.name}”"
+    )
+  end
+end

--- a/app/models/submission_set.rb
+++ b/app/models/submission_set.rb
@@ -33,6 +33,18 @@ class SubmissionSet < ApplicationRecord
   has_many :inclusions, class_name: 'SubmissionSetInclusion', inverse_of: :set, dependent: :destroy
   has_many :submission_requests, through: :inclusions
 
+  # The set's own conversation — see SubmissionSetMessage for why it is a
+  # thread of its own rather than a message copied into the submissions'.
+  has_many :messages, -> { chronological }, class_name: 'SubmissionSetMessage', inverse_of: :set, dependent: :destroy
+
+  # Curators who have worked in this thread. Members are not here: the
+  # roster is what makes the thread theirs.
+  has_many :participations, class_name: 'SubmissionSetParticipant', inverse_of: :set, dependent: :destroy
+  has_many :participants, through: :participations, source: :user
+
+  has_many :followers, -> { merge(SubmissionSetParticipant.subscribed) },
+           through: :participations, source: :user
+
   validates :name, presence: true, length: {maximum: 200}
 
   # The creator is on the roster from the start. A set nobody is in
@@ -47,6 +59,84 @@ class SubmissionSet < ApplicationRecord
   # membership: nothing is shared with somebody who has not walked
   # through the link yet.
   scope :joined_by, ->(user) { where(id: SubmissionSetMember.joined.where(user_id: user.id).select(:submission_set_id)) }
+
+  # Sets a curator is following. The set-axis twin of
+  # SubmissionRequest.involving.
+  scope :followed_by, ->(user) {
+    where(id: SubmissionSetParticipant.subscribed.where(user_id: user.id).select(:submission_set_id))
+  }
+
+  # Sets whose thread is waiting on the curator side: a member has
+  # written and no curator has written since.
+  #
+  # Given a curator it narrows to what they have not put aside
+  # themselves, so one of them dismissing a thread does not speak for the
+  # others — the same shape as MyQueue.unread_messages, one axis over.
+  scope :needing_curator, ->(user = nil) { where(id: unread_curator_messages(user).select(:submission_set_id)) }
+
+  def self.unread_curator_messages(user)
+    return SubmissionSetMessage.unanswered unless user
+
+    join = SubmissionSetMessage.sanitize_sql_array([<<~SQL.squish, user_id: user.id])
+      LEFT JOIN submission_set_participants
+        ON submission_set_participants.submission_set_id = submission_set_messages.submission_set_id
+       AND submission_set_participants.user_id = :user_id
+    SQL
+
+    SubmissionSetMessage
+      .unanswered
+      .joins(join)
+      .where('submission_set_participants.last_read_at IS NULL OR submission_set_messages.created_at > submission_set_participants.last_read_at')
+  end
+
+  # Sets whose thread is waiting on THIS member: a curator has written,
+  # nobody in the set has answered, and this person has not marked it
+  # read. The mirror of `needing_curator`, and the number the nav badge
+  # carries so a member does not have to be on the sets page to know.
+  scope :waiting_on_member, ->(user) {
+    joined_by(user).where(id: unread_member_messages(user).select(:submission_set_id))
+  }
+
+  def self.unread_member_messages(user)
+    join = SubmissionSetMessage.sanitize_sql_array([<<~SQL.squish, user_id: user.id])
+      INNER JOIN submission_set_members
+        ON submission_set_members.submission_set_id = submission_set_messages.submission_set_id
+       AND submission_set_members.user_id = :user_id
+    SQL
+
+    SubmissionSetMessage
+      .unanswered_by_members
+      .joins(join)
+      .where('submission_set_members.last_read_at IS NULL OR submission_set_messages.created_at > submission_set_members.last_read_at')
+  end
+
+  # The three integers every list of sets prints, counted in SQL for the
+  # whole page. There is no ceiling on what a set holds, and these must
+  # not be what loads it.
+  def self.counts_for(ids)
+    {
+      members:     SubmissionSetMember.joined.where(submission_set_id: ids).group(:submission_set_id).count,
+      invited:     SubmissionSetMember.pending.where(submission_set_id: ids).group(:submission_set_id).count,
+      submissions: SubmissionSetInclusion.where(submission_set_id: ids).group(:submission_set_id).count
+    }
+  end
+
+  # What is waiting on one member, and on one curator, across a page of
+  # sets. Two conditions in each, and they are different in kind: the
+  # thread's own state — answered or not, which is collective because
+  # answering is the work — and this person's marker, which is theirs
+  # alone.
+  def self.member_unread_counts(user, ids)
+    return {} if user.nil? || Array(ids).empty?
+
+    unread_member_messages(user).where(submission_set_id: ids).group(:submission_set_id).count
+  end
+
+  def self.curator_unread_counts(user, ids)
+    return {} if user.nil? || Array(ids).empty?
+
+    unread_curator_messages(user).where(submission_set_id: ids).group(:submission_set_id).count
+  end
 
   def member?(user)
     return false unless user
@@ -74,7 +164,114 @@ class SubmissionSet < ApplicationRecord
 
   def delete_blocked_reason = deletable? ? nil : EMPTY_FIRST
 
+  # Everything below mirrors SubmissionRequest's thread deliberately,
+  # name for name: a curator moves between the two axes all day, and the
+  # rules are the same rules. What differs is who the other side is —
+  # a roster rather than one submitter — which is why reading has two
+  # markers rather than one.
+
+  # What is waiting on THIS curator: unanswered by any curator, and not
+  # already put aside by them. No marker means "nothing put aside", so
+  # picking up a set whose conversation was settled long ago does not
+  # report its history as unread.
+  def unread_message_count_for(user)
+    return 0 unless user
+
+    marker = participations.find_by(user_id: user.id)&.last_read_at
+    scope  = messages.unanswered
+    scope  = scope.where('submission_set_messages.created_at > ?', marker) if marker
+
+    scope.count
+  end
+
+  # What is waiting on THIS member. The mirror image, and individual for
+  # the opposite reason to the curator side: answering settles the thread
+  # for the set, but a colleague having read something is not this person
+  # having read it.
+  def unread_message_count_for_member(user)
+    return 0 unless user
+
+    marker = members.find_by(user_id: user.id)&.last_read_at
+    scope  = messages.unanswered_by_members
+    scope  = scope.where('submission_set_messages.created_at > ?', marker) if marker
+
+    scope.count
+  end
+
+  # "I have seen this thread, up to here." `through` is the newest
+  # message the reader had in front of them, so a message that lands
+  # while a reply is being typed is not discharged unseen.
+  def mark_read_by!(user, through: nil)
+    return unless user
+
+    at = through ? messages.where(id: through).pick(:created_at) : Time.current
+    return unless at
+
+    user.admin? ? mark_curator_read(user, at) : mark_member_read(user, at)
+  end
+
+  # Who hears about a message here, apart from whoever wrote it. Asked by
+  # the mailer and by the caller deciding whether there is anything to
+  # send, so the two cannot drift.
+  def followers_to_notify(message) = followers.reject { it.id == message.user_id }
+
+  def following?(user)
+    return false unless user
+
+    participations.subscribed.exists?(user_id: user.id)
+  end
+
+  # Posting follows it from then on: a curator who steps back in has
+  # stepped back in. Marking read is the opposite and does not come
+  # through here.
+  def subscribe!(user)
+    participate!(user)
+    participations.where(user_id: user.id).update_all(unsubscribed_at: nil)
+  end
+
+  def unsubscribe!(user)
+    participate!(user)
+    participations.where(user_id: user.id).update_all(unsubscribed_at: Time.current)
+  end
+
+  # A side effect of a curator doing something here, so it must never
+  # fail the action it hangs off: already-a-participant is a no-op, and a
+  # member acting in their own set is simply not a participant.
+  def participate!(user)
+    return unless user&.admin?
+
+    SubmissionSetParticipant.insert_all(
+      [{submission_set_id: id, user_id: user.id, created_at: Time.current, updated_at: Time.current}],
+      unique_by: %i[submission_set_id user_id]
+    )
+  end
+
   private
+
+  # Creates the row it writes on, but NOT as a subscription:
+  # acknowledging a thread is the opposite of asking to hear more about
+  # it. An existing row keeps whatever it said, so this never
+  # unsubscribes anybody either.
+  def mark_curator_read(user, at)
+    SubmissionSetParticipant.insert_all(
+      [{submission_set_id: id, user_id: user.id, created_at: Time.current, updated_at: Time.current,
+        unsubscribed_at:   Time.current}],
+      unique_by: %i[submission_set_id user_id]
+    )
+
+    advance_marker participations.where(user_id: user.id), at
+  end
+
+  # No row to create — a member already has one, and somebody who is not
+  # on the roster is not reading this thread at all.
+  def mark_member_read(user, at) = advance_marker(members.joined.where(user_id: user.id), at)
+
+  # Never backwards: a stale tab rendered when more was unread would
+  # otherwise reset the position and resurrect everything already dealt
+  # with.
+  def advance_marker(scope, at)
+    scope.where('last_read_at IS NULL OR last_read_at < ?', at).update_all(last_read_at: at)
+  end
 
   def owner_membership = members.where(user_id: owner_id).select(:id)
 end

--- a/app/models/submission_set.rb
+++ b/app/models/submission_set.rb
@@ -40,7 +40,6 @@ class SubmissionSet < ApplicationRecord
   # Curators who have worked in this thread. Members are not here: the
   # roster is what makes the thread theirs.
   has_many :participations, class_name: 'SubmissionSetParticipant', inverse_of: :set, dependent: :destroy
-  has_many :participants, through: :participations, source: :user
 
   has_many :followers, -> { merge(SubmissionSetParticipant.subscribed) },
            through: :participations, source: :user
@@ -110,6 +109,35 @@ class SubmissionSet < ApplicationRecord
       .where('submission_set_members.last_read_at IS NULL OR submission_set_messages.created_at > submission_set_members.last_read_at')
   end
 
+  # Since when a set has been waiting on a curator — the oldest message
+  # no curator has answered.
+  #
+  # NOT `updated_at`. That moves for a rename as readily as for a
+  # message, so a five-day-old question sorts as new the moment somebody
+  # touches the set, and the queue's promise of "oldest first" quietly
+  # becomes "oldest by whatever last happened".
+  def self.waiting_since(ids)
+    return {} if Array(ids).empty?
+
+    SubmissionSetMessage.unanswered.where(submission_set_id: ids).group(:submission_set_id).minimum(:created_at)
+  end
+
+  # The same value as a sort key, for the queue. A correlated subquery
+  # rather than a join so the scope composes with the rest.
+  scope :by_longest_waiting, -> {
+    order(Arel.sql(<<~SQL.squish))
+      (SELECT MIN(m.created_at) FROM submission_set_messages m
+        WHERE m.submission_set_id = submission_sets.id
+          AND m.author_role = 'member'
+          AND NOT EXISTS (
+            SELECT 1 FROM submission_set_messages later
+            WHERE later.submission_set_id = m.submission_set_id
+              AND later.author_role = 'curator'
+              AND (later.created_at, later.id) > (m.created_at, m.id)
+          )) ASC NULLS LAST
+    SQL
+  }
+
   # The three integers every list of sets prints, counted in SQL for the
   # whole page. There is no ceiling on what a set holds, and these must
   # not be what loads it.
@@ -155,14 +183,25 @@ class SubmissionSet < ApplicationRecord
   # the set would kill a link that is sitting in a mailbox, and would
   # do it silently; taking the invitation back is a thing the owner can
   # see and undo.
-  def deletable? = inclusions.none? && members.where.not(id: owner_membership).none?
+  def deletable? = inclusions.none? && messages.none? && members.where.not(id: owner_membership).none?
 
   # Said once, here, and served to the client rather than written out
   # again in the template that shows it — the rule and its wording belong
   # together, and two copies in two languages drift.
   EMPTY_FIRST = 'Take the submissions out and remove everyone else — including invitations nobody has used — first.'.freeze
 
-  def delete_blocked_reason = deletable? ? nil : EMPTY_FIRST
+  # A conversation is not the owner's to erase, and unlike the other two
+  # blockers there is nothing anybody can do to clear it: a thread is
+  # DDBJ's record of what was asked and answered, and the curator who
+  # answered has no copy anywhere else. Said as a fact rather than as an
+  # instruction, because there is no step that unblocks it.
+  CONVERSATION_KEPT = 'This set has a conversation with DDBJ on it, which is the record of what was asked and answered — so the set stays.'.freeze
+
+  def delete_blocked_reason
+    return CONVERSATION_KEPT if messages.exists?
+
+    deletable? ? nil : EMPTY_FIRST
+  end
 
   # Everything below mirrors SubmissionRequest's thread deliberately,
   # name for name: a curator moves between the two axes all day, and the
@@ -184,30 +223,35 @@ class SubmissionSet < ApplicationRecord
     scope.count
   end
 
-  # What is waiting on THIS member. The mirror image, and individual for
-  # the opposite reason to the curator side: answering settles the thread
-  # for the set, but a colleague having read something is not this person
-  # having read it.
-  def unread_message_count_for_member(user)
-    return 0 unless user
-
-    marker = members.find_by(user_id: user.id)&.last_read_at
-    scope  = messages.unanswered_by_members
-    scope  = scope.where('submission_set_messages.created_at > ?', marker) if marker
-
-    scope.count
-  end
-
   # "I have seen this thread, up to here." `through` is the newest
   # message the reader had in front of them, so a message that lands
   # while a reply is being typed is not discharged unseen.
-  def mark_read_by!(user, through: nil)
-    return unless user
+  #
+  # `as:` is passed rather than read off the account, and that is the
+  # whole of it: which side somebody is acting from is a fact about the
+  # screen they pressed the button on. A curator can be a member of a set
+  # like anybody else, and inferring the side from `admin?` gave that
+  # person a badge they could never clear — and, worse, let a press on
+  # the member's side dismiss a curator queue entry they had never seen
+  # as a curator.
+  #
+  # Returns whether anything moved, so a screen does not report having
+  # marked what it did not: a `through` naming a message from another set
+  # (a stale tab, a hand-edited form) marks nothing.
+  def mark_read_by!(user, as:, through: nil)
+    return false unless user
 
     at = through ? messages.where(id: through).pick(:created_at) : Time.current
-    return unless at
+    return false unless at
 
-    user.admin? ? mark_curator_read(user, at) : mark_member_read(user, at)
+    marked =
+      case as
+      when :curator then mark_curator_read(user, at)
+      when :member  then mark_member_read(user, at)
+      else raise ArgumentError, "unknown side: #{as.inspect}"
+      end
+
+    marked.positive?
   end
 
   # Who hears about a message here, apart from whoever wrote it. Asked by

--- a/app/models/submission_set_message.rb
+++ b/app/models/submission_set_message.rb
@@ -1,0 +1,76 @@
+# One message in a set's thread — the conversation about the bundle
+# rather than about any one submission in it.
+#
+# Everyone in the set reads and writes this one. The per-submission
+# threads are not part of it: those are between one submitter and DDBJ,
+# and reading somebody's submission through a shared set is not being
+# party to what they have been asked about it (SetContents scopes the
+# unread counts on the set page for the same reason).
+#
+# `author_role` is `member` rather than `submitter`. Here the other side
+# of the conversation is a roster, and the message says which of them
+# wrote it — `user` is shown, unlike the request thread where every
+# submitter message is by definition the owner's.
+#
+# There is no `read_at` column. On a request thread that one timestamp
+# works because there is exactly one submitter; a set has as many members
+# as it has, so how far somebody has read is a fact about the person —
+# SubmissionSetMember#last_read_at for members,
+# SubmissionSetParticipant#last_read_at for curators.
+class SubmissionSetMessage < ApplicationRecord
+  # `set` is the word everywhere else — the class is SubmissionSet only
+  # because Ruby owns the constant `Set`.
+  # `touch: true` because both screens that list sets are ordered by when
+  # the set was last touched, and a conversation is the only thing that
+  # touches most of them. Without it a set renamed in March sorts above
+  # one somebody wrote in this morning, and the queue's "oldest first"
+  # would be oldest by rename.
+  belongs_to :set, class_name: 'SubmissionSet', foreign_key: :submission_set_id, inverse_of: :messages, touch: true
+  belongs_to :user
+
+  # Same reasoning as the request thread's: the files this conversation
+  # is about are submission files, and both sides upload straight to
+  # storage, so nothing here is bounded by a request body.
+  has_many_attached :files
+
+  AUTHOR_ROLES = %w[curator member].freeze
+
+  # Hash form on a string column — the array form stores integer indices
+  # and mangles them silently. `suffix: :role` gives `curator_role?`
+  # rather than the unreadable `curator_author_role?`.
+  enum :author_role, AUTHOR_ROLES.index_with(&:itself), suffix: :role, validate: true
+
+  # "Here is the corrected file" needs no prose; nothing at all is a
+  # misfire, and both sides refuse it before they get here.
+  validates :body, presence: true, unless: -> { files.attached? }
+
+  scope :chronological, -> { order(:created_at, :id) }
+
+  # Member messages nobody on the curator side has answered — the same
+  # collective rule the request thread uses, for the same reason:
+  # answering is the work, so it settles the thread for every curator.
+  scope :unanswered, -> {
+    member_role.where(<<~SQL.squish)
+      NOT EXISTS (
+        SELECT 1 FROM submission_set_messages later
+        WHERE later.submission_set_id = submission_set_messages.submission_set_id
+          AND later.author_role = 'curator'
+          AND later.created_at > submission_set_messages.created_at
+      )
+    SQL
+  }
+
+  # Curator messages the set has not answered. The mirror of the above,
+  # and what puts "waiting on us" on a member's screen — collective for
+  # the same reason: a colleague answering answers for the set.
+  scope :unanswered_by_members, -> {
+    curator_role.where(<<~SQL.squish)
+      NOT EXISTS (
+        SELECT 1 FROM submission_set_messages later
+        WHERE later.submission_set_id = submission_set_messages.submission_set_id
+          AND later.author_role = 'member'
+          AND later.created_at > submission_set_messages.created_at
+      )
+    SQL
+  }
+end

--- a/app/models/submission_set_message.rb
+++ b/app/models/submission_set_message.rb
@@ -46,6 +46,12 @@ class SubmissionSetMessage < ApplicationRecord
 
   scope :chronological, -> { order(:created_at, :id) }
 
+  # Both scopes below compare `(created_at, id)` rather than `created_at`
+  # alone, matching the order the thread is read in. On `created_at` a
+  # question and its answer written in the same microsecond — reachable
+  # for seeded or imported rows — leave the thread waiting on both sides
+  # at once, while the screen renders them as asked-then-answered.
+
   # Member messages nobody on the curator side has answered — the same
   # collective rule the request thread uses, for the same reason:
   # answering is the work, so it settles the thread for every curator.
@@ -55,7 +61,7 @@ class SubmissionSetMessage < ApplicationRecord
         SELECT 1 FROM submission_set_messages later
         WHERE later.submission_set_id = submission_set_messages.submission_set_id
           AND later.author_role = 'curator'
-          AND later.created_at > submission_set_messages.created_at
+          AND (later.created_at, later.id) > (submission_set_messages.created_at, submission_set_messages.id)
       )
     SQL
   }
@@ -69,7 +75,7 @@ class SubmissionSetMessage < ApplicationRecord
         SELECT 1 FROM submission_set_messages later
         WHERE later.submission_set_id = submission_set_messages.submission_set_id
           AND later.author_role = 'member'
-          AND later.created_at > submission_set_messages.created_at
+          AND (later.created_at, later.id) > (submission_set_messages.created_at, submission_set_messages.id)
       )
     SQL
   }

--- a/app/models/submission_set_participant.rb
+++ b/app/models/submission_set_participant.rb
@@ -1,0 +1,17 @@
+# A curator's relationship to one set's thread: whether it keeps
+# reaching their queue, and how far they have read.
+#
+# The set-axis twin of SubmissionRequestParticipant, and deliberately the
+# same shape — a curator who posts follows from then on, a colleague who
+# only reads speaks for nobody but themselves, and a row is never
+# removed because having worked here is a fact about the past.
+#
+# Members are not here. Being in the set is what makes the thread theirs
+# to read, so there is nothing to subscribe to or unsubscribe from; their
+# marker is on the roster row (SubmissionSetMember#last_read_at).
+class SubmissionSetParticipant < ApplicationRecord
+  belongs_to :set, class_name: 'SubmissionSet', foreign_key: :submission_set_id, inverse_of: :participations
+  belongs_to :user
+
+  scope :subscribed, -> { where(unsubscribed_at: nil) }
+end

--- a/app/services/my_queue.rb
+++ b/app/services/my_queue.rb
@@ -115,8 +115,12 @@ class MyQueue
   # built on first.
   def count = sections.sum(&:count) + set_count
 
-  # Oldest first, like the sections: a queue is a working order.
-  def sets = SubmissionSet.needing_curator(user).includes(:owner).order(updated_at: :asc)
+  # Oldest first, like the sections: a queue is a working order — and
+  # "oldest" means the question that has been sitting longest, not the
+  # set that was touched longest ago. `updated_at` moves for a rename as
+  # readily as for a message, which would send a five-day-old question to
+  # the back of the queue and relabel it as new.
+  def sets = SubmissionSet.needing_curator(user).includes(:owner).by_longest_waiting
 
   def set_count = SubmissionSet.needing_curator(user).count
 

--- a/app/services/my_queue.rb
+++ b/app/services/my_queue.rb
@@ -108,7 +108,17 @@ class MyQueue
     ]
   end
 
-  def count = sections.sum(&:count)
+  # Requests and set conversations, which are two axes and one queue.
+  # A question about a bundle waits on a curator in exactly the way a
+  # question about one submission does, and a landing screen that
+  # promises "everything waiting" cannot answer only for the axis it was
+  # built on first.
+  def count = sections.sum(&:count) + set_count
+
+  # Oldest first, like the sections: a queue is a working order.
+  def sets = SubmissionSet.needing_curator(user).includes(:owner).order(updated_at: :asc)
+
+  def set_count = SubmissionSet.needing_curator(user).count
 
   # Requests with something a curator can actually do. Kept as two plain
   # `where`s so they can be OR-ed (`.or` refuses structurally different

--- a/app/views/admin/messages/_thread.html.erb
+++ b/app/views/admin/messages/_thread.html.erb
@@ -92,7 +92,11 @@
     <%# form, so the upstream body limit — which is not ours to raise — %>
     <%# never comes into it. %>
     <div class="mb-3">
-      <%= label_tag :files, 'Attach files', class: 'form-label' %>
+      <%# `for` has to name the input's real id: `file_field_tag 'files[]'` %>
+      <%# emits `files_`, so `label_tag :files` labelled nothing — the %>
+      <%# control was unreachable by name, for a screen reader and for a %>
+      <%# test alike. %>
+      <%= label_tag 'files_', 'Attach files', class: 'form-label' %>
       <%# `direct_upload: true` would point at Active Storage's own route, which is off — see config/application.rb. %>
       <%= file_field_tag 'files[]', multiple: true, class: 'form-control', data: {direct_upload_url: admin_direct_uploads_path} %>
     </div>

--- a/app/views/admin/my_queue/show.html.erb
+++ b/app/views/admin/my_queue/show.html.erb
@@ -9,10 +9,11 @@
   <% if @total.zero? %>
     Nothing is waiting on a curator right now.
   <% else %>
-    <%= pluralize(@total, 'request') %>
+    <%= pluralize(@total, 'thing') %>
     <%= @total == 1 ? 'needs' : 'need' %> a curator:
     <%= mine %> <%= mine == 1 ? 'is' : 'are' %> yours or involve you,
-    <%= unclaimed %> unclaimed. Oldest first.
+    <%= unclaimed %> unclaimed<%= ", #{pluralize(@set_count, 'set conversation')}" if @set_count.positive? %>.
+    Oldest first.
   <% end %>
 </p>
 
@@ -50,6 +51,55 @@
           <%= link_to 'open in All requests', admin_submission_requests_path %>.
         </p>
       <% end %>
+    <% end %>
+  </section>
+<% end %>
+
+<%# The other axis. Kept apart from the three above rather than made a %>
+<%# fourth of them: those three are one thing split by this curator's %>
+<%# relationship to it, and a set has no assignee for that split to be %>
+<%# about — only whether anybody has answered. %>
+<% if @set_count.positive? %>
+  <section class="mb-4" data-test-section="sets">
+    <div class="d-flex align-items-baseline gap-2 flex-wrap mb-2">
+      <h2 class="h6 mb-0">Set conversations</h2>
+      <span class="badge text-bg-danger"><%= number_with_delimiter(@set_count) %></span>
+      <span class="small text-body-tertiary">
+        A question about a bundle of submissions — asked once, answered once.
+      </span>
+    </div>
+
+    <div class="list-group">
+      <% @sets.each do |set| %>
+        <% unread = @set_unread.fetch(set.id, 0) %>
+
+        <%= link_to admin_set_path(set), class: 'list-group-item list-group-item-action', data: {test_set: set.id} do %>
+          <div class="d-flex justify-content-between align-items-baseline gap-2 flex-wrap">
+            <span>
+              <strong><%= set.name %></strong>
+              <span class="text-body-secondary small">
+                <%= pluralize(@set_counts.fetch(:submissions).fetch(set.id, 0), 'submission') %>,
+                <%= pluralize(@set_counts.fetch(:members).fetch(set.id, 0), 'member') %>
+              </span>
+            </span>
+
+            <span class="d-flex align-items-baseline gap-2">
+              <% if unread.positive? %>
+                <span class="badge text-bg-danger"><%= pluralize(unread, 'message') %></span>
+              <% end %>
+
+              <span class="small text-body-secondary"><%= elapsed_time(set.updated_at) %></span>
+            </span>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+
+    <% if @set_count > @sets.size %>
+      <p class="small text-body-secondary mt-2 mb-0">
+        <%= number_with_delimiter(@set_count - @sets.size) %> more —
+        <%= link_to 'open in Sets', admin_sets_path(filter: 'waiting') %>.
+      </p>
     <% end %>
   </section>
 <% end %>

--- a/app/views/admin/my_queue/show.html.erb
+++ b/app/views/admin/my_queue/show.html.erb
@@ -65,7 +65,7 @@
       <h2 class="h6 mb-0">Set conversations</h2>
       <span class="badge text-bg-danger"><%= number_with_delimiter(@set_count) %></span>
       <span class="small text-body-tertiary">
-        A question about a bundle of submissions — asked once, answered once.
+        A question about a bundle of submissions — asked once, answered once. Longest waiting first.
       </span>
     </div>
 
@@ -88,7 +88,12 @@
                 <span class="badge text-bg-danger"><%= pluralize(unread, 'message') %></span>
               <% end %>
 
-              <span class="small text-body-secondary"><%= elapsed_time(set.updated_at) %></span>
+              <%# How long the question has been sitting — the same value %>
+              <%# the section is ordered by. `updated_at` would say "just %>
+              <%# now" for a set somebody renamed this morning. %>
+              <span class="small text-body-secondary">
+                waiting <%= elapsed_time(@waiting_since[set.id]) %>
+              </span>
             </span>
           </div>
         <% end %>

--- a/app/views/admin/sets/_thread.html.erb
+++ b/app/views/admin/sets/_thread.html.erb
@@ -72,7 +72,11 @@
     </div>
 
     <div class="mb-3">
-      <%= label_tag :files, 'Attach files', class: 'form-label' %>
+      <%# `for` has to name the input's real id: `file_field_tag 'files[]'` %>
+      <%# emits `files_`, so `label_tag :files` labelled nothing — the %>
+      <%# control was unreachable by name, for a screen reader and for a %>
+      <%# test alike. %>
+      <%= label_tag 'files_', 'Attach files', class: 'form-label' %>
       <%= file_field_tag 'files[]', multiple: true, class: 'form-control', data: {direct_upload_url: admin_direct_uploads_path} %>
     </div>
 

--- a/app/views/admin/sets/_thread.html.erb
+++ b/app/views/admin/sets/_thread.html.erb
@@ -1,0 +1,81 @@
+<%# locals: (set:, messages:, unread: 0) %>
+<%# The set's own thread. Everyone on the roster is party to it, which is %>
+<%# the difference from the per-request thread and the reason the author %>
+<%# of each message is named. %>
+<section data-test-thread>
+  <div class="d-flex justify-content-between align-items-baseline mb-1">
+    <h2 class="h5 mb-0">Messages</h2>
+    <span class="text-body-secondary small"><%= pluralize(set.users.size, 'member') %></span>
+  </div>
+
+  <p class="text-body-secondary small">
+    Every post emails all the members of this set. An unanswered message stays
+    in your queue until you reply or mark it read — a colleague reading it does
+    not clear yours, though a colleague answering it does. Replying follows the
+    set from then on.
+  </p>
+
+  <%# Both controls carry the newest message on screen: one that lands %>
+  <%# while a reply is being typed has not been read by sending it. %>
+  <% newest = messages.last&.id %>
+
+  <% if unread.positive? %>
+    <div class="mb-3">
+      <%= button_to "Mark #{pluralize(unread, 'message')} as read",
+                    read_admin_set_messages_path(set, through_id: newest),
+                    method: :post,
+                    class:  'btn btn-outline-secondary btn-sm' %>
+    </div>
+  <% end %>
+
+  <% if messages.any? %>
+    <ul class="list-unstyled mb-4 d-flex flex-column gap-3">
+      <% messages.each do |m| %>
+        <li class="d-flex gap-3 <%= 'ps-5' unless m.curator_role? %>">
+          <% if m.curator_role? %>
+            <span class="badge rounded-circle text-bg-dark d-flex align-items-center justify-content-center"
+                  style="width: 2rem; height: 2rem;" aria-hidden="true">DC</span>
+          <% end %>
+
+          <div class="flex-fill border rounded p-3 <%= m.curator_role? ? 'bg-body-tertiary' : 'bg-primary-subtle border-primary-subtle' %>">
+            <div class="d-flex justify-content-between small text-body-secondary mb-1">
+              <strong class="text-body"><%= m.user.uid %></strong>
+              <span><%= format_datetime(m.created_at) %></span>
+            </div>
+
+            <div style="white-space: pre-wrap;"><%= m.body %></div>
+
+            <% if m.files.attached? %>
+              <ul class="list-unstyled mb-0 mt-2 small">
+                <% m.files.each do |file| %>
+                  <li>
+                    <%= link_to file.filename.to_s, admin_set_message_file_path(m, file.id, disposition: 'attachment') %>
+                    <span class="text-body-secondary"><%= number_to_human_size(file.byte_size) %></span>
+                  </li>
+                <% end %>
+              </ul>
+            <% end %>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="text-body-secondary fst-italic">No messages yet.</p>
+  <% end %>
+
+  <%= form_with url: admin_set_messages_path(set), method: :post, scope: :submission_set_message, local: true do |f| %>
+    <%= hidden_field_tag :through_id, newest %>
+
+    <div class="mb-3">
+      <%= f.label :body, 'New message to the set', class: 'form-label' %>
+      <%= f.text_area :body, class: 'form-control textarea-autogrow' %>
+    </div>
+
+    <div class="mb-3">
+      <%= label_tag :files, 'Attach files', class: 'form-label' %>
+      <%= file_field_tag 'files[]', multiple: true, class: 'form-control', data: {direct_upload_url: admin_direct_uploads_path} %>
+    </div>
+
+    <%= f.submit 'Send message', class: 'btn btn-primary' %>
+  <% end %>
+</section>

--- a/app/views/admin/sets/index.html.erb
+++ b/app/views/admin/sets/index.html.erb
@@ -1,0 +1,87 @@
+<% content_for :title, 'Sets' %>
+
+<h1 class="display-6 mb-1">Sets</h1>
+
+<%# What a set is, said here because a curator meets one for the first %>
+<%# time on this screen. The submissions in it are reached through the %>
+<%# rows, not through this list: what is here is the conversation. %>
+<p class="text-body-secondary mb-4">
+  Submissions their owners have bundled together, and one thread per bundle.
+  A question about a whole set is asked once and answered once — the
+  submissions' own threads are elsewhere, on each request.
+</p>
+
+<%= form_with url: admin_sets_path, method: :get, local: true, class: 'mb-3' do %>
+  <div class="btn-group btn-group-sm" role="group">
+    <%# Filters in the URL, never in the session: a filtered view has to %>
+    <%# survive being sent to somebody else. %>
+    <%= link_to 'All', admin_sets_path,
+                class: "btn btn-outline-secondary#{' active' if params[:filter].blank?}" %>
+
+    <%= link_to "Waiting on us (#{number_with_delimiter(@waiting)})", admin_sets_path(filter: 'waiting'),
+                class: "btn btn-outline-secondary#{' active' if params[:filter] == 'waiting'}",
+                data:  {test_filter: 'waiting'} %>
+
+    <%= link_to 'Following', admin_sets_path(filter: 'following'),
+                class: "btn btn-outline-secondary#{' active' if params[:filter] == 'following'}" %>
+  </div>
+<% end %>
+
+<% if @sets.empty? %>
+  <% if @total.zero? %>
+    <%= empty_state :first_run, 'No sets yet.',
+                    'A set appears here when a submitter bundles submissions together and starts a conversation about them.' %>
+  <% elsif params[:filter] == 'waiting' %>
+    <%# Empty is the goal here — every set has been answered — so it %>
+    <%# reads as an outcome and offers nothing to press. %>
+    <%= empty_state :clear, 'Nothing waiting.', 'Every set thread has been answered or put aside.' %>
+  <% else %>
+    <%= empty_state :filtered, 'No sets match.', "Showing #{params[:filter]} only." do %>
+      <%= link_to 'Clear', admin_sets_path, class: 'btn btn-outline-secondary btn-sm' %>
+    <% end %>
+  <% end %>
+<% else %>
+  <div class="table-responsive">
+    <table class="table table-hover align-middle">
+      <thead>
+        <tr>
+          <th>Set</th>
+          <th>Owner</th>
+          <th class="text-end">Members</th>
+          <th class="text-end">Submissions</th>
+          <th>Last message</th>
+          <th>Waiting</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% @sets.each do |set| %>
+          <% unread = @unread.fetch(set.id, 0) %>
+          <% last   = @last_posts[set.id] %>
+
+          <tr data-test-set="<%= set.id %>">
+            <td><%= link_to set.name, admin_set_path(set) %></td>
+            <td><code><%= set.owner.uid %></code></td>
+            <td class="text-end"><%= number_with_delimiter(@counts.fetch(:members).fetch(set.id, 0)) %></td>
+            <td class="text-end"><%= number_with_delimiter(@counts.fetch(:submissions).fetch(set.id, 0)) %></td>
+
+            <%# Relative, because the question a queue asks is "has this %>
+            <%# been sitting?" — the absolute value rides along in the %>
+            <%# title. %>
+            <td class="<%= 'text-danger' if stale?(last) && unread.positive? %>"><%= elapsed_time(last) %></td>
+
+            <td>
+              <% if unread.positive? %>
+                <span class="badge text-bg-danger"><%= pluralize(unread, 'message') %></span>
+              <% else %>
+                <span class="text-body-secondary">—</span>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <%= render 'admin/shared/pagy_nav', pagy: @pagy %>
+<% end %>

--- a/app/views/admin/sets/index.html.erb
+++ b/app/views/admin/sets/index.html.erb
@@ -11,32 +11,39 @@
   submissions' own threads are elsewhere, on each request.
 </p>
 
-<%= form_with url: admin_sets_path, method: :get, local: true, class: 'mb-3' do %>
-  <div class="btn-group btn-group-sm" role="group">
-    <%# Filters in the URL, never in the session: a filtered view has to %>
-    <%# survive being sent to somebody else. %>
-    <%= link_to 'All', admin_sets_path,
-                class: "btn btn-outline-secondary#{' active' if params[:filter].blank?}" %>
+<%# Filters in the URL, never in the session: a filtered view has to %>
+<%# survive being sent to somebody else. Two independent toggles rather %>
+<%# than a three-way switch — "which of the ones I follow still need %>
+<%# me?" is the question this screen is for. %>
+<div class="d-flex gap-2 flex-wrap mb-3">
+  <%= link_to "Waiting on you (#{number_with_delimiter(@waiting)})",
+              admin_sets_path(waiting: waiting? ? nil : 1, following: following? ? 1 : nil),
+              class: "btn btn-sm btn-outline-secondary#{' active' if waiting?}",
+              data:  {test_filter: 'waiting'} %>
 
-    <%= link_to "Waiting on us (#{number_with_delimiter(@waiting)})", admin_sets_path(filter: 'waiting'),
-                class: "btn btn-outline-secondary#{' active' if params[:filter] == 'waiting'}",
-                data:  {test_filter: 'waiting'} %>
+  <%= link_to 'Following',
+              admin_sets_path(waiting: waiting? ? 1 : nil, following: following? ? nil : 1),
+              class: "btn btn-sm btn-outline-secondary#{' active' if following?}",
+              data:  {test_filter: 'following'} %>
 
-    <%= link_to 'Following', admin_sets_path(filter: 'following'),
-                class: "btn btn-outline-secondary#{' active' if params[:filter] == 'following'}" %>
-  </div>
-<% end %>
+  <% if waiting? || following? %>
+    <%= link_to 'Clear', admin_sets_path, class: 'btn btn-sm btn-link' %>
+  <% end %>
+</div>
 
 <% if @sets.empty? %>
   <% if @total.zero? %>
     <%= empty_state :first_run, 'No sets yet.',
                     'A set appears here when a submitter bundles submissions together and starts a conversation about them.' %>
-  <% elsif params[:filter] == 'waiting' %>
+  <% elsif waiting? && !following? %>
     <%# Empty is the goal here — every set has been answered — so it %>
     <%# reads as an outcome and offers nothing to press. %>
-    <%= empty_state :clear, 'Nothing waiting.', 'Every set thread has been answered or put aside.' %>
+    <%= empty_state :clear, 'Nothing waiting on you.', 'Every set thread has been answered or put aside.' %>
   <% else %>
-    <%= empty_state :filtered, 'No sets match.', "Showing #{params[:filter]} only." do %>
+    <%# Recites what is on, in the words the buttons use. %>
+    <% on = [('waiting on you' if waiting?), ('followed by you' if following?)].compact %>
+
+    <%= empty_state :filtered, 'No sets match.', "Showing sets #{on.to_sentence} only." do %>
       <%= link_to 'Clear', admin_sets_path, class: 'btn btn-outline-secondary btn-sm' %>
     <% end %>
   <% end %>

--- a/app/views/admin/sets/show.html.erb
+++ b/app/views/admin/sets/show.html.erb
@@ -60,7 +60,10 @@
       <h2 class="h6">Submissions</h2>
 
       <% if @inclusions.empty? %>
-        <%= empty_state :clear, 'Nothing in it yet.' %>
+        <%# Not `:clear`: an empty set is not an outcome anybody wanted, %>
+        <%# it is a set nobody has put anything in yet. %>
+        <%= empty_state :first_run, 'Nothing in it yet.',
+                        'Submissions appear here as their owners add them — which only they can do.' %>
       <% else %>
         <ul class="list-group list-group-flush">
           <% @inclusions.each do |inclusion| %>
@@ -78,6 +81,8 @@
             </li>
           <% end %>
         </ul>
+
+        <%= render 'admin/shared/pagy_nav', pagy: @pagy %>
       <% end %>
     </section>
   </div>

--- a/app/views/admin/sets/show.html.erb
+++ b/app/views/admin/sets/show.html.erb
@@ -1,0 +1,84 @@
+<% content_for :title, "Set — #{@set.name}" %>
+
+<%= render 'admin/shared/breadcrumb', items: [
+  {label: 'Sets', path: admin_sets_path},
+  {label: @set.name}
+] %>
+
+<div class="d-flex justify-content-between align-items-start gap-3 flex-wrap mb-1">
+  <h1 class="display-6 mb-0"><%= @set.name %></h1>
+
+  <%# Following, not assignment. A set has no state to move through and %>
+  <%# nothing to hand over but the conversation, so who is dealing with %>
+  <%# it is who is listening to it. %>
+  <% if @set.following?(current_user) %>
+    <%= button_to 'Unfollow', admin_set_subscription_path(@set), method: :delete,
+                  class: 'btn btn-outline-secondary btn-sm' %>
+  <% else %>
+    <%= button_to 'Follow', admin_set_subscription_path(@set), method: :post,
+                  class: 'btn btn-outline-secondary btn-sm' %>
+  <% end %>
+</div>
+
+<p class="text-body-secondary mb-4">
+  Owned by <code><%= @set.owner.uid %></code>, created <%= format_datetime(@set.created_at) %>.
+</p>
+
+<div class="row g-4">
+  <div class="col-lg-7">
+    <%= render 'thread', set: @set, messages: @messages,
+               unread: @set.unread_message_count_for(current_user) %>
+  </div>
+
+  <div class="col-lg-5">
+    <section class="mb-4">
+      <h2 class="h6">Members</h2>
+
+      <%# Every member reads and writes the thread above, which is what %>
+      <%# makes this list part of the conversation rather than reference %>
+      <%# material: it is who a message here reaches. %>
+      <ul class="list-group list-group-flush">
+        <% @members.each do |member| %>
+          <li class="list-group-item d-flex justify-content-between align-items-baseline gap-2 px-0">
+            <span>
+              <% if member.joined? %>
+                <code><%= member.user.uid %></code>
+              <% else %>
+                <span class="text-body-secondary"><%= member.email %></span>
+              <% end %>
+            </span>
+
+            <span class="small text-body-secondary">
+              <%= member.joined? ? "joined #{format_datetime(member.joined_at)}" : 'invited' %>
+            </span>
+          </li>
+        <% end %>
+      </ul>
+    </section>
+
+    <section>
+      <h2 class="h6">Submissions</h2>
+
+      <% if @inclusions.empty? %>
+        <%= empty_state :clear, 'Nothing in it yet.' %>
+      <% else %>
+        <ul class="list-group list-group-flush">
+          <% @inclusions.each do |inclusion| %>
+            <% request = inclusion.submission_request %>
+
+            <li class="list-group-item d-flex justify-content-between align-items-baseline gap-2 px-0">
+              <span>
+                <%= link_to "##{request.id}", admin_submission_request_path(request) %>
+                <span class="text-body-secondary"><%= request.submission&.source_id %></span>
+              </span>
+
+              <%# Whose it is. On this screen it is the first thing a %>
+              <%# reader needs — a set holds several people's work. %>
+              <code class="small"><%= request.user.uid %></code>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+    </section>
+  </div>
+</div>

--- a/app/views/attentions/show.json.jb
+++ b/app/views/attentions/show.json.jb
@@ -4,6 +4,11 @@
 # (a curator can write while a file sits unapplied); the band names the
 # reason the submitter has to deal with first.
 {
+  # Sets whose conversation is waiting on this member — a count, not a
+  # list: the sets page shows which, and the band above the page is about
+  # submissions.
+  sets_waiting: @sets_waiting,
+
   requests: @requests.map {|request|
     reason =
       case request.status

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -86,7 +86,11 @@
               </button>
 
               <ul class="dropdown-menu dropdown-menu-end">
-                <li><%= link_to 'Back to repository', '/web/', class: 'dropdown-item', data: {turbo: false} %></li>
+                <%# `WebApp.url_for`, not a bare path: the SPA is only on the %>
+                <%# same origin where a proxy puts it there. In development %>
+                <%# it is served by its own dev server on another port, and %>
+                <%# a hard-coded /web/ lands on a Rails 404. %>
+                <li><%= link_to 'Back to repository', WebApp.url_for, class: 'dropdown-item', data: {turbo: false} %></li>
                 <li><hr class="dropdown-divider"></li>
                 <li>
                   <%= button_to 'Logout', admin_session_path, method: :delete, class: 'dropdown-item', data: {turbo: false} %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -50,6 +50,13 @@
                        active: controller_path == 'admin/submission_requests' %>
 
             <%= render 'layouts/admin_nav_item',
+                       label:  'Sets',
+                       path:   admin_sets_path,
+                       active: controller_path.in?(%w[admin/sets admin/set_messages]),
+                       badge:  set_queue_count,
+                       badge_class: set_queue_count.positive? ? 'text-bg-danger' : 'text-bg-secondary' %>
+
+            <%= render 'layouts/admin_nav_item',
                        label:  'Users',
                        path:   admin_users_path,
                        active: controller_path == 'admin/users' %>

--- a/app/views/set_invitation_mailer/invite.html.erb
+++ b/app/views/set_invitation_mailer/invite.html.erb
@@ -5,8 +5,9 @@
 <p>
   A set is submissions that belong together — the ones behind a paper, a study, a
   piece of work. Everyone in the set can see what the others have put in it and how
-  far along it is. Which of your own submissions go in stays your decision, and you
-  can take them back out at any time.
+  far along it is, and there is one conversation with DDBJ about the whole of it, so
+  a question about several submissions is asked in one place. Which of your own
+  submissions go in stays your decision, and you can take them back out at any time.
 </p>
 
 <p><%= link_to 'Open the invitation', @member.invitation_url %></p>

--- a/app/views/set_invitation_mailer/invite.text.erb
+++ b/app/views/set_invitation_mailer/invite.text.erb
@@ -4,8 +4,10 @@ Hello,
 
 A set is submissions that belong together — the ones behind a paper, a
 study, a piece of work. Everyone in the set can see what the others have
-put in it and how far along it is. Which of your own submissions go in
-stays your decision, and you can take them back out at any time.
+put in it and how far along it is, and there is one conversation with
+DDBJ about the whole of it, so a question about several submissions is
+asked in one place. Which of your own submissions go in stays your
+decision, and you can take them back out at any time.
 
 Open the invitation:
 <%= @member.invitation_url %>

--- a/app/views/set_messages/_message.json.jb
+++ b/app/views/set_messages/_message.json.jb
@@ -1,0 +1,20 @@
+# locals: (message:)
+
+{
+  id:          message.id,
+  body:        message.body,
+  author_role: message.author_role,
+
+  # Shown, unlike the request thread's: there every member message is by
+  # definition the owner's, and here it is whichever of them wrote it.
+  author_uid: message.user.uid,
+  created_at: message.created_at.iso8601,
+
+  files: message.files.map {
+    render(
+      'application/attachment_file',
+      file: it,
+      url:  set_message_file_url(message.submission_set_id, message.id, it.id)
+    )
+  }
+}

--- a/app/views/set_messages/index.json.jb
+++ b/app/views/set_messages/index.json.jb
@@ -1,0 +1,1 @@
+render(partial: 'message', collection: @messages, as: :message)

--- a/app/views/set_messages/show.json.jb
+++ b/app/views/set_messages/show.json.jb
@@ -1,0 +1,1 @@
+render(partial: 'message', locals: {message: @message})

--- a/app/views/sets/_set_summary.json.jb
+++ b/app/views/sets/_set_summary.json.jb
@@ -12,5 +12,10 @@
   # three integers must not be what loads it.
   member_count:     counts.fetch(:members).fetch(set.id, 0),
   invited_count:    counts.fetch(:invited).fetch(set.id, 0),
-  submission_count: counts.fetch(:submissions).fetch(set.id, 0)
+  submission_count: counts.fetch(:submissions).fetch(set.id, 0),
+
+  # The set's own thread, waiting on this member. Not the submissions'
+  # threads — those are each their owner's, and the set page counts them
+  # per row.
+  unread_message_count: counts.fetch(:unread).fetch(set.id, 0)
 }

--- a/app/views/submission_set_message_mailer/_files.html.erb
+++ b/app/views/submission_set_message_mailer/_files.html.erb
@@ -1,0 +1,4 @@
+<%# locals: (message:) %>
+<% if message.files.attached? %>
+  <p>Attached: <%= message.files.map { it.filename.to_s }.to_sentence %></p>
+<% end %>

--- a/app/views/submission_set_message_mailer/_files.text.erb
+++ b/app/views/submission_set_message_mailer/_files.text.erb
@@ -1,0 +1,5 @@
+<%# locals: (message:) -%>
+<% if message.files.attached? -%>
+
+Attached: <%= message.files.map { it.filename.to_s }.to_sentence %>
+<% end -%>

--- a/app/views/submission_set_message_mailer/followed_activity.html.erb
+++ b/app/views/submission_set_message_mailer/followed_activity.html.erb
@@ -1,7 +1,7 @@
 <% thread_url = File.join(Rails.application.config_for(:app).app_url!, 'admin', 'sets', @set.id.to_s) %>
 
 <p>
-  <%= @message.user.uid %> replied to the set on the set “<%= @set.name %>”
+  <%= @message.user.uid %> replied on the set “<%= @set.name %>”
   (<%= @set.submission_requests.size %> submissions, <%= @set.users.size %> members):
 </p>
 

--- a/app/views/submission_set_message_mailer/followed_activity.html.erb
+++ b/app/views/submission_set_message_mailer/followed_activity.html.erb
@@ -1,0 +1,18 @@
+<% thread_url = File.join(Rails.application.config_for(:app).app_url!, 'admin', 'sets', @set.id.to_s) %>
+
+<p>
+  <%= @message.user.uid %> replied to the set on the set “<%= @set.name %>”
+  (<%= @set.submission_requests.size %> submissions, <%= @set.users.size %> members):
+</p>
+
+<% if @message.body.present? %>
+  <blockquote style="border-left: 3px solid #ccc; padding-left: 1em; color: #555;">
+    <%= simple_format @message.body %>
+  </blockquote>
+<% end %>
+
+<%= render 'files', message: @message %>
+
+<p><a href="<%= thread_url %>">Open the thread in the admin UI.</a></p>
+
+<p>— DDBJ Repository</p>

--- a/app/views/submission_set_message_mailer/followed_activity.text.erb
+++ b/app/views/submission_set_message_mailer/followed_activity.text.erb
@@ -1,0 +1,12 @@
+<% app_url = Rails.application.config_for(:app).app_url! -%>
+<%= @message.user.uid %> replied to the set on the set “<%= @set.name %>” (<%= @set.submission_requests.size %> submissions, <%= @set.users.size %> members):
+
+<% if @message.body.present? -%>
+<%= @message.body.lines.map { "  #{it}" }.join.chomp %>
+<% end -%>
+<%= render 'files', message: @message -%>
+
+Open the thread in the admin UI:
+<%= File.join(app_url, 'admin', 'sets', @set.id.to_s) %>
+
+— DDBJ Repository

--- a/app/views/submission_set_message_mailer/followed_activity.text.erb
+++ b/app/views/submission_set_message_mailer/followed_activity.text.erb
@@ -1,5 +1,5 @@
 <% app_url = Rails.application.config_for(:app).app_url! -%>
-<%= @message.user.uid %> replied to the set on the set “<%= @set.name %>” (<%= @set.submission_requests.size %> submissions, <%= @set.users.size %> members):
+<%= @message.user.uid %> replied on the set “<%= @set.name %>” (<%= @set.submission_requests.size %> submissions, <%= @set.users.size %> members):
 
 <% if @message.body.present? -%>
 <%= @message.body.lines.map { "  #{it}" }.join.chomp %>

--- a/app/views/submission_set_message_mailer/notify_curators.html.erb
+++ b/app/views/submission_set_message_mailer/notify_curators.html.erb
@@ -1,0 +1,18 @@
+<% thread_url = File.join(Rails.application.config_for(:app).app_url!, 'admin', 'sets', @set.id.to_s) %>
+
+<p>
+  <%= @message.user.uid %> has written on the set “<%= @set.name %>”
+  (<%= @set.submission_requests.size %> submissions, <%= @set.users.size %> members):
+</p>
+
+<% if @message.body.present? %>
+  <blockquote style="border-left: 3px solid #ccc; padding-left: 1em; color: #555;">
+    <%= simple_format @message.body %>
+  </blockquote>
+<% end %>
+
+<%= render 'files', message: @message %>
+
+<p><a href="<%= thread_url %>">Open the thread in the admin UI.</a></p>
+
+<p>— DDBJ Repository</p>

--- a/app/views/submission_set_message_mailer/notify_curators.text.erb
+++ b/app/views/submission_set_message_mailer/notify_curators.text.erb
@@ -1,0 +1,12 @@
+<% app_url = Rails.application.config_for(:app).app_url! -%>
+<%= @message.user.uid %> has written on the set “<%= @set.name %>” (<%= @set.submission_requests.size %> submissions, <%= @set.users.size %> members):
+
+<% if @message.body.present? -%>
+<%= @message.body.lines.map { "  #{it}" }.join.chomp %>
+<% end -%>
+<%= render 'files', message: @message -%>
+
+Open the thread in the admin UI:
+<%= File.join(app_url, 'admin', 'sets', @set.id.to_s) %>
+
+— DDBJ Repository

--- a/app/views/submission_set_message_mailer/notify_members.html.erb
+++ b/app/views/submission_set_message_mailer/notify_members.html.erb
@@ -1,0 +1,25 @@
+<% thread_url = WebApp.url_for("/sets/#{@set.id}") %>
+
+<p>Dear member,</p>
+
+<p>
+  A DDBJ curator (<%= @curator.uid %>) has posted a message on the set
+  “<%= @set.name %>”:
+</p>
+
+<% if @message.body.present? %>
+  <blockquote style="border-left: 3px solid #ccc; padding-left: 1em; color: #555;">
+    <%= simple_format @message.body %>
+  </blockquote>
+<% end %>
+
+<%= render 'files', message: @message %>
+
+<p>
+  <a href="<%= thread_url %>">Open the set on the web UI to reply.</a>
+</p>
+
+<p>
+  Regards,<br>
+  DDBJ Repository
+</p>

--- a/app/views/submission_set_message_mailer/notify_members.html.erb
+++ b/app/views/submission_set_message_mailer/notify_members.html.erb
@@ -1,10 +1,10 @@
 <% thread_url = WebApp.url_for("/sets/#{@set.id}") %>
 
-<p>Dear member,</p>
+<p>Hello,</p>
 
 <p>
-  A DDBJ curator (<%= @curator.uid %>) has posted a message on the set
-  “<%= @set.name %>”:
+  <%= @message.curator_role? ? "A DDBJ curator (#{@author.uid})" : @author.uid %>
+  has posted a message on the set “<%= @set.name %>”:
 </p>
 
 <% if @message.body.present? %>
@@ -15,9 +15,9 @@
 
 <%= render 'files', message: @message %>
 
-<p>
-  <a href="<%= thread_url %>">Open the set on the web UI to reply.</a>
-</p>
+<p><a href="<%= thread_url %>">Open the set on the web UI to reply.</a></p>
+
+<p>Everyone in this set receives this message.</p>
 
 <p>
   Regards,<br>

--- a/app/views/submission_set_message_mailer/notify_members.text.erb
+++ b/app/views/submission_set_message_mailer/notify_members.text.erb
@@ -1,6 +1,6 @@
-Dear member,
+Hello,
 
-A DDBJ curator (<%= @curator.uid %>) has posted a message on the set “<%= @set.name %>”:
+<%= @message.curator_role? ? "A DDBJ curator (#{@author.uid})" : @author.uid %> has posted a message on the set “<%= @set.name %>”:
 
 <% if @message.body.present? -%>
 <%= @message.body.lines.map { "  #{it}" }.join.chomp %>
@@ -9,6 +9,8 @@ A DDBJ curator (<%= @curator.uid %>) has posted a message on the set “<%= @set
 
 Open the set on the web UI to reply:
 <%= WebApp.url_for("/sets/#{@set.id}") %>
+
+Everyone in this set receives this message.
 
 Regards,
 DDBJ Repository

--- a/app/views/submission_set_message_mailer/notify_members.text.erb
+++ b/app/views/submission_set_message_mailer/notify_members.text.erb
@@ -1,0 +1,14 @@
+Dear member,
+
+A DDBJ curator (<%= @curator.uid %>) has posted a message on the set “<%= @set.name %>”:
+
+<% if @message.body.present? -%>
+<%= @message.body.lines.map { "  #{it}" }.join.chomp %>
+<% end -%>
+<%= render 'files', message: @message -%>
+
+Open the set on the web UI to reply:
+<%= WebApp.url_for("/sets/#{@set.id}") %>
+
+Regards,
+DDBJ Repository

--- a/config/initializers/rambulance.rb
+++ b/config/initializers/rambulance.rb
@@ -20,6 +20,12 @@ Rambulance.setup do |config|
     # not reported as a fault of ours.
     'EnumFilterable::UnknownFilterValue'           => :bad_request,
 
+    # A signed id that does not verify is a bad request, not a fault of
+    # ours: it is a client sending something Active Storage did not mint,
+    # which is exactly what the message controllers say they refuse when
+    # they check the shape of `files`.
+    'ActiveSupport::MessageVerifier::InvalidSignature' => :bad_request,
+
     'Validation::UnprocessableContent'             => :unprocessable_content
   }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
-  root to: redirect('/web/')
+  # Through WebApp rather than as a bare path: the SPA shares this origin
+  # only where a proxy puts it there. In development it is served by its
+  # own dev server on another port, so `/web/` is a Rails 404.
+  root to: redirect { WebApp.url_for }
 
   get 'auth/:provider/callback', to: 'sessions#create'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,16 @@ Rails.application.routes.draw do
         resource :reminder, only: %i[create], controller: 'set_member_reminders'
       end
 
+      # The set's own thread. Its own resource rather than something
+      # hanging off a submission: what is being talked about is the
+      # bundle, and every member is party to it.
+      resources :messages, only: %i[index create], controller: 'set_messages' do
+        # Opening the thread does not discharge it; saying so does.
+        post :read, on: :collection
+
+        resources :files, only: %i[show], controller: 'set_message_files'
+      end
+
       # Keyed by the submission's own id rather than by the join row's:
       # from the client's side the thing being taken out of the set is
       # the submission, and the row that records it has no other use.
@@ -213,6 +223,17 @@ Rails.application.routes.draw do
       end
     end
 
+    # The set axis. Only the conversation: a set has no state to move
+    # through, and what is in it is reached through the submissions
+    # themselves.
+    resources :sets, only: %i[index show] do
+      resources :messages, only: %i[create], controller: 'set_messages' do
+        post :read, on: :collection
+      end
+
+      resource :subscription, only: %i[create destroy], controller: 'set_subscriptions'
+    end
+
     resources :users,               only: %i[index show update], param: :uid do
       resource :proxy_login, only: %i[create]
     end
@@ -267,6 +288,8 @@ Rails.application.routes.draw do
         constraints: {name: /ddbj_record|flatfile_na|flatfile_aa/}
 
     get 'messages/:message_id/files/:id', to: 'files#message', as: :message_file
+
+    get 'set_messages/:message_id/files/:id', to: 'files#set_message', as: :set_message_file
 
     # Same story as the API's: authenticated, because redrawing Active
     # Storage's public one is not the same as leaving it where Rails put

--- a/db/migrate/20260821000001_create_submission_set_messages.rb
+++ b/db/migrate/20260821000001_create_submission_set_messages.rb
@@ -1,0 +1,52 @@
+# The set's own conversation.
+#
+# Its own thread rather than a message fanned out to the submissions in
+# the set: a question about twelve submissions is one question, and
+# writing it into twelve request threads would put it in a curator's
+# queue twelve times — the duplication the submitter was trying to avoid,
+# handed to the other side.
+#
+# `read_at` (the request thread's marker) has no meaning here. There it
+# stands for "the submitter has dealt with this", and there is exactly
+# one submitter; a set has as many members as it has, so where each of
+# them has got to is a fact about the person and lives on their roster
+# row or their participation.
+class CreateSubmissionSetMessages < ActiveRecord::Migration[8.1]
+  def change
+    create_table :submission_set_messages do |t|
+      t.references :submission_set, null: false, foreign_key: true
+      t.references :user,           null: false, foreign_key: true
+
+      t.string :author_role, null: false
+      t.text   :body,        null: false
+
+      t.timestamps
+
+      # How the thread is read, and how "has anybody answered since?" is
+      # asked — both walk one set's messages in order.
+      t.index %i[submission_set_id created_at id]
+    end
+
+    # A curator's relationship to one set's thread, mirroring
+    # SubmissionRequestParticipant: `unsubscribed_at` decides whether it
+    # reaches their queue at all, `last_read_at` how far they have got.
+    # Members are not here — they are the roster, and their marker is on
+    # it.
+    create_table :submission_set_participants do |t|
+      t.references :submission_set, null: false, foreign_key: true
+      t.references :user,           null: false, foreign_key: true
+
+      t.datetime :last_read_at
+      t.datetime :unsubscribed_at
+
+      t.timestamps
+
+      t.index %i[submission_set_id user_id], unique: true, name: 'index_set_participants_on_set_and_user'
+    end
+
+    # Where this member has got to in the set's thread. On the roster row
+    # because that is what a member is: nothing here follows or unfollows,
+    # since being in the set is what makes it theirs to read.
+    add_column :submission_set_members, :last_read_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_20_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_21_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -365,6 +365,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_000001) do
     t.string "invitation_token"
     t.bigint "invited_by_id", null: false
     t.datetime "joined_at"
+    t.datetime "last_read_at"
     t.bigint "submission_set_id", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
@@ -375,6 +376,30 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_000001) do
     t.index ["submission_set_id"], name: "index_submission_set_members_on_submission_set_id"
     t.index ["user_id"], name: "index_submission_set_members_on_user_id"
     t.check_constraint "user_id IS NULL AND joined_at IS NULL AND email IS NOT NULL AND invitation_token IS NOT NULL AND invitation_expires_at IS NOT NULL OR user_id IS NOT NULL AND joined_at IS NOT NULL", name: "submission_set_members_state_exclusivity"
+  end
+
+  create_table "submission_set_messages", force: :cascade do |t|
+    t.string "author_role", null: false
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.bigint "submission_set_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["submission_set_id", "created_at", "id"], name: "idx_on_submission_set_id_created_at_id_070ddeb119"
+    t.index ["submission_set_id"], name: "index_submission_set_messages_on_submission_set_id"
+    t.index ["user_id"], name: "index_submission_set_messages_on_user_id"
+  end
+
+  create_table "submission_set_participants", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "last_read_at"
+    t.bigint "submission_set_id", null: false
+    t.datetime "unsubscribed_at"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["submission_set_id", "user_id"], name: "index_set_participants_on_set_and_user", unique: true
+    t.index ["submission_set_id"], name: "index_submission_set_participants_on_submission_set_id"
+    t.index ["user_id"], name: "index_submission_set_participants_on_user_id"
   end
 
   create_table "submission_sets", force: :cascade do |t|
@@ -495,6 +520,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_000001) do
   add_foreign_key "submission_set_members", "submission_sets"
   add_foreign_key "submission_set_members", "users"
   add_foreign_key "submission_set_members", "users", column: "invited_by_id"
+  add_foreign_key "submission_set_messages", "submission_sets"
+  add_foreign_key "submission_set_messages", "users"
+  add_foreign_key "submission_set_participants", "submission_sets"
+  add_foreign_key "submission_set_participants", "users"
   add_foreign_key "submission_sets", "users", column: "owner_id"
   add_foreign_key "submission_updates", "submissions"
   add_foreign_key "submissions", "submission_updates", column: "cached_at_update_id", on_delete: :nullify

--- a/schema/openapi.d.ts
+++ b/schema/openapi.d.ts
@@ -888,7 +888,12 @@ export interface paths {
                 content: {
                     "application/json": {
                         submission_message: {
-                            body: string;
+                            /**
+                             * @description Optional: a message that is only an attachment is a real
+                             *     thing to send — "here is the corrected file" needs no
+                             *     prose. A message with neither is refused.
+                             */
+                            body?: string;
                             /**
                              * @description Signed ids from ActiveStorage direct upload. The file goes
                              *     to storage from the browser, so nothing here is bounded by
@@ -1614,7 +1619,11 @@ export interface paths {
                 content: {
                     "application/json": {
                         submission_set_message: {
-                            body: string;
+                            /**
+                             * @description Optional: an attachment on its own is a real thing to
+                             *     send. A message with neither is refused.
+                             */
+                            body?: string;
                             /**
                              * @description Signed ids from ActiveStorage direct upload — the bytes go
                              *     to storage from the browser, so nothing here is bounded by

--- a/schema/openapi.d.ts
+++ b/schema/openapi.d.ts
@@ -118,6 +118,14 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            /**
+                             * @description How many of the reader's sets have a conversation waiting on
+                             *     them — a curator has written, nobody in the set has answered,
+                             *     and this member has not marked it read. A count rather than a
+                             *     list: the banner is about the reader's own submissions, and
+                             *     this feeds the badge on the Sets link instead.
+                             */
+                            sets_waiting: number;
                             requests: {
                                 id: number;
                                 db: components["schemas"]["Db"];
@@ -1549,6 +1557,218 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/sets/{set_id}/messages": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        /**
+         * @description The set's own thread — the conversation about the bundle rather than
+         *     about any one submission in it. Every member reads and writes it.
+         *
+         *     It does not carry the per-submission threads. Those are between one
+         *     submitter and DDBJ, and being able to read somebody's submission
+         *     through a shared set is not being party to what they were asked about
+         *     it.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    set_id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The chronological list of messages. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SetMessage"][];
+                    };
+                };
+                401: components["responses"]["Unauthorized"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        /** @description Post to the set's thread. Notifies the curators following it. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    set_id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        submission_set_message: {
+                            body: string;
+                            /**
+                             * @description Signed ids from ActiveStorage direct upload — the bytes go
+                             *     to storage from the browser, so nothing here is bounded by
+                             *     this request.
+                             */
+                            files?: string[];
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description The newly-created message. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SetMessage"];
+                    };
+                };
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                422: components["responses"]["UnprocessableContent"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sets/{set_id}/messages/read": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * @description Mark the curator's messages in this thread as read — "nothing to answer
+         *     here". Per member: a colleague reading speaks for nobody but themselves.
+         *
+         *     `through_id` is the newest message the client had in front of it; one
+         *     that arrives a moment later is not acknowledged by a press that could
+         *     not have taken it into account.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    set_id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        through_id?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Marked read for this member. */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                401: components["responses"]["Unauthorized"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sets/{set_id}/messages/{message_id}/files/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+                message_id: number;
+                id: number;
+            };
+            cookie?: never;
+        };
+        /**
+         * @description A file attached to a message in the set's thread. Readable by every
+         *     member — unlike a per-request thread's attachments, which stay with the
+         *     submission's owner.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description `url` answers with the address as JSON instead of redirecting to it. */
+                    as?: "url";
+                    /**
+                     * @description `attachment` saves the file; `inline` (the default) leaves it to the
+                     *     browser. A value outside this list is the default rather than an
+                     *     error — a disposition is a preference, not an instruction.
+                     */
+                    disposition?: "inline" | "attachment";
+                };
+                header?: never;
+                path: {
+                    set_id: number;
+                    message_id: number;
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The address, when `as=url` was asked for. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: uri */
+                            url: string;
+                        };
+                    };
+                };
+                /** @description A redirect to storage. */
+                302: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                401: components["responses"]["Unauthorized"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/invitations/{token}": {
         parameters: {
             query?: never;
@@ -2134,6 +2354,12 @@ export interface components {
             /** @description Invitations still outstanding. */
             invited_count: number;
             submission_count: number;
+            /**
+             * @description Messages in the set's own thread waiting on you — a curator message
+             *     nobody in the set has answered, that you have not marked read. Per
+             *     member: a colleague reading speaks for nobody but themselves.
+             */
+            unread_message_count: number;
         };
         Set: {
             id: number;
@@ -2145,6 +2371,12 @@ export interface components {
             member_count: number;
             invited_count: number;
             submission_count: number;
+            /**
+             * @description Messages in the set's own thread waiting on you — a curator message
+             *     nobody in the set has answered, that you have not marked read. Per
+             *     member: a colleague reading speaks for nobody but themselves.
+             */
+            unread_message_count: number;
             /**
              * @description Whether the set can be deleted now — only once everyone else has
              *     left and every submission has been taken out. Deleting is the
@@ -2476,6 +2708,20 @@ export interface components {
              *     gone.
              */
             url: string;
+        };
+        SetMessage: {
+            id: number;
+            body: string;
+            /** @enum {string} */
+            author_role: "curator" | "member";
+            /**
+             * @description Which member wrote it. Named, unlike a request thread's, where every
+             *     non-curator message is by definition the owner's.
+             */
+            author_uid: string;
+            /** Format: date-time */
+            created_at: string;
+            files: components["schemas"]["AttachedFile"][];
         };
         Message: {
             id: number;

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -868,10 +868,13 @@ paths:
                 submission_message:
                   type: object
                   additionalProperties: false
-                  required: [body]
 
                   properties:
                     body:
+                      description: |
+                        Optional: a message that is only an attachment is a real
+                        thing to send — "here is the corrected file" needs no
+                        prose. A message with neither is refused.
                       type: string
 
                     files:
@@ -1588,10 +1591,12 @@ paths:
                 submission_set_message:
                   type: object
                   additionalProperties: false
-                  required: [body]
 
                   properties:
                     body:
+                      description: |
+                        Optional: an attachment on its own is a real thing to
+                        send. A message with neither is refused.
                       type: string
 
                     files:

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -94,9 +94,18 @@ paths:
               schema:
                 type: object
                 additionalProperties: false
-                required: [requests]
+                required: [requests, sets_waiting]
 
                 properties:
+                  sets_waiting:
+                    description: |
+                      How many of the reader's sets have a conversation waiting on
+                      them — a curator has written, nobody in the set has answered,
+                      and this member has not marked it read. A count rather than a
+                      list: the banner is about the reader's own submissions, and
+                      this feeds the badge on the Sets link instead.
+                    type: number
+
                   requests:
                     type: array
 
@@ -1519,6 +1528,225 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /sets/{set_id}/messages:
+    parameters:
+      - name: set_id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+    get:
+      description: |
+        The set's own thread — the conversation about the bundle rather than
+        about any one submission in it. Every member reads and writes it.
+
+        It does not carry the per-submission threads. Those are between one
+        submitter and DDBJ, and being able to read somebody's submission
+        through a shared set is not being party to what they were asked about
+        it.
+
+      tags:
+        - Sets
+
+      responses:
+        '200':
+          description: The chronological list of messages.
+
+          content:
+            application/json:
+              schema:
+                type: array
+
+                items:
+                  $ref: '#/components/schemas/SetMessage'
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      description: Post to the set's thread. Notifies the curators following it.
+
+      tags:
+        - Sets
+
+      requestBody:
+        required: true
+
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [submission_set_message]
+
+              properties:
+                submission_set_message:
+                  type: object
+                  additionalProperties: false
+                  required: [body]
+
+                  properties:
+                    body:
+                      type: string
+
+                    files:
+                      description: |
+                        Signed ids from ActiveStorage direct upload — the bytes go
+                        to storage from the browser, so nothing here is bounded by
+                        this request.
+                      type: array
+
+                      items:
+                        type: string
+
+      responses:
+        '201':
+          description: The newly-created message.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetMessage'
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
+
+  /sets/{set_id}/messages/read:
+    parameters:
+      - name: set_id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+    post:
+      description: |
+        Mark the curator's messages in this thread as read — "nothing to answer
+        here". Per member: a colleague reading speaks for nobody but themselves.
+
+        `through_id` is the newest message the client had in front of it; one
+        that arrives a moment later is not acknowledged by a press that could
+        not have taken it into account.
+
+      requestBody:
+        required: false
+
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+
+              properties:
+                through_id:
+                  type: number
+
+      tags:
+        - Sets
+
+      responses:
+        '204':
+          description: Marked read for this member.
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /sets/{set_id}/messages/{message_id}/files/{id}:
+    parameters:
+      - name: set_id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+      - name: message_id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+      - name: id
+        in: path
+        required: true
+
+        schema:
+          type: number
+
+    get:
+      description: |
+        A file attached to a message in the set's thread. Readable by every
+        member — unlike a per-request thread's attachments, which stay with the
+        submission's owner.
+
+      tags:
+        - Sets
+
+      parameters:
+        - name: as
+          in: query
+          description: |
+            `url` answers with the address as JSON instead of redirecting to it.
+
+          schema:
+            type: string
+            enum: [url]
+
+        - name: disposition
+          in: query
+          description: |
+            `attachment` saves the file; `inline` (the default) leaves it to the
+            browser. A value outside this list is the default rather than an
+            error — a disposition is a preference, not an instruction.
+
+          schema:
+            type: string
+            enum: [inline, attachment]
+
+      responses:
+        '200':
+          description: The address, when `as=url` was asked for.
+
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [url]
+
+                properties:
+                  url:
+                    type: string
+                    format: uri
+
+        '302':
+          description: A redirect to storage.
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /invitations/{token}:
     parameters:
       - name: token
@@ -2142,6 +2370,7 @@ components:
         - member_count
         - invited_count
         - submission_count
+        - unread_message_count
 
       properties:
         id:
@@ -2172,6 +2401,13 @@ components:
         submission_count:
           type: number
 
+        unread_message_count:
+          description: |
+            Messages in the set's own thread waiting on you — a curator message
+            nobody in the set has answered, that you have not marked read. Per
+            member: a colleague reading speaks for nobody but themselves.
+          type: number
+
     Set:
       type: object
       additionalProperties: false
@@ -2185,6 +2421,7 @@ components:
         - member_count
         - invited_count
         - submission_count
+        - unread_message_count
         - deletable
         - delete_blocked_reason
         - members
@@ -2214,6 +2451,13 @@ components:
           type: number
 
         submission_count:
+          type: number
+
+        unread_message_count:
+          description: |
+            Messages in the set's own thread waiting on you — a curator message
+            nobody in the set has answered, that you have not marked read. Per
+            member: a colleague reading speaks for nobody but themselves.
           type: number
 
         deletable:
@@ -2998,6 +3242,48 @@ components:
             them, which is what makes access that has been taken away actually
             gone.
           type: string
+
+    SetMessage:
+      type: object
+      additionalProperties: false
+
+      required:
+        - id
+        - body
+        - author_role
+        - author_uid
+        - created_at
+        - files
+
+      properties:
+        id:
+          type: number
+
+        body:
+          type: string
+
+        author_role:
+          type: string
+
+          enum:
+            - curator
+            - member
+
+        author_uid:
+          description: |
+            Which member wrote it. Named, unlike a request thread's, where every
+            non-curator message is by definition the owner's.
+          type: string
+
+        created_at:
+          type: string
+          format: date-time
+
+        files:
+          type: array
+
+          items:
+            $ref: '#/components/schemas/AttachedFile'
 
     Message:
       type: object

--- a/test/integration/attention_test.rb
+++ b/test/integration/attention_test.rb
@@ -7,6 +7,38 @@ class AttentionTest < ActionDispatch::IntegrationTest
     default_headers['Authorization'] = "Bearer #{@user.api_key}"
   end
 
+  # The set axis, as one number. A badge nothing tests can be zeroed by
+  # accident and nobody finds out — which is what happened to this one
+  # when a reviewer tried it.
+  test 'counts the sets whose conversation is waiting on this member' do
+    set = SubmissionSet.create!(name: 'Deep sea study', owner: @user)
+
+    get attention_path
+    assert_conform_schema 200
+    assert_equal 0, response.parsed_body.fetch('sets_waiting')
+
+    message = set.messages.create!(user: users(:bob), author_role: :curator, body: 'Which of these is the parent?')
+
+    get attention_path
+    assert_equal 1, response.parsed_body.fetch('sets_waiting'), 'a curator has asked and nobody has answered'
+
+    set.mark_read_by!(@user, as: :member, through: message.id)
+
+    get attention_path
+    assert_equal 0, response.parsed_body.fetch('sets_waiting'), 'marked read by this member'
+  end
+
+  # Somebody else's set is not this member's business, invitation or not.
+  test 'does not count a set you are only invited to' do
+    theirs = SubmissionSet.create!(name: 'Somebody else', owner: users(:carol))
+    theirs.members.create!(email: @user.email, invited_by: users(:carol))
+    theirs.messages.create!(user: users(:bob), author_role: :curator, body: 'Anyone?')
+
+    get attention_path
+
+    assert_equal 0, response.parsed_body.fetch('sets_waiting')
+  end
+
   test 'empty when nothing is waiting on the submitter' do
     get attention_path
 

--- a/test/integration/set_messages_test.rb
+++ b/test/integration/set_messages_test.rb
@@ -1,0 +1,176 @@
+require 'test_helper'
+
+# The set's own thread: one conversation about the bundle, which every
+# member is party to.
+#
+# The line this draws — and the reason the file exists — is that being in
+# a set makes you party to the SET's conversation, and to nothing else.
+# The per-submission threads stay between their owner and DDBJ, and
+# test/integration/set_sharing_boundary_test.rb holds that half.
+class SetMessagesTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  JSON_HEADERS = {'Content-Type' => 'application/json'}.freeze
+
+  setup do
+    @alice = users(:alice)
+    @carol = users(:carol)
+    @bob   = users(:bob) # curator
+
+    @set = SubmissionSet.create!(name: 'Deep sea study', owner: @alice)
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+
+    default_headers['Authorization'] = "Bearer #{@alice.api_key}"
+  end
+
+  test 'a member posts and the whole set reads it' do
+    assert_difference 'SubmissionSetMessage.count', 1 do
+      post set_messages_path(@set),
+           params:  {submission_set_message: {body: 'Are these two projects one submission or two?'}}.to_json,
+           headers: JSON_HEADERS
+    end
+
+    assert_conform_schema 201
+    assert_equal 'member',      response.parsed_body['author_role']
+    assert_equal @alice.uid,    response.parsed_body['author_uid']
+
+    as @carol
+
+    get set_messages_path(@set)
+
+    assert_conform_schema 200
+    assert_equal ['Are these two projects one submission or two?'], response.parsed_body.map { it['body'] }
+  end
+
+  test 'a set you are not in has no thread to read or write' do
+    theirs = SubmissionSet.create!(name: 'Somebody else', owner: @carol)
+
+    with_exceptions_app { get set_messages_path(theirs) }
+    assert_response :not_found
+
+    with_exceptions_app do
+      post set_messages_path(theirs), params: {submission_set_message: {body: 'hello'}}.to_json, headers: JSON_HEADERS
+    end
+
+    assert_response :not_found
+  end
+
+  # An invitation nobody has walked through is not membership — nothing
+  # is shared until they do, and that has to include the conversation.
+  test 'an outstanding invitation reads nothing' do
+    @set.messages.create!(user: @alice, author_role: :member, body: 'Members only')
+
+    invited = users(:dave)
+    @set.members.create!(email: invited.email, invited_by: @alice)
+
+    as invited
+
+    with_exceptions_app { get set_messages_path(@set) }
+
+    assert_response :not_found
+  end
+
+  test 'an attachment is readable by every member and by nobody else' do
+    message = @set.messages.create!(user: @alice, author_role: :member, body: 'Here it is')
+    message.files.attach(io: StringIO.new('x'), filename: 'notes.txt', content_type: 'text/plain')
+
+    file = message.files.first
+
+    as @carol
+
+    get set_message_file_path(@set, message, file.id)
+    assert_response :redirect
+
+    as users(:dave)
+
+    with_exceptions_app { get set_message_file_path(@set, message, file.id) }
+    assert_response :not_found
+  end
+
+  test 'an attachment from another set is not found rather than served' do
+    mine   = @set.messages.create!(user: @alice, author_role: :member, body: 'Mine')
+    other  = SubmissionSet.create!(name: 'Other', owner: @alice)
+    theirs = other.messages.create!(user: @alice, author_role: :member, body: 'Theirs')
+
+    theirs.files.attach(io: StringIO.new('x'), filename: 'notes.txt', content_type: 'text/plain')
+
+    with_exceptions_app { get set_message_file_path(@set, mine, theirs.files.first.id) }
+
+    assert_response :not_found
+  end
+
+  # Reading is one person's business. The request thread can hold "the
+  # submitter has dealt with this" in one timestamp because there is one
+  # submitter; a set has as many members as it has.
+  test 'marking read moves this member and nobody else' do
+    curator_message = @set.messages.create!(user: @bob, author_role: :curator, body: 'Which of these is the parent?')
+
+    get sets_path
+    assert_equal 1, response.parsed_body.sole['unread_message_count'], 'waiting on alice'
+
+    post read_set_messages_path(@set), params: {through_id: curator_message.id}.to_json, headers: JSON_HEADERS
+    assert_response :no_content
+
+    get sets_path
+    assert_equal 0, response.parsed_body.sole['unread_message_count']
+
+    as @carol
+
+    get sets_path
+    assert_equal 1, response.parsed_body.sole['unread_message_count'], 'carol has not read it'
+  end
+
+  # Answering is the work, so it settles the thread for the whole set —
+  # the same rule the curator side has always had, in the other
+  # direction.
+  test 'a colleague answering settles it for everyone' do
+    @set.messages.create!(user: @bob, author_role: :curator, body: 'Which of these is the parent?')
+
+    as @carol
+
+    post set_messages_path(@set),
+         params:  {submission_set_message: {body: 'PRJDB1234 is.'}}.to_json,
+         headers: JSON_HEADERS
+
+    assert_response :created
+
+    as @alice
+
+    get sets_path
+
+    assert_equal 0, response.parsed_body.sole['unread_message_count'], 'carol answered for the set'
+  end
+
+  test 'a message with neither body nor file is refused' do
+    with_exceptions_app do
+      post set_messages_path(@set), params: {submission_set_message: {body: '   '}}.to_json, headers: JSON_HEADERS
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  # Posting notifies the curators following the set. Nobody following
+  # means nothing goes out — the set reaches the queue on its own, which
+  # is how a thread nobody has answered yet is found at all.
+  test 'posting tells the curators who follow the set, and only them' do
+    perform_enqueued_jobs do
+      assert_no_emails do
+        post set_messages_path(@set), params: {submission_set_message: {body: 'Anyone?'}}.to_json, headers: JSON_HEADERS
+      end
+
+      @set.subscribe!(@bob)
+
+      assert_emails 1 do
+        post set_messages_path(@set), params: {submission_set_message: {body: 'Still anyone?'}}.to_json, headers: JSON_HEADERS
+      end
+    end
+
+    assert_equal [@bob.email], ActionMailer::Base.deliveries.last.to
+  end
+
+  private
+
+  def as(user)
+    default_headers['Authorization'] = "Bearer #{user.api_key}"
+  end
+end

--- a/test/integration/set_messages_test.rb
+++ b/test/integration/set_messages_test.rb
@@ -141,6 +141,66 @@ class SetMessagesTest < ActionDispatch::IntegrationTest
     assert_equal 0, response.parsed_body.sole['unread_message_count'], 'carol answered for the set'
   end
 
+  # A message reaches the people it is addressed to. The screen says
+  # everyone in the set gets it, and a thread where half the messages
+  # notify nobody would be a conversation working in one direction only.
+  test 'a member writing to the set tells the other members' do
+    @carol.update!(email: 'carol@example.com')
+
+    perform_enqueued_jobs do
+      assert_emails 1 do
+        post set_messages_path(@set),
+             params:  {submission_set_message: {body: 'I have fixed the metadata.'}}.to_json,
+             headers: JSON_HEADERS
+      end
+    end
+
+    mail = ActionMailer::Base.deliveries.last
+
+    assert_equal [@carol.email], mail.bcc, 'the other members, not the author'
+    assert_match @alice.uid, mail.parts.map(&:body).join, 'and it says who wrote it'
+  end
+
+  # Under a proxy the marker written is the member's own reminder, and
+  # discharging somebody's reminder while acting as them is not helping.
+  test 'a curator acting as a member can neither write nor mark read' do
+    admin = users(:bob)
+
+    default_headers['Authorization']  = "Bearer #{admin.api_key}"
+    default_headers['X-Dway-User-Id'] = @alice.uid
+
+    with_exceptions_app do
+      post set_messages_path(@set), params: {submission_set_message: {body: 'x'}}.to_json, headers: JSON_HEADERS
+    end
+
+    assert_response :forbidden
+
+    with_exceptions_app { post read_set_messages_path(@set), params: {}.to_json, headers: JSON_HEADERS }
+
+    assert_response :forbidden
+  ensure
+    default_headers.delete 'X-Dway-User-Id'
+  end
+
+  # `through_id` bounds a press to what was on screen; one naming another
+  # set's message marks nothing at all.
+  test 'a through_id from another thread marks nothing' do
+    @set.messages.create!(user: @bob, author_role: :curator, body: 'A question')
+
+    elsewhere = SubmissionSet.create!(name: 'Other', owner: @alice)
+    theirs    = elsewhere.messages.create!(user: @bob, author_role: :curator, body: 'Not this one')
+
+    post read_set_messages_path(@set), params: {through_id: theirs.id}.to_json, headers: JSON_HEADERS
+
+    assert_response :no_content
+
+    get sets_path
+
+    waiting = response.parsed_body.find { it['id'] == @set.id }
+
+    assert_equal 1, waiting.fetch('unread_message_count'), 'nothing was marked, so nothing was cleared'
+  end
+
   test 'a message with neither body nor file is refused' do
     with_exceptions_app do
       post set_messages_path(@set), params: {submission_set_message: {body: '   '}}.to_json, headers: JSON_HEADERS

--- a/test/integration/sets_test.rb
+++ b/test/integration/sets_test.rb
@@ -211,4 +211,21 @@ class GroupsTest < ActionDispatch::IntegrationTest
 
     assert_conform_schema 404
   end
+
+  # A thread is DDBJ's record of what was asked and answered, and the
+  # curator who answered has no copy anywhere else. Unlike the other two
+  # blockers there is no step that clears it, so the set stays.
+  test 'a set with a conversation on it cannot be deleted' do
+    @set.messages.create!(user: @alice, author_role: :member, body: 'A question')
+
+    get set_path(@set)
+
+    assert_equal false, response.parsed_body.fetch('deletable')
+    assert_match 'record of what was asked and answered', response.parsed_body.fetch('delete_blocked_reason')
+
+    with_exceptions_app { delete set_path(@set) }
+
+    assert_response :unprocessable_content
+    assert SubmissionSet.exists?(@set.id)
+  end
 end

--- a/test/services/my_queue_test.rb
+++ b/test/services/my_queue_test.rb
@@ -115,4 +115,103 @@ class MyQueueTest < ActiveSupport::TestCase
     assert_equal 0, req.unread_message_count_for(users(:bob))
     assert_not_includes MyQueue.unread_request_ids(users(:bob)).map(&:submission_request_id), req.id
   end
+
+  # --- the set axis -------------------------------------------------------
+  #
+  # Sets are the queue's second axis. The numbers behind the two badges
+  # and the queue's own total all come from here, and each of them was
+  # silently zeroable before these existed.
+
+  def waiting_set(author: users(:alice))
+    SubmissionSet.create!(name: 'Deep sea study', owner: users(:alice)).tap {
+      it.messages.create!(user: author, author_role: :member, body: 'Are these one submission or two?')
+    }
+  end
+
+  test 'a set with an unanswered question is in the queue, and its count is the badge' do
+    set = waiting_set
+
+    assert_equal [set], MyQueue.new(users(:bob)).sets.to_a
+    assert_equal 1,     MyQueue.new(users(:bob)).set_count
+  end
+
+  test 'the total counts both axes' do
+    unread_request
+    waiting_set
+
+    assert_equal 2, MyQueue.new(users(:bob)).count, 'one request and one set'
+  end
+
+  # Answering is the work, so it settles the set for every curator.
+  test 'a colleague answering takes it out of everybody queue' do
+    set = waiting_set
+
+    set.messages.create!(user: users(:dave), author_role: :curator, body: 'Two.')
+
+    assert_empty MyQueue.new(users(:bob)).sets.to_a
+    assert_empty MyQueue.new(users(:dave)).sets.to_a
+  end
+
+  # Reading is not answering, and it speaks for nobody else.
+  test 'marking read clears one curator and leaves the others' do
+    set     = waiting_set
+    message = set.messages.last
+
+    set.mark_read_by!(users(:bob), as: :curator, through: message.id)
+
+    assert_empty MyQueue.new(users(:bob)).sets.to_a
+    assert_equal [set], MyQueue.new(users(:dave)).sets.to_a
+  end
+
+  # The marker never moves backwards: a stale tab rendered when more was
+  # unread would otherwise resurrect everything already dealt with.
+  test 'a stale mark-read does not move the marker back' do
+    set   = waiting_set
+    first = set.messages.last
+
+    second = set.messages.create!(user: users(:alice), author_role: :member, body: 'And another thing')
+
+    set.mark_read_by!(users(:bob), as: :curator, through: second.id)
+    set.mark_read_by!(users(:bob), as: :curator, through: first.id)
+
+    assert_empty MyQueue.new(users(:bob)).sets.to_a, 'the older press must not undo the newer one'
+  end
+
+  # `through` bounds what a press can discharge to what was on screen.
+  test 'a message that landed after the page was drawn is not discharged by it' do
+    set  = waiting_set
+    seen = set.messages.last
+
+    set.messages.create!(user: users(:alice), author_role: :member, body: 'One more')
+    set.mark_read_by!(users(:bob), as: :curator, through: seen.id)
+
+    assert_equal [set], MyQueue.new(users(:bob)).sets.to_a
+  end
+
+  # Which side somebody acts from is the screen they pressed, not what
+  # their account is: a curator can be on a set's roster like anyone else.
+  test 'a curator who is also a member keeps two markers' do
+    set        = waiting_set
+    membership = set.members.create!(user: users(:bob), invited_by: users(:alice), joined_at: Time.current)
+
+    set.mark_read_by!(users(:bob), as: :member, through: set.messages.last.id)
+
+    assert_not_nil membership.reload.last_read_at, 'the member side is what a press on the member screen marks'
+    assert_equal [set], MyQueue.new(users(:bob)).sets.to_a,
+                 'and it must not discharge a curator queue entry they never saw as a curator'
+
+    set.mark_read_by!(users(:bob), as: :curator, through: set.messages.last.id)
+
+    assert_empty MyQueue.new(users(:bob)).sets.to_a
+  end
+
+  test 'the oldest question comes first' do
+    recent = waiting_set
+    older  = SubmissionSet.create!(name: 'Asked last week', owner: users(:alice))
+
+    older.messages.create!(user: users(:alice), author_role: :member, body: 'Still waiting', created_at: 7.days.ago)
+    older.touch
+
+    assert_equal [older, recent], MyQueue.new(users(:bob)).sets.to_a
+  end
 end

--- a/test/system/admin_sets_test.rb
+++ b/test/system/admin_sets_test.rb
@@ -1,0 +1,138 @@
+require 'application_system_test_case'
+
+# The curator's side of a set's conversation: finding one that is
+# waiting, answering it, and what answering does to the queue.
+#
+# The rules it holds to are the request thread's, one axis over —
+# answering settles the thread for every curator, reading settles it only
+# for the one who read it, and posting follows the set from then on.
+class AdminSetsSystemTest < ApplicationSystemTestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    sign_in_as users(:bob)
+
+    @alice = users(:alice)
+
+    # Given an address on purpose: the fixture has none, and a member we
+    # cannot reach is dropped from the mail rather than failing it — so
+    # without this the "everyone in the set hears about it" assertion
+    # below would pass for the wrong reason.
+    @carol = users(:carol)
+    @carol.update!(email: 'carol@example.com')
+
+    @set = SubmissionSet.create!(name: 'Deep sea study', owner: @alice)
+    @set.members.create!(user: @carol, invited_by: @alice, joined_at: Time.current)
+    @set.inclusions.create!(submission_request: submission_requests(:bioproject), added_by: @alice)
+  end
+
+  test 'a set waiting for an answer reaches the queue, and answering takes it out' do
+    @set.messages.create!(user: @alice, author_role: :member, body: 'Are these one submission or two?')
+
+    visit admin_my_queue_path
+
+    within '[data-test-section="sets"]' do
+      assert_text 'Deep sea study'
+      assert_text '1 submission, 2 members'
+
+      click_link 'Deep sea study'
+    end
+
+    assert_text 'Are these one submission or two?'
+
+    fill_in 'New message to the set', with: 'Two — one per organism.'
+
+    perform_enqueued_jobs do
+      click_button 'Send message'
+    end
+
+    assert_text 'Message sent to the 2 members of this set.'
+    assert_text 'Two — one per organism.'
+
+    # Both members hear about it. This is the thing that stops scaling
+    # first, and it is deliberate: everybody in the set is party to the
+    # conversation.
+    assert_equal [@alice.email, @carol.email].sort, ActionMailer::Base.deliveries.last.to.sort
+
+    visit admin_my_queue_path
+
+    assert_no_selector '[data-test-section="sets"]'
+  end
+
+  # Reading is not answering. A curator who has looked and decided there
+  # is nothing to say needs it out of their queue without it leaving
+  # everyone else's.
+  test 'marking read clears this curator and nobody else' do
+    @set.messages.create!(user: @alice, author_role: :member, body: 'No reply needed, just a note.')
+
+    visit admin_set_path(@set)
+
+    click_button 'Mark 1 message as read'
+
+    assert_text 'Marked as read.'
+
+    visit admin_my_queue_path
+    assert_no_selector '[data-test-section="sets"]'
+
+    # A colleague still has it.
+    assert_equal 1, SubmissionSet.needing_curator(users(:dave)).count
+  end
+
+  # The list is not a directory: a curator opens it to find the
+  # conversations that are waiting.
+  test 'the list filters to what is waiting and says so when nothing is' do
+    visit admin_sets_path(filter: 'waiting')
+
+    within '[data-test-empty-state="clear"]' do
+      assert_text 'Nothing waiting'
+    end
+
+    @set.messages.create!(user: @alice, author_role: :member, body: 'Anyone?')
+
+    visit admin_sets_path(filter: 'waiting')
+
+    assert_selector "[data-test-set='#{@set.id}']", text: 'Deep sea study'
+    assert_text '1 message'
+  end
+
+  # Posting follows it — including for a curator who had stopped, since
+  # stepping back in is stepping back in.
+  test 'answering follows the set' do
+    @set.messages.create!(user: @alice, author_role: :member, body: 'Anyone?')
+
+    visit admin_set_path(@set)
+
+    assert_button 'Follow'
+
+    fill_in 'New message to the set', with: 'Looking now.'
+    click_button 'Send message'
+
+    assert_button 'Unfollow'
+  end
+
+  # Both screens that list sets order by when the set was last touched,
+  # and the conversation is the only thing that touches most of them.
+  test 'a set sorts by its conversation, not by when it was renamed' do
+    quiet = SubmissionSet.create!(name: 'Renamed yesterday', owner: @alice)
+    quiet.update!(name: 'Renamed just now')
+
+    @set.messages.create!(user: @alice, author_role: :member, body: 'Anyone?')
+
+    visit admin_sets_path
+
+    names = all('tbody tr td:first-child').map(&:text)
+
+    assert_equal ['Deep sea study', 'Renamed just now'], names.first(2)
+  end
+
+  # The roster is who a message here reaches, so it belongs on the screen
+  # that sends one — and the submissions are how a curator gets from the
+  # conversation to the work.
+  test 'the thread names who is in the set and what is in it' do
+    visit admin_set_path(@set)
+
+    assert_text @alice.uid
+    assert_text @carol.uid
+    assert_link "##{submission_requests(:bioproject).id}"
+  end
+end

--- a/test/system/admin_sets_test.rb
+++ b/test/system/admin_sets_test.rb
@@ -52,7 +52,14 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
     # Both members hear about it. This is the thing that stops scaling
     # first, and it is deliberate: everybody in the set is party to the
     # conversation.
-    assert_equal [@alice.email, @carol.email].sort, ActionMailer::Base.deliveries.last.to.sort
+    #
+    # Bcc, not To: the roster shows each member the address they were
+    # invited at, and the addresses their accounts carry are not the
+    # set's to hand round.
+    mail = ActionMailer::Base.deliveries.last
+
+    assert_equal [@alice.email, @carol.email].sort, mail.bcc.sort
+    assert_equal ['repo@ddbj.nig.ac.jp'],           mail.to
 
     visit admin_my_queue_path
 
@@ -81,7 +88,7 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
   # The list is not a directory: a curator opens it to find the
   # conversations that are waiting.
   test 'the list filters to what is waiting and says so when nothing is' do
-    visit admin_sets_path(filter: 'waiting')
+    visit admin_sets_path(waiting: 1)
 
     within '[data-test-empty-state="clear"]' do
       assert_text 'Nothing waiting'
@@ -89,10 +96,49 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
 
     @set.messages.create!(user: @alice, author_role: :member, body: 'Anyone?')
 
-    visit admin_sets_path(filter: 'waiting')
+    visit admin_sets_path(waiting: 1)
 
     assert_selector "[data-test-set='#{@set.id}']", text: 'Deep sea study'
     assert_text '1 message'
+  end
+
+  # The two filters are different questions and combine. A single slot
+  # would answer "which of the ones I follow still need me?" with the
+  # wrong list rather than say it could not.
+  test 'waiting and following narrow together' do
+    @set.messages.create!(user: @alice, author_role: :member, body: 'Anyone?')
+
+    followed = SubmissionSet.create!(name: 'Followed but quiet', owner: @alice)
+    followed.subscribe! users(:bob)
+
+    visit admin_sets_path(waiting: 1)
+    assert_text 'Deep sea study'
+    assert_no_text 'Followed but quiet'
+
+    visit admin_sets_path(following: 1)
+    assert_text 'Followed but quiet'
+    assert_no_text 'Deep sea study'
+
+    visit admin_sets_path(waiting: 1, following: 1)
+
+    within '[data-test-empty-state="filtered"]' do
+      assert_text 'waiting on you and followed by you'
+    end
+
+    @set.subscribe! users(:bob)
+
+    visit admin_sets_path(waiting: 1, following: 1)
+    assert_text 'Deep sea study'
+    assert_no_text 'Followed but quiet'
+  end
+
+  # A page past the end used to render an empty table under a filter bar
+  # counting the rows that are there.
+  test 'a page past the end goes back to one that exists' do
+    visit admin_sets_path(page: 99)
+
+    assert_no_selector '[data-test-empty-state]'
+    assert_text 'Deep sea study'
   end
 
   # Posting follows it — including for a curator who had stopped, since
@@ -108,6 +154,36 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
     click_button 'Send message'
 
     assert_button 'Unfollow'
+  end
+
+  # The queue's order and the age it prints are the same fact: how long
+  # the question has been sitting. `updated_at` says "just now" for a set
+  # somebody renamed this morning, which would put a five-day-old
+  # question at the back under a heading promising the opposite.
+  test 'the queue is ordered by how long the question has been sitting' do
+    old_set = SubmissionSet.create!(name: 'Asked last week', owner: @alice)
+    old_set.messages.create!(user: @alice, author_role: :member, body: 'Still waiting', created_at: 7.days.ago)
+    old_set.update!(name: 'Asked last week, renamed just now')
+
+    @set.messages.create!(user: @alice, author_role: :member, body: 'Asked today')
+
+    visit admin_my_queue_path
+
+    within '[data-test-section="sets"]' do
+      names = all('.list-group-item strong').map(&:text)
+
+      assert_equal ['Asked last week, renamed just now', 'Deep sea study'], names
+      assert_text 'waiting 7d ago'
+    end
+  end
+
+  # An attachment control a label does not name cannot be reached by a
+  # screen reader or by a test.
+  test 'the file control on the curator form is named' do
+    visit admin_set_path(@set)
+
+    assert_selector 'label', text: 'Attach files'
+    assert_equal 'files_', find('label', text: 'Attach files')[:for]
   end
 
   # Both screens that list sets order by when the set was last touched,

--- a/test/system/admin_sets_test.rb
+++ b/test/system/admin_sets_test.rb
@@ -46,7 +46,7 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
       click_button 'Send message'
     end
 
-    assert_text 'Message sent to the 2 members of this set.'
+    assert_text 'Message sent to 2 members of this set.'
     assert_text 'Two — one per organism.'
 
     # Both members hear about it. This is the thing that stops scaling

--- a/test/system/sessions_test.rb
+++ b/test/system/sessions_test.rb
@@ -28,6 +28,15 @@ class SessionsSystemTest < ApplicationSystemTestCase
     assert_link href: WebApp.url_for
   end
 
+  # The same address, from inside. The SPA shares this origin only where a
+  # proxy puts it there — in development it is a dev server on another
+  # port, and the bare `/web/` this used to carry was a 404.
+  test 'the way back to the submitter view leaves the admin origin correctly' do
+    sign_in_as users(:bob)
+
+    assert_link 'Back to repository', href: WebApp.url_for
+  end
+
   # --- no curator access ---------------------------------------------------
 
   # A bare 403 tells somebody they are wrong without telling them what to

--- a/web/app/components/message-thread.ts
+++ b/web/app/components/message-thread.ts
@@ -1,0 +1,89 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { DirectUpload } from '@rails/activestorage';
+
+import ENV from 'repository/config/environment';
+
+import type AttentionService from 'repository/services/attention';
+import type CurrentUserService from 'repository/services/current-user';
+import type { RequestManager } from '@warp-drive/core';
+import type RouterService from '@ember/routing/router-service';
+
+// What the two conversations have in common: a draft, some files on
+// their way to storage, and what to do to the rest of the screen once
+// something has been said.
+//
+// The two threads themselves are deliberately separate components — a
+// submission's is between one submitter and DDBJ, a set's is between
+// everyone in it, and they name their speakers, count their unread and
+// address their endpoints differently. What is shared is the plumbing
+// under that, which was copied once and would have drifted.
+export default class MessageThread<S> extends Component<S> {
+  @service declare attention: AttentionService;
+  @service declare currentUser: CurrentUserService;
+  @service declare requestManager: RequestManager;
+  @service declare router: RouterService;
+
+  @tracked draft = '';
+  @tracked files: File[] = [];
+  @tracked posting = false;
+  @tracked error: string | null = null;
+
+  // The element itself, so it can be emptied after a send. Clearing
+  // `files` alone leaves the control still displaying the name of what
+  // was just sent, and the next message then goes out with nothing
+  // attached while the sender is looking at the filename they believe is
+  // on it.
+  fileInput?: HTMLInputElement;
+
+  @action
+  selectFiles(e: Event) {
+    this.fileInput = e.target as HTMLInputElement;
+    this.files = Array.from(this.fileInput.files ?? []);
+  }
+
+  // Straight to storage, the same path the submission upload itself
+  // takes. Nothing goes through the API request, so the files these
+  // conversations are about — submission files, large by nature — are
+  // not bounded by anything in front of Rails.
+  async upload(file: File) {
+    // The endpoint authenticates (it mints a blob row and a presigned
+    // PUT, which is not something to leave open), and
+    // @rails/activestorage sends only its own headers unless it is given
+    // more.
+    const upload = new DirectUpload(file, ENV.directUploadURL, undefined, this.currentUser.authorizationHeader);
+
+    return new Promise<string>((resolve, reject) => {
+      upload.create((error, blob) => (error ? reject(error) : resolve(blob!.signed_id)));
+    });
+  }
+
+  uploadDraftFiles() {
+    return Promise.all(this.files.map((file) => this.upload(file)));
+  }
+
+  clearForm() {
+    this.draft = '';
+    this.files = [];
+
+    if (this.fileInput) this.fileInput.value = '';
+  }
+
+  // The panels around a thread are rendered from counts the route
+  // fetched, so dealing with the thread has to send the route back for
+  // them — otherwise a notice stays up over a conversation that has just
+  // been answered, and only the button vanishes.
+  async settle() {
+    await this.router.refresh();
+
+    void this.attention.refresh();
+  }
+
+  // Storage going away is not hypothetical — a dev SeaweedFS
+  // crash-looped unnoticed for a fortnight — and the only signal a
+  // silent failure gives is that the button came back and nothing
+  // happened.
+  static readonly SEND_FAILED = 'Could not send. The file may not have uploaded — check your connection and try again.';
+}

--- a/web/app/components/set-messages.gts
+++ b/web/app/components/set-messages.gts
@@ -1,20 +1,15 @@
-import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
-import { service } from '@ember/service';
+import { modifier } from 'ember-modifier';
 import { uniqueId } from '@ember/helper';
-import { DirectUpload } from '@rails/activestorage';
+import { Textarea } from '@ember/component';
 
 import DownloadLink from 'repository/components/download-link';
+import MessageThread from 'repository/components/message-thread';
 import formatDatetime from 'repository/helpers/format-datetime';
 import humanSize from 'repository/helpers/human-size';
-import ENV from 'repository/config/environment';
 
-import type AttentionService from 'repository/services/attention';
-import type CurrentUserService from 'repository/services/current-user';
-import type { RequestManager } from '@warp-drive/core';
-import type RouterService from '@ember/routing/router-service';
 import type { paths } from 'schema/openapi';
 
 type MessagesResponse = paths['/sets/{set_id}/messages']['get']['responses']['200']['content']['application/json'];
@@ -43,36 +38,35 @@ interface Signature {
 // and are on each submission's own page; being able to read somebody's
 // submission through a shared set is not being party to what they were
 // asked about it.
-export default class SetMessages extends Component<Signature> {
-  @service declare attention: AttentionService;
-  @service declare currentUser: CurrentUserService;
-  @service declare requestManager: RequestManager;
-  @service declare router: RouterService;
-
+export default class SetMessages extends MessageThread<Signature> {
   @tracked messages: Message[] = [];
-  @tracked draft = '';
-  @tracked files: File[] = [];
 
-  // The element itself, so it can be emptied after a send — clearing
-  // `files` alone leaves the control showing the name of what was just
-  // sent, and the next message goes out with nothing attached while the
-  // sender is looking at the filename they believe is on it.
-  fileInput?: HTMLInputElement;
-  @tracked posting = false;
-  @tracked error: string | null = null;
+  // Which set the messages on screen belong to. Ember reuses a component
+  // instance when the model changes under the same route, so loading
+  // once at construction would leave one set's thread rendered under
+  // another set's name — in a feature whose whole premise is who is
+  // party to which conversation.
+  #loaded?: number;
 
-  constructor(owner: unknown, args: Signature['Args']) {
-    // @ts-expect-error -- Glimmer Component owner typing
-    super(owner, args);
+  reload = modifier((_element: Element, [setId]: [number]) => {
+    if (this.#loaded === setId) return;
+
+    this.#loaded = setId;
+    this.messages = [];
+
     void this.load();
-  }
+  });
 
   async load() {
+    const setId = this.args.setId;
+
     const { content } = await this.requestManager.request<MessagesResponse>({
-      url: `/sets/${this.args.setId}/messages`,
+      url: `/sets/${setId}/messages`,
     });
 
-    this.messages = content;
+    // A slower answer for the set we have left must not land on the one
+    // we are looking at.
+    if (setId === this.args.setId) this.messages = content;
   }
 
   // Acknowledges what is on screen, not whatever has arrived since.
@@ -80,46 +74,34 @@ export default class SetMessages extends Component<Signature> {
     return this.messages.at(-1)?.id;
   }
 
+  get unreadShown() {
+    return Boolean(this.args.unreadCount) && Boolean(this.newestMessageId);
+  }
+
   @action
   async markRead() {
-    await this.requestManager.request({
-      url: `/sets/${this.args.setId}/messages/read`,
-      method: 'POST',
-      data: { through_id: this.newestMessageId },
-      options: { reportErrors: false },
-    });
+    // Nothing to acknowledge until the thread has arrived: without an id
+    // the server falls back to "now" and would discharge messages this
+    // reader has not seen — the exact thing `through_id` exists to stop.
+    if (!this.newestMessageId) return;
 
-    await this.settle();
-  }
+    this.error = null;
 
-  // The count above this thread comes from the route's copy of the set,
-  // so discharging the thread has to send the route back for it.
-  async settle() {
-    await this.router.refresh();
+    try {
+      await this.requestManager.request({
+        url: `/sets/${this.args.setId}/messages/read`,
+        method: 'POST',
+        data: { through_id: this.newestMessageId },
+        options: { reportErrors: false },
+      });
 
-    void this.attention.refresh();
-  }
-
-  @action
-  updateDraft(e: Event) {
-    this.draft = (e.target as HTMLTextAreaElement).value;
-  }
-
-  @action
-  selectFiles(e: Event) {
-    this.fileInput = e.target as HTMLInputElement;
-    this.files = Array.from(this.fileInput.files ?? []);
-  }
-
-  // Straight to storage, like every other upload here: the files this
-  // conversation is about are submission files, and nothing about them
-  // should be bounded by a request body.
-  async upload(file: File) {
-    const upload = new DirectUpload(file, ENV.directUploadURL, undefined, this.currentUser.authorizationHeader);
-
-    return new Promise<string>((resolve, reject) => {
-      upload.create((error, blob) => (error ? reject(error) : resolve(blob!.signed_id)));
-    });
+      // Both: the count above comes from the route, and anything posted
+      // while this page was open is still missing from the thread.
+      await this.load();
+      await this.settle();
+    } catch {
+      this.error = 'Could not mark it read. Try again.';
+    }
   }
 
   isMine = (m: Message) => m.author_role === 'member' && m.author_uid === this.currentUser.user?.uid;
@@ -137,7 +119,7 @@ export default class SetMessages extends Component<Signature> {
     this.error = null;
 
     try {
-      const files = await Promise.all(this.files.map((file) => this.upload(file)));
+      const files = await this.uploadDraftFiles();
 
       const { content } = await this.requestManager.request<CreateMessageResponse>({
         url: `/sets/${this.args.setId}/messages`,
@@ -148,28 +130,25 @@ export default class SetMessages extends Component<Signature> {
 
       this.messages = [...this.messages, content];
 
-      this.draft = '';
-      this.files = [];
-
-      if (this.fileInput) this.fileInput.value = '';
+      this.clearForm();
 
       await this.settle();
     } catch {
-      this.error = 'Could not send. The file may not have uploaded — check your connection and try again.';
+      this.error = SetMessages.SEND_FAILED;
     } finally {
       this.posting = false;
     }
   }
 
   <template>
-    <section class="mt-4" data-test-set-messages>
+    <section class="mt-4" data-test-set-messages {{this.reload @setId}}>
       <div class="d-flex align-items-baseline gap-3 flex-wrap">
         <h2 class="h5">Messages about this set</h2>
 
         {{! The other way to deal with a thread: a curator's note that
         needs no reply would otherwise sit here for ever. Per member —
         marking it read speaks for nobody else in the set. }}
-        {{#if @unreadCount}}
+        {{#if this.unreadShown}}
           <button
             type="button"
             class="btn btn-outline-secondary btn-sm"
@@ -241,12 +220,7 @@ export default class SetMessages extends Component<Signature> {
         <div class="mb-3">
           {{#let (uniqueId) as |id|}}
             <label for={{id}} class="form-label">Write to the set</label>
-            <textarea
-              id={{id}}
-              class="form-control font-monospace small textarea-autogrow"
-              value={{this.draft}}
-              {{on "input" this.updateDraft}}
-            ></textarea>
+            <Textarea id={{id}} class="form-control font-monospace small textarea-autogrow" @value={{this.draft}} />
           {{/let}}
         </div>
 

--- a/web/app/components/set-messages.gts
+++ b/web/app/components/set-messages.gts
@@ -1,0 +1,274 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+import { service } from '@ember/service';
+import { uniqueId } from '@ember/helper';
+import { DirectUpload } from '@rails/activestorage';
+
+import DownloadLink from 'repository/components/download-link';
+import formatDatetime from 'repository/helpers/format-datetime';
+import humanSize from 'repository/helpers/human-size';
+import ENV from 'repository/config/environment';
+
+import type AttentionService from 'repository/services/attention';
+import type CurrentUserService from 'repository/services/current-user';
+import type { RequestManager } from '@warp-drive/core';
+import type RouterService from '@ember/routing/router-service';
+import type { paths } from 'schema/openapi';
+
+type MessagesResponse = paths['/sets/{set_id}/messages']['get']['responses']['200']['content']['application/json'];
+
+type CreateMessageResponse =
+  paths['/sets/{set_id}/messages']['post']['responses']['201']['content']['application/json'];
+
+type Message = MessagesResponse[number];
+
+interface Signature {
+  Args: {
+    setId: number;
+
+    // How many messages are waiting on this member, as the server counts
+    // it. The thread itself cannot say: a message carries no `read_at`
+    // here, because where each member has got to is a fact about the
+    // person rather than about the message.
+    unreadCount: number;
+  };
+}
+
+// The set's own conversation — one thread about the bundle, which every
+// member of the set reads and writes.
+//
+// Not the submissions' threads. Those stay between their owner and DDBJ,
+// and are on each submission's own page; being able to read somebody's
+// submission through a shared set is not being party to what they were
+// asked about it.
+export default class SetMessages extends Component<Signature> {
+  @service declare attention: AttentionService;
+  @service declare currentUser: CurrentUserService;
+  @service declare requestManager: RequestManager;
+  @service declare router: RouterService;
+
+  @tracked messages: Message[] = [];
+  @tracked draft = '';
+  @tracked files: File[] = [];
+
+  // The element itself, so it can be emptied after a send — clearing
+  // `files` alone leaves the control showing the name of what was just
+  // sent, and the next message goes out with nothing attached while the
+  // sender is looking at the filename they believe is on it.
+  fileInput?: HTMLInputElement;
+  @tracked posting = false;
+  @tracked error: string | null = null;
+
+  constructor(owner: unknown, args: Signature['Args']) {
+    // @ts-expect-error -- Glimmer Component owner typing
+    super(owner, args);
+    void this.load();
+  }
+
+  async load() {
+    const { content } = await this.requestManager.request<MessagesResponse>({
+      url: `/sets/${this.args.setId}/messages`,
+    });
+
+    this.messages = content;
+  }
+
+  // Acknowledges what is on screen, not whatever has arrived since.
+  get newestMessageId() {
+    return this.messages.at(-1)?.id;
+  }
+
+  @action
+  async markRead() {
+    await this.requestManager.request({
+      url: `/sets/${this.args.setId}/messages/read`,
+      method: 'POST',
+      data: { through_id: this.newestMessageId },
+      options: { reportErrors: false },
+    });
+
+    await this.settle();
+  }
+
+  // The count above this thread comes from the route's copy of the set,
+  // so discharging the thread has to send the route back for it.
+  async settle() {
+    await this.router.refresh();
+
+    void this.attention.refresh();
+  }
+
+  @action
+  updateDraft(e: Event) {
+    this.draft = (e.target as HTMLTextAreaElement).value;
+  }
+
+  @action
+  selectFiles(e: Event) {
+    this.fileInput = e.target as HTMLInputElement;
+    this.files = Array.from(this.fileInput.files ?? []);
+  }
+
+  // Straight to storage, like every other upload here: the files this
+  // conversation is about are submission files, and nothing about them
+  // should be bounded by a request body.
+  async upload(file: File) {
+    const upload = new DirectUpload(file, ENV.directUploadURL, undefined, this.currentUser.authorizationHeader);
+
+    return new Promise<string>((resolve, reject) => {
+      upload.create((error, blob) => (error ? reject(error) : resolve(blob!.signed_id)));
+    });
+  }
+
+  isMine = (m: Message) => m.author_role === 'member' && m.author_uid === this.currentUser.user?.uid;
+
+  @action
+  async submit(e: Event) {
+    e.preventDefault();
+
+    const body = this.draft.trim();
+
+    // An attachment on its own is a real thing to send.
+    if ((!body && this.files.length === 0) || this.posting) return;
+
+    this.posting = true;
+    this.error = null;
+
+    try {
+      const files = await Promise.all(this.files.map((file) => this.upload(file)));
+
+      const { content } = await this.requestManager.request<CreateMessageResponse>({
+        url: `/sets/${this.args.setId}/messages`,
+        method: 'POST',
+        data: { submission_set_message: { body, files } },
+        options: { reportErrors: false },
+      });
+
+      this.messages = [...this.messages, content];
+
+      this.draft = '';
+      this.files = [];
+
+      if (this.fileInput) this.fileInput.value = '';
+
+      await this.settle();
+    } catch {
+      this.error = 'Could not send. The file may not have uploaded — check your connection and try again.';
+    } finally {
+      this.posting = false;
+    }
+  }
+
+  <template>
+    <section class="mt-4" data-test-set-messages>
+      <div class="d-flex align-items-baseline gap-3 flex-wrap">
+        <h2 class="h5">Messages about this set</h2>
+
+        {{! The other way to deal with a thread: a curator's note that
+        needs no reply would otherwise sit here for ever. Per member —
+        marking it read speaks for nobody else in the set. }}
+        {{#if @unreadCount}}
+          <button
+            type="button"
+            class="btn btn-outline-secondary btn-sm"
+            data-test-mark-read
+            {{on "click" this.markRead}}
+          >Mark as read</button>
+        {{/if}}
+      </div>
+
+      <p class="text-body-secondary small">
+        Everyone in this set can read and write here, and every message is emailed to all of them. A question about one
+        submission belongs on that submission instead — those conversations stay between its owner and DDBJ.
+      </p>
+
+      {{! Speaker by side and colour, as on a submission's thread: the
+      curator sits left with an avatar, the members sit indented. Which
+      member wrote it is named — unlike a submission's thread, where every
+      non-curator message is by definition the owner's. }}
+      {{#if this.messages.length}}
+        <ul class="list-unstyled mb-3 d-flex flex-column gap-3">
+          {{#each this.messages as |m|}}
+            <li class="d-flex gap-3 {{unless (isCurator m) 'ps-5'}}">
+              {{#if (isCurator m)}}
+                <span
+                  class="message-avatar badge rounded-circle text-bg-dark d-flex align-items-center justify-content-center"
+                  aria-hidden="true"
+                >DC</span>
+              {{/if}}
+
+              <div
+                class="flex-fill border rounded p-3
+                  {{if (isCurator m) 'bg-body-tertiary' 'bg-primary-subtle border-primary-subtle'}}"
+              >
+                <div class="d-flex justify-content-between small text-body-secondary mb-1">
+                  <strong class="text-body">
+                    {{#if (isCurator m)}}
+                      DDBJ curator
+                    {{else if (this.isMine m)}}
+                      You
+                    {{else}}
+                      {{m.author_uid}}
+                    {{/if}}
+                  </strong>
+
+                  <span>{{formatDatetime m.created_at}}</span>
+                </div>
+
+                <div class="text-pre-wrap">{{m.body}}</div>
+
+                {{#if m.files.length}}
+                  <ul class="list-unstyled mb-0 mt-2 small">
+                    {{#each m.files as |file|}}
+                      <li>
+                        <DownloadLink @url={{file.url}} @filename={{file.filename}} />
+                        <span class="text-body-secondary">{{humanSize file.byte_size}}</span>
+                      </li>
+                    {{/each}}
+                  </ul>
+                {{/if}}
+              </div>
+            </li>
+          {{/each}}
+        </ul>
+      {{else}}
+        <p class="text-body-secondary fst-italic">No messages yet.</p>
+      {{/if}}
+
+      <form {{on "submit" this.submit}}>
+        <div class="mb-3">
+          {{#let (uniqueId) as |id|}}
+            <label for={{id}} class="form-label">Write to the set</label>
+            <textarea
+              id={{id}}
+              class="form-control font-monospace small textarea-autogrow"
+              value={{this.draft}}
+              {{on "input" this.updateDraft}}
+            ></textarea>
+          {{/let}}
+        </div>
+
+        <div class="mb-3">
+          {{#let (uniqueId) as |id|}}
+            <label for={{id}} class="form-label">Attach files</label>
+            <input id={{id}} type="file" multiple class="form-control" {{on "change" this.selectFiles}} />
+          {{/let}}
+        </div>
+
+        <button type="submit" class="btn btn-primary" disabled={{this.posting}}>
+          {{if this.posting "Sending..." "Send message"}}
+        </button>
+
+        {{#if this.error}}
+          <div class="alert alert-warning mt-3 mb-0" data-test-error>{{this.error}}</div>
+        {{/if}}
+      </form>
+    </section>
+  </template>
+}
+
+function isCurator(m: Message): boolean {
+  return m.author_role === 'curator';
+}

--- a/web/app/components/set-messages.gts
+++ b/web/app/components/set-messages.gts
@@ -159,8 +159,9 @@ export default class SetMessages extends MessageThread<Signature> {
       </div>
 
       <p class="text-body-secondary small">
-        Everyone in this set can read and write here, and every message is emailed to all of them. A question about one
-        submission belongs on that submission instead — those conversations stay between its owner and DDBJ.
+        Everyone in this set can read and write here, and every message is emailed to the others and to the DDBJ
+        curators following the set. A question about one submission belongs on that submission instead — those
+        conversations stay between its owner and DDBJ.
       </p>
 
       {{! Speaker by side and colour, as on a submission's thread: the

--- a/web/app/components/submission-messages.gts
+++ b/web/app/components/submission-messages.gts
@@ -1,21 +1,15 @@
-import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
-import { service } from '@ember/service';
-import { DirectUpload } from '@rails/activestorage';
+import { Textarea } from '@ember/component';
 
 import DownloadLink from 'repository/components/download-link';
+import MessageThread from 'repository/components/message-thread';
 import { uniqueId } from '@ember/helper';
 
 import formatDatetime from 'repository/helpers/format-datetime';
 import humanSize from 'repository/helpers/human-size';
-import ENV from 'repository/config/environment';
 
-import type AttentionService from 'repository/services/attention';
-import type CurrentUserService from 'repository/services/current-user';
-import type { RequestManager } from '@warp-drive/core';
-import type RouterService from '@ember/routing/router-service';
 import type { paths } from 'schema/openapi';
 
 type MessagesResponse =
@@ -32,24 +26,8 @@ interface Signature {
   };
 }
 
-export default class SubmissionMessages extends Component<Signature> {
-  @service declare attention: AttentionService;
-  @service declare currentUser: CurrentUserService;
-  @service declare requestManager: RequestManager;
-  @service declare router: RouterService;
-
+export default class SubmissionMessages extends MessageThread<Signature> {
   @tracked messages: Message[] = [];
-  @tracked draft = '';
-  @tracked files: File[] = [];
-
-  // The element itself, so it can be emptied after a send. Clearing
-  // `files` alone leaves the control still displaying the name of what
-  // was just sent, and the next message then goes out with nothing
-  // attached while the sender is looking at the filename they believe is
-  // on it.
-  fileInput?: HTMLInputElement;
-  @tracked posting = false;
-  @tracked error: string | null = null;
 
   constructor(owner: unknown, args: Signature['Args']) {
     // @ts-expect-error -- Glimmer Component owner typing
@@ -91,42 +69,6 @@ export default class SubmissionMessages extends Component<Signature> {
     await this.settle();
   }
 
-  // The panel above this thread is rendered from counts the route
-  // fetched, so discharging the thread has to send the route back for
-  // them — otherwise "A curator has a question … reply below" stays up
-  // over a thread that was just answered, and only the button vanishes.
-  async settle() {
-    await this.router.refresh();
-
-    void this.attention.refresh();
-  }
-
-  @action
-  updateDraft(e: Event) {
-    this.draft = (e.target as HTMLTextAreaElement).value;
-  }
-
-  @action
-  selectFiles(e: Event) {
-    this.fileInput = e.target as HTMLInputElement;
-    this.files = Array.from(this.fileInput.files ?? []);
-  }
-
-  // Straight to storage, the same path the submission upload itself
-  // takes. Nothing goes through the API request, so the files this
-  // conversation is about — submission files, large by nature — are not
-  // bounded by anything in front of Rails.
-  async upload(file: File) {
-    // The endpoint authenticates now (it mints a blob row and a presigned
-    // PUT, which is not something to leave open), and @rails/activestorage
-    // sends only its own headers unless it is given more.
-    const upload = new DirectUpload(file, ENV.directUploadURL, undefined, this.currentUser.authorizationHeader);
-
-    return new Promise<string>((resolve, reject) => {
-      upload.create((error, blob) => (error ? reject(error) : resolve(blob!.signed_id)));
-    });
-  }
-
   @action
   async submit(e: Event) {
     e.preventDefault();
@@ -141,7 +83,7 @@ export default class SubmissionMessages extends Component<Signature> {
     this.error = null;
 
     try {
-      const files = await Promise.all(this.files.map((file) => this.upload(file)));
+      const files = await this.uploadDraftFiles();
 
       const { content } = await this.requestManager.request<CreateMessageResponse>({
         url: `/submission_requests/${this.args.requestId}/messages`,
@@ -161,18 +103,11 @@ export default class SubmissionMessages extends Component<Signature> {
         content,
       ];
 
-      this.draft = '';
-      this.files = [];
-
-      if (this.fileInput) this.fileInput.value = '';
+      this.clearForm();
 
       await this.settle();
     } catch {
-      // Storage going away is not hypothetical here — a dev SeaweedFS
-      // crash-looped unnoticed for a fortnight — and the only signal a
-      // silent failure gives is that the button came back and nothing
-      // happened.
-      this.error = 'Could not send. The file may not have uploaded — check your connection and try again.';
+      this.error = SubmissionMessages.SEND_FAILED;
     } finally {
       this.posting = false;
     }
@@ -246,12 +181,10 @@ export default class SubmissionMessages extends Component<Signature> {
         <div class="mb-3">
           {{#let (uniqueId) as |id|}}
             <label for={{id}} class="form-label">Reply to the curator</label>
-            <textarea
-              id={{id}}
-              class="form-control font-monospace small textarea-autogrow"
-              value={{this.draft}}
-              {{on "input" this.updateDraft}}
-            ></textarea>
+            {{! `<Textarea @value>` rather than a bare element: an HTML
+            textarea whose content starts with a newline loses it, so a
+            draft beginning with a blank line comes back one line short. }}
+            <Textarea id={{id}} class="form-control font-monospace small textarea-autogrow" @value={{this.draft}} />
           {{/let}}
         </div>
 
@@ -265,6 +198,13 @@ export default class SubmissionMessages extends Component<Signature> {
         <button type="submit" class="btn btn-primary" disabled={{this.posting}}>
           {{if this.posting "Sending..." "Send message"}}
         </button>
+
+        {{! It was set and never shown: a failed send left the button
+        coming back and nothing else happening, which is exactly what a
+        lost message looks like from the sender's side. }}
+        {{#if this.error}}
+          <div class="alert alert-warning mt-3 mb-0" data-test-error>{{this.error}}</div>
+        {{/if}}
       </form>
     </section>
   </template>

--- a/web/app/services/attention.ts
+++ b/web/app/services/attention.ts
@@ -23,6 +23,12 @@ export default class AttentionService extends Service {
 
   @tracked requests: AttentionRequest[] = [];
 
+  // The set axis, as one number. Sets are not in the band — every word
+  // of it is about the reader's own submissions — but a conversation
+  // waiting on them has to be visible from wherever they are, which is
+  // what the badge on the Sets link is for.
+  @tracked setsWaiting = 0;
+
   // Two refreshes race on every visit to a request: one on navigation, one
   // after the thread fetch that marks its messages read. Whichever was
   // issued last is the one that saw the newest state, so an older response
@@ -38,17 +44,25 @@ export default class AttentionService extends Service {
 
     if (!this.currentUser.isLoggedIn) {
       this.requests = [];
+      this.setsWaiting = 0;
+
       return;
     }
 
     try {
       const { content } = await this.requestManager.request<Attention>({ url: '/attention' });
 
-      if (generation === this.#generation) this.requests = content.requests;
+      if (generation === this.#generation) {
+        this.requests = content.requests;
+        this.setsWaiting = content.sets_waiting;
+      }
     } catch {
       // A banner is an aid, not the task. Losing it must never take the
       // page down with it.
-      if (generation === this.#generation) this.requests = [];
+      if (generation === this.#generation) {
+        this.requests = [];
+        this.setsWaiting = 0;
+      }
     }
   }
 }

--- a/web/app/templates/application.gts
+++ b/web/app/templates/application.gts
@@ -9,6 +9,7 @@ import ENV from 'repository/config/environment';
 import AttentionBanner from 'repository/components/attention-banner';
 import ErrorMessage from 'repository/components/error-message';
 
+import type AttentionService from 'repository/services/attention';
 import type CurrentUserService from 'repository/services/current-user';
 import type ErrorModalService from 'repository/services/error-modal';
 import type LoadingService from 'repository/services/loading';
@@ -18,6 +19,7 @@ const adminURL = ENV.adminURL;
 const authURL = ENV.authURL;
 
 export default class extends Component {
+  @service declare attention: AttentionService;
   @service declare currentUser: CurrentUserService;
   @service declare errorModal: ErrorModalService;
   @service declare loading: LoadingService;
@@ -45,7 +47,19 @@ export default class extends Component {
               </li>
 
               <li class="nav-item">
-                <LinkTo @route="sets" class="nav-link">Sets</LinkTo>
+                <LinkTo @route="sets" class="nav-link">
+                  Sets
+
+                  {{! A conversation waiting on this member, from
+                  wherever they are. The band above the page is about
+                  their own submissions and says so in every word, so a
+                  set does not belong in it. }}
+                  {{#if this.attention.setsWaiting}}
+                    <span class="badge text-bg-danger ms-1" data-test-sets-waiting>
+                      {{this.attention.setsWaiting}}
+                    </span>
+                  {{/if}}
+                </LinkTo>
               </li>
 
               {{#if this.currentUser.user.isAdmin}}

--- a/web/app/templates/set.gts
+++ b/web/app/templates/set.gts
@@ -9,6 +9,7 @@ import { pageTitle } from 'ember-page-title';
 
 import Breadcrumb from 'repository/components/breadcrumb';
 import Pagination from 'repository/components/pagination';
+import SetMessages from 'repository/components/set-messages';
 import dbLabel from 'repository/helpers/db-label';
 import formatDatetime from 'repository/helpers/format-datetime';
 import { requestState, stateLabel, toneClasses } from 'repository/utils/request-state';
@@ -613,5 +614,9 @@ export default class extends Component<Signature> {
         </div>
       {{/if}}
     </section>
+
+    {{! The set's own conversation, below what it holds — the thread is
+    about the bundle, so it reads after the bundle. }}
+    <SetMessages @setId={{this.submissionSet.id}} @unreadCount={{this.submissionSet.unread_message_count}} />
   </template>
 }

--- a/web/app/templates/set.gts
+++ b/web/app/templates/set.gts
@@ -328,20 +328,26 @@ export default class extends Component<Signature> {
 
       {{#if this.submissionSet.owned}}
         <div class="text-end">
-          <button
-            type="button"
-            class="btn btn-warning"
-            disabled={{this.deleteDisabled}}
-            title={{this.deleteHint}}
-            data-test-delete
-            {{on "click" this.deleteSet}}
-          >
-            Delete set
-          </button>
+          {{#let (uniqueId) as |hintId|}}
+            {{! The reason is a description, not the button's name: with
+            it in `title` the control announced itself as a paragraph of
+            prose, and "Delete set" — the thing it does — was never
+            spoken. }}
+            <button
+              type="button"
+              class="btn btn-warning"
+              disabled={{this.deleteDisabled}}
+              aria-describedby={{if this.deleteHint hintId}}
+              data-test-delete
+              {{on "click" this.deleteSet}}
+            >
+              Delete set
+            </button>
 
-          {{#if this.deleteHint}}
-            <p class="form-text mb-0 delete-hint">{{this.deleteHint}}</p>
-          {{/if}}
+            {{#if this.deleteHint}}
+              <p id={{hintId}} class="form-text mb-0 delete-hint">{{this.deleteHint}}</p>
+            {{/if}}
+          {{/let}}
         </div>
       {{/if}}
     </div>

--- a/web/app/templates/sets.gts
+++ b/web/app/templates/sets.gts
@@ -80,8 +80,8 @@ export default class extends Component<Signature> {
 
     <p class="text-body-secondary prose mb-4">
       A set is submissions that belong together — the ones behind a paper, a study, a piece of work — and the people
-      they belong to. Everyone in a set can see the submissions in it and how far along they are. What goes in stays
-      each person's own decision.
+      they belong to. Everyone in a set can see the submissions in it and how far along they are, and each set has one
+      conversation with DDBJ about the whole of it. What goes in stays each person's own decision.
     </p>
 
     {{#if @model.length}}
@@ -90,7 +90,18 @@ export default class extends Component<Signature> {
           <LinkTo @route="set" @model={{set.id}} class="list-group-item list-group-item-action">
             <div class="d-flex justify-content-between align-items-start">
               <div>
-                <div class="fw-semibold">{{set.name}}</div>
+                <div class="fw-semibold">
+                  {{set.name}}
+
+                  {{! Red because it is a fact about the data — somebody
+                  is waiting on this set and nobody in it has answered. }}
+                  {{#if set.unread_message_count}}
+                    <span class="badge text-bg-danger ms-1" data-test-unread>
+                      {{set.unread_message_count}}
+                      {{if (eq set.unread_message_count 1) "message" "messages"}}
+                    </span>
+                  {{/if}}
+                </div>
 
                 <div class="small text-body-secondary">
                   Created by

--- a/web/tests/acceptance/attention-test.gts
+++ b/web/tests/acceptance/attention-test.gts
@@ -33,6 +33,7 @@ module('Acceptance | attention banner', function (hooks) {
     worker.use(
       http.get('/attention', ({ response }) => {
         return response(200).json({
+          sets_waiting: 0,
           requests: [
             { id: 42, db: 'biosample', source_id: 'SSUB000123', reason: 'unread_message' },
             { id: 7, db: 'bioproject', source_id: null, reason: 'ready_to_apply' },
@@ -53,6 +54,7 @@ module('Acceptance | attention banner', function (hooks) {
     worker.use(
       http.get('/attention', ({ response }) => {
         return response(200).json({
+          sets_waiting: 0,
           requests: [{ id: 42, db: 'st26', source_id: null, reason: 'validation_failed' }],
         });
       }),
@@ -72,6 +74,7 @@ module('Acceptance | attention banner', function (hooks) {
     worker.use(
       http.get('/attention', ({ response }) => {
         return response(200).json({
+          sets_waiting: 0,
           requests: answered ? [] : [{ id: 42, db: 'st26', source_id: null, reason: 'unread_message' }],
         });
       }),

--- a/web/tests/acceptance/bulk-add-to-set-test.gts
+++ b/web/tests/acceptance/bulk-add-to-set-test.gts
@@ -50,6 +50,7 @@ const mine: SetSummary = {
   member_count: 1,
   invited_count: 0,
   submission_count: 0,
+  unread_message_count: 0,
 };
 
 const rows = [summary(1), summary(2), summary(3)];

--- a/web/tests/acceptance/home-test.gts
+++ b/web/tests/acceptance/home-test.gts
@@ -170,7 +170,10 @@ module('Acceptance | home', function (hooks) {
 
     worker.use(
       http.get('/attention', ({ response }) =>
-        response(200).json({ requests: [{ id: 7, db: 'biosample', source_id: null, reason: 'ready_to_apply' }] }),
+        response(200).json({
+          sets_waiting: 0,
+          requests: [{ id: 7, db: 'biosample', source_id: null, reason: 'ready_to_apply' }],
+        }),
       ),
 
       http.get('/submission_requests', ({ request, response }) => {

--- a/web/tests/acceptance/invitation-test.gts
+++ b/web/tests/acceptance/invitation-test.gts
@@ -27,6 +27,7 @@ const joined = {
   member_count: 2,
   invited_count: 0,
   submission_count: 0,
+  unread_message_count: 0,
 };
 
 // WebsController injects this into the shell per environment; a test

--- a/web/tests/acceptance/set-conversation-test.gts
+++ b/web/tests/acceptance/set-conversation-test.gts
@@ -1,0 +1,148 @@
+import { module, test } from 'qunit';
+import { visit, click, fillIn } from '@ember/test-helpers';
+import { setupApplicationTest } from 'repository/tests/helpers';
+import { setupAuthentication } from 'repository/tests/helpers/setup-auth';
+
+import { http } from '../msw/http';
+import { worker } from '../msw/worker';
+
+import type { components } from 'schema/openapi';
+
+type Set = components['schemas']['Set'];
+type SetMessage = components['schemas']['SetMessage'];
+
+const now = '2025-01-01T00:00:00.000Z';
+
+function set(overrides: Partial<Set> = {}): Set {
+  return {
+    id: 7,
+    name: 'Deep sea study',
+    owner_uid: 'test-user',
+    owned: true,
+    created_at: now,
+    member_count: 2,
+    invited_count: 0,
+    submission_count: 0,
+    unread_message_count: 0,
+    deletable: true,
+    delete_blocked_reason: null,
+    members: [],
+    submissions: [],
+    ...overrides,
+  };
+}
+
+function message(overrides: Partial<SetMessage> = {}): SetMessage {
+  return {
+    id: 1,
+    body: 'Are these two projects one submission or two?',
+    author_role: 'member',
+    author_uid: 'test-user',
+    created_at: now,
+    files: [],
+    ...overrides,
+  };
+}
+
+// The set's own thread: one conversation about the bundle, which every
+// member reads and writes. The submissions' own threads are not part of
+// it — those stay between their owner and DDBJ.
+module('Acceptance | the conversation about a set', function (hooks) {
+  setupApplicationTest(hooks);
+  setupAuthentication(hooks);
+
+  test('the thread names which member wrote what, and marks your own', async function (assert) {
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => response(200).json(set())),
+
+      http.get('/sets/{set_id}/messages', ({ response }) =>
+        response(200).json([
+          message({ id: 1, author_uid: 'test-user', body: 'Are these one submission or two?' }),
+          message({ id: 2, author_role: 'curator', author_uid: 'bob', body: 'Two — one per organism.' }),
+          message({ id: 3, author_uid: 'colleague', body: 'Thanks, I will split mine.' }),
+        ]),
+      ),
+    );
+
+    await visit('/sets/7');
+
+    const authors = [...document.querySelectorAll('[data-test-set-messages] li strong')].map((el) =>
+      el.textContent?.trim(),
+    );
+
+    assert.deepEqual(authors, ['You', 'DDBJ curator', 'colleague'], 'a set has more than one voice on its side');
+  });
+
+  test('posting sends the body and appends what came back', async function (assert) {
+    let posted: string | undefined;
+
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => response(200).json(set())),
+
+      http.get('/sets/{set_id}/messages', ({ response }) => response(200).json([])),
+
+      http.post('/sets/{set_id}/messages', async ({ request, response }) => {
+        posted = (await request.json()).submission_set_message.body;
+
+        return response(201).json(message({ id: 9, body: 'Both, actually.' }));
+      }),
+    );
+
+    await visit('/sets/7');
+
+    assert.dom('[data-test-set-messages]').includesText('No messages yet');
+
+    await fillIn('[data-test-set-messages] textarea', 'Both, actually.');
+    await click('[data-test-set-messages] button[type="submit"]');
+
+    assert.strictEqual(posted, 'Both, actually.');
+    assert.dom('[data-test-set-messages]').includesText('Both, actually.');
+    assert.dom('[data-test-set-messages] textarea').hasValue('');
+  });
+
+  // Reading is not answering, and the count is the server's: a message
+  // here carries no read mark, because where each member has got to is a
+  // fact about the person rather than about the message.
+  test('a note that needs no reply is dealt with explicitly', async function (assert) {
+    let read = false;
+
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => response(200).json(set({ unread_message_count: read ? 0 : 1 }))),
+
+      http.get('/sets/{set_id}/messages', ({ response }) =>
+        response(200).json([message({ author_role: 'curator', author_uid: 'bob', body: 'For your information.' })]),
+      ),
+
+      http.post('/sets/{set_id}/messages/read', ({ response }) => {
+        read = true;
+
+        return response(204).empty();
+      }),
+    );
+
+    await visit('/sets/7');
+
+    assert.dom('[data-test-set-messages] [data-test-mark-read]').exists();
+
+    await click('[data-test-set-messages] [data-test-mark-read]');
+
+    assert.true(read);
+    assert.dom('[data-test-set-messages] [data-test-mark-read]').doesNotExist();
+  });
+
+  // A badge on a row is only visible if that row is on the page in front
+  // of you. The nav carries it from wherever the member happens to be.
+  test('a set waiting on you is visible from any screen', async function (assert) {
+    worker.use(
+      http.get('/attention', ({ response }) => response(200).json({ requests: [], sets_waiting: 2 })),
+
+      http.get('/submission_requests', ({ response }) =>
+        response(200).json([], { headers: { 'Total-Pages': '1', 'Unfinished-Count': '0', 'Finished-Count': '0' } }),
+      ),
+    );
+
+    await visit('/');
+
+    assert.dom('[data-test-sets-waiting]').hasText('2');
+  });
+});

--- a/web/tests/acceptance/set-conversation-test.gts
+++ b/web/tests/acceptance/set-conversation-test.gts
@@ -98,6 +98,10 @@ module('Acceptance | the conversation about a set', function (hooks) {
     assert.strictEqual(posted, 'Both, actually.');
     assert.dom('[data-test-set-messages]').includesText('Both, actually.');
     assert.dom('[data-test-set-messages] textarea').hasValue('');
+    // `fillIn` addresses by selector, so the name a person would use is
+    // asserted rather than used: without it the control is unlabelled
+    // for a screen reader and nothing here would notice.
+    assert.dom('[data-test-set-messages] label').hasText('Write to the set');
   });
 
   // Reading is not answering, and the count is the server's: a message
@@ -128,6 +132,57 @@ module('Acceptance | the conversation about a set', function (hooks) {
 
     assert.true(read);
     assert.dom('[data-test-set-messages] [data-test-mark-read]').doesNotExist();
+  });
+
+  // Ember reuses the component when the model changes under the same
+  // route. Without a re-fetch, one set's conversation stays on screen
+  // under another set's name — which, in a feature about who is party to
+  // which conversation, is the worst thing it could get wrong.
+  test("moving to another set fetches that set's thread", async function (assert) {
+    worker.use(
+      http.get('/sets/{id}', ({ params, response }) =>
+        response(200).json(set({ id: Number(params.id), name: `Set ${params.id}` })),
+      ),
+
+      http.get('/sets/{set_id}/messages', ({ params, response }) =>
+        response(200).json([message({ body: `thread for set ${params.set_id}` })]),
+      ),
+    );
+
+    await visit('/sets/7');
+
+    assert.dom('[data-test-set-messages]').includesText('thread for set 7');
+
+    await visit('/sets/8');
+
+    assert.dom('[data-test-set-messages]').includesText('thread for set 8');
+    assert.dom('[data-test-set-messages]').doesNotIncludeText('thread for set 7');
+  });
+
+  // Until the thread has arrived there is nothing to acknowledge: with
+  // no id the server falls back to "now" and would discharge messages
+  // the reader never saw.
+  test('the acknowledge button waits until it knows what is on screen', async function (assert) {
+    let sent: unknown;
+
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => response(200).json(set({ unread_message_count: 1 }))),
+
+      http.get('/sets/{set_id}/messages', ({ response }) =>
+        response(200).json([message({ id: 42, author_role: 'curator', author_uid: 'bob' })]),
+      ),
+
+      http.post('/sets/{set_id}/messages/read', async ({ request, response }) => {
+        sent = (await request.json())?.through_id;
+
+        return response(204).empty();
+      }),
+    );
+
+    await visit('/sets/7');
+    await click('[data-test-set-messages] [data-test-mark-read]');
+
+    assert.strictEqual(sent, 42, 'it names the newest message it had in front of it');
   });
 
   // A badge on a row is only visible if that row is on the page in front

--- a/web/tests/acceptance/set-membership-test.gts
+++ b/web/tests/acceptance/set-membership-test.gts
@@ -22,6 +22,7 @@ const mine: SetSummary = {
   member_count: 1,
   invited_count: 0,
   submission_count: 0,
+  unread_message_count: 0,
 };
 
 function request(sets: SubmissionRequest['sets']): SubmissionRequest {

--- a/web/tests/acceptance/sets-test.gts
+++ b/web/tests/acceptance/sets-test.gts
@@ -22,6 +22,7 @@ const summary: SetSummary = {
   member_count: 2,
   invited_count: 1,
   submission_count: 1,
+  unread_message_count: 0,
 };
 
 const set: Set = {

--- a/web/tests/acceptance/submission-messages-test.gts
+++ b/web/tests/acceptance/submission-messages-test.gts
@@ -233,6 +233,28 @@ module('Acceptance | submission messages', function (hooks) {
     assert.deepEqual(posted, ['signed-id'], 'the signed id is what the message carries');
   });
 
+  // The failure was recorded and never rendered: the button came back
+  // and nothing else happened, which is what a lost message looks like.
+  test('a send that fails says so', async function (assert) {
+    worker.use(
+      http.get('/submission_requests/{id}', ({ response }) => response(200).json(request)),
+
+      http.get('/submission_requests/{submission_request_id}/messages', ({ response }) => response(200).json([])),
+
+      // Raw, not typed: the contract does not declare a 500 here, and
+      // the point is what the screen does when one arrives anyway.
+      mswHttp.post(`${ENV.apiURL}/submission_requests/${request.id}/messages`, () =>
+        HttpResponse.json({ error: 'Internal server error' }, { status: 500 }),
+      ),
+    );
+
+    await visit(`/requests/${request.id}`);
+    await fillIn('[data-test-messages] textarea', 'Updated, please review.');
+    await click('[data-test-messages] button[type="submit"]');
+
+    assert.dom('[data-test-messages] [data-test-error]').exists();
+  });
+
   test('renders the thread and posts a reply', async function (assert) {
     const initial: Message[] = [
       {

--- a/web/tests/msw/handlers.ts
+++ b/web/tests/msw/handlers.ts
@@ -20,7 +20,7 @@ export const handlers = [
   // application test hits this; default to "nothing waiting" and let the
   // tests that care override it.
   http.get('/attention', ({ response }) => {
-    return response(200).json({ requests: [] });
+    return response(200).json({ requests: [], sets_waiting: 0 });
   }),
 
   // The request detail page offers "add to a set", which needs to know
@@ -34,6 +34,13 @@ export const handlers = [
   // disabled so tests that don't care about it don't have to stub it.
   http.get('/submission_requests/{submission_request_id}/reviewer_access', ({ response }) => {
     return response(200).json({ enabled: false });
+  }),
+
+  // The set page renders the set's own thread; default to empty so the
+  // tests that are about the roster or the submissions do not have to
+  // stub a conversation.
+  http.get('/sets/{set_id}/messages', ({ response }) => {
+    return response(200).json([]);
   }),
 
   mswHttp.post(directUploadURL, () => {


### PR DESCRIPTION
セットは「束ねること自体に意味がある submission のまとまり」なので、そのまとまりについての質問がある。これまでは submission 1件ずつのスレッドしか無かったので、12件に跨る質問は12回書くことになっていました。

**セット自身が1本のスレッドを持つ形**にしました。

## なぜ「各 submission に配る」形にしなかったか

12件のセットなら curator の queue に12件立ち、答えるのも12回になります。submitter が1回で済ませたかった重複を、答える側に渡すだけです。

代わりに軸が2本になり、未読と「追いかけている」を2箇所で持つことになりますが、その代償で「1回訊いて1回答える」が成立します。

## 見える範囲

- セットのスレッドは**メンバー全員のもの**。読むのも書くのも全員で、誰が書いたかが出ます
- **submission ごとのスレッドは含めません。** あれは所有者と DDBJ の間のもので、セット経由で人の submission を読めることは、その人が何を訊かれたかを知ってよいということではない（セットのページの未読バッジが既に引いていた線と同じ）

## 既読が2つある理由

request のスレッドは `read_at` 1本で足ります（submitter が1人なので）。セットはメンバーが何人でもいるので、どこまで読んだかは**人についての事実**になります。

| | どこに | 購読 |
|---|---|---|
| メンバー | `submission_set_members.last_read_at` | 無し（セットに居ることが資格） |
| curator | `submission_set_participants` | `SubmissionRequestParticipant` と同型 |

「答えられたか」は逆に**集合的** — 答えることが仕事なので、同僚が答えればセット全体として片付きます。

## 画面

- **curator**: `/admin/sets`（Waiting on you / Following は独立トグル）+ 詳細（スレッド・名簿・中身）。担当は付けていません（セットには進むべき状態が無い）。My queue にセクション1つ、ナビにバッジ
- **メンバー**: セットのページ末尾にスレッド、ナビの Sets にバッジ（`/attention` に `sets_waiting`）

## 意図的にそうしてある

curator またはメンバーが書くと**セット全員**にメールが飛びます。大きくなったとき最初に壊れるのはここで、直し方はメンバーごとの設定であって見える範囲を狭めることではない、とコードに書いてあります。

## レビュー

敵対的レビューを2観点（認可・整合性 / 規約・画面の正直さ）で実施し、2コミット目で反映しました。HIGH 1件（`user.admin?` で既読の側を判定していた）を含みます。詳細は `9e39e463` のメッセージに。

- `bin/rails test:all` 1317 / `pnpm test` 92 / rubocop・brakeman clean
- 既知の残り: セットのスレッド自体はページングしていない（request 側と同じ）、curator の cc（Also notify）はセット側に無い

🤖 Generated with [Claude Code](https://claude.com/claude-code)