### PR TITLE
セットの行に「中身を誰が見ているか」を出す

### DIFF
--- a/app/controllers/admin/my_queue_controller.rb
+++ b/app/controllers/admin/my_queue_controller.rb
@@ -31,10 +31,22 @@ module Admin
       # Since when, so the row and the order it is in are the same fact.
       @waiting_since = SubmissionSet.waiting_since(@sets.map(&:id))
 
+      # And who is already curating what is in it, which is usually what
+      # decides whether this question is the reader's to answer.
+      @set_assignees = SubmissionSet.assignee_counts(@sets.map(&:id))
+      @assignee_uids = assignee_uids(@set_assignees)
+
       @total = @requests + @set_count
     end
 
     private
+
+    # One lookup for every name any of the rows will print.
+    def assignee_uids(counts)
+      ids = counts.values.flat_map(&:keys).compact.uniq
+
+      User.where(id: ids).pluck(:id, :uid).to_h
+    end
 
     def present(section)
       count    = section.count

--- a/app/controllers/admin/sets_controller.rb
+++ b/app/controllers/admin/sets_controller.rb
@@ -50,6 +50,12 @@ module Admin
       @counts     = SubmissionSet.counts_for(ids)
       @unread     = SubmissionSet.curator_unread_counts(current_user, ids)
       @last_posts = SubmissionSetMessage.where(submission_set_id: ids).group(:submission_set_id).maximum(:created_at)
+
+      # Who is already curating what is in each set — see
+      # ViewHelpers#assignee_breakdown for why this belongs next to the
+      # conversation rather than on the submissions.
+      @assignees     = SubmissionSet.assignee_counts(ids)
+      @assignee_uids = assignee_uids(@assignees)
     end
 
 
@@ -65,13 +71,22 @@ module Admin
       # study is hundreds of submissions. The member's own view of the
       # same list paginates for the same reason.
       @pagy, @inclusions = pagy(
-        @set.inclusions.includes(submission_request: [:user, {submission: :project}]).order(:created_at, :id)
+        @set.inclusions
+              .includes(submission_request: [:user, :assignee, {submission: :project}])
+              .order(:created_at, :id)
       )
 
       redirect_out_of_range_page(@pagy)
     end
 
     private
+
+    # One lookup for every name any of the rows will print.
+    def assignee_uids(counts)
+      ids = counts.values.flat_map(&:keys).compact.uniq
+
+      User.where(id: ids).pluck(:id, :uid).to_h
+    end
 
     # Unrecognised values mean nothing rather than something: a `filter`
     # the screen does not know used to render the whole list with no

--- a/app/controllers/admin/view_helpers.rb
+++ b/app/controllers/admin/view_helpers.rb
@@ -260,6 +260,42 @@ module Admin::ViewHelpers
     distance_of_time_in_words(rate * count)
   end
 
+  # "8 yours, 3 suzuki, 1 unassigned" — who is already curating the
+  # submissions a set-wide question is about.
+  #
+  # This is what decides who answers it, and it is the one fact neither
+  # the set nor the thread carries: a set whose submissions are all one
+  # curator's is that curator's question, and one split between three is
+  # a question somebody has to agree to take. Yours first, because the
+  # reader is deciding whether it is theirs; unassigned last, because it
+  # is the part nobody has claimed yet.
+  #
+  # Long tails are summed rather than listed. A row is read at a glance,
+  # and five names in it is not a glance.
+  NAMED_ASSIGNEES = 2
+
+  def assignee_breakdown(counts, uids:)
+    return nil if counts.blank?
+
+    mine       = counts[current_user.id].to_i
+    unassigned = counts[nil].to_i
+    others     = counts.except(current_user.id, nil).sort_by { -it.last }
+
+    parts = []
+    parts << "#{number_with_delimiter(mine)} yours" if mine.positive?
+
+    others.first(NAMED_ASSIGNEES).each do |id, count|
+      parts << "#{number_with_delimiter(count)} #{uids.fetch(id, 'somebody else')}"
+    end
+
+    rest = others.drop(NAMED_ASSIGNEES).sum { it.last }
+
+    parts << "#{number_with_delimiter(rest)} others" if rest.positive?
+    parts << "#{number_with_delimiter(unassigned)} unassigned" if unassigned.positive?
+
+    parts.join(', ')
+  end
+
   # The three ways a list can be empty, which are three different
   # situations for whoever is looking at it. See the conventions in
   # CLAUDE.md.

--- a/app/models/submission_set.rb
+++ b/app/models/submission_set.rb
@@ -138,6 +138,29 @@ class SubmissionSet < ApplicationRecord
     SQL
   }
 
+  # Who already holds the submissions in each set — the assignees, not
+  # the owners.
+  #
+  # A question about a whole bundle is usually answered by whoever is
+  # already curating most of it, and when that is split between people,
+  # the split is the thing worth seeing: it is the difference between
+  # "this is obviously mine" and "somebody has to agree who takes it".
+  # `nil` is unassigned, which is a real answer rather than a gap.
+  #
+  # One grouped query for the whole page. {set_id => {assignee_id => n}}.
+  def self.assignee_counts(ids)
+    return {} if Array(ids).empty?
+
+    SubmissionSetInclusion
+      .where(submission_set_id: ids)
+      .joins(:submission_request)
+      .group(:submission_set_id, 'submission_requests.assignee_id')
+      .count
+      .each_with_object({}) {|((set_id, assignee_id), count), acc|
+        (acc[set_id] ||= {})[assignee_id] = count
+      }
+  end
+
   # The three integers every list of sets prints, counted in SQL for the
   # whole page. There is no ceiling on what a set holds, and these must
   # not be what loads it.

--- a/app/views/admin/my_queue/show.html.erb
+++ b/app/views/admin/my_queue/show.html.erb
@@ -77,9 +77,14 @@
           <div class="d-flex justify-content-between align-items-baseline gap-2 flex-wrap">
             <span>
               <strong><%= set.name %></strong>
+              <%# Who is already curating what is in it. Usually the answer %>
+              <%# to "is this mine?" — and where it is split, the split is %>
+              <%# the thing that has to be seen rather than assumed. %>
+              <% breakdown = assignee_breakdown(@set_assignees[set.id], uids: @assignee_uids) %>
+
               <span class="text-body-secondary small">
                 <%= pluralize(@set_counts.fetch(:submissions).fetch(set.id, 0), 'submission') %>,
-                <%= pluralize(@set_counts.fetch(:members).fetch(set.id, 0), 'member') %>
+                <%= pluralize(@set_counts.fetch(:members).fetch(set.id, 0), 'member') %><%= " — #{breakdown}" if breakdown %>
               </span>
             </span>
 

--- a/app/views/admin/sets/index.html.erb
+++ b/app/views/admin/sets/index.html.erb
@@ -70,7 +70,15 @@
             <td><%= link_to set.name, admin_set_path(set) %></td>
             <td><code><%= set.owner.uid %></code></td>
             <td class="text-end"><%= number_with_delimiter(@counts.fetch(:members).fetch(set.id, 0)) %></td>
-            <td class="text-end"><%= number_with_delimiter(@counts.fetch(:submissions).fetch(set.id, 0)) %></td>
+            <td class="text-end">
+              <%= number_with_delimiter(@counts.fetch(:submissions).fetch(set.id, 0)) %>
+
+              <% breakdown = assignee_breakdown(@assignees[set.id], uids: @assignee_uids) %>
+
+              <% if breakdown %>
+                <div class="small text-body-secondary"><%= breakdown %></div>
+              <% end %>
+            </td>
 
             <%# Relative, because the question a queue asks is "has this %>
             <%# been sitting?" — the absolute value rides along in the %>

--- a/app/views/admin/sets/show.html.erb
+++ b/app/views/admin/sets/show.html.erb
@@ -59,6 +59,10 @@
     <section>
       <h2 class="h6">Submissions</h2>
 
+      <%# The arrow in each row, said once: whose work it is, and which %>
+      <%# of us is curating it. %>
+      <p class="small text-body-tertiary mb-1">submitter → curator</p>
+
       <% if @inclusions.empty? %>
         <%# Not `:clear`: an empty set is not an outcome anybody wanted, %>
         <%# it is a set nobody has put anything in yet. %>
@@ -75,9 +79,17 @@
                 <span class="text-body-secondary"><%= request.submission&.source_id %></span>
               </span>
 
-              <%# Whose it is. On this screen it is the first thing a %>
-              <%# reader needs — a set holds several people's work. %>
-              <code class="small"><%= request.user.uid %></code>
+              <%# Two different people, and the row needs both: whose work %>
+              <%# it is, and which of us is already curating it. %>
+              <span class="small text-body-secondary">
+                <code><%= request.user.uid %></code>
+                →
+                <% if request.assignee %>
+                  <code><%= request.assignee.uid %></code>
+                <% else %>
+                  unassigned
+                <% end %>
+              </span>
             </li>
           <% end %>
         </ul>

--- a/test/system/admin_sets_test.rb
+++ b/test/system/admin_sets_test.rb
@@ -177,6 +177,42 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
     end
   end
 
+  # Who is already curating what is in the set. This is what decides
+  # whether a set-wide question is the reader's to answer, and it is the
+  # one fact neither the set nor the thread carries.
+  test 'the queue row says who holds the submissions in the set' do
+    @set.messages.create!(user: @alice, author_role: :member, body: 'Anyone?')
+
+    # Three submissions, split: one this curator's, one a colleague's,
+    # one nobody's.
+    @set.inclusions.create!(submission_request: submission_requests(:biosample), added_by: @alice)
+    @set.inclusions.create!(submission_request: submission_requests(:st26), added_by: @alice)
+
+    # `update_columns`: the fixtures carry no uploaded record, and the
+    # attachment validation is not what this is about.
+    submission_requests(:bioproject).update_columns(assignee_id: users(:bob).id)
+    submission_requests(:biosample).update_columns(assignee_id: users(:dave).id)
+
+    visit admin_my_queue_path
+
+    within '[data-test-section="sets"]' do
+      assert_text '3 submissions, 2 members — 1 yours, 1 dave, 1 unassigned'
+    end
+  end
+
+  # A set nobody has been assigned any of is still a real answer, and
+  # different from one that is half yours.
+  test 'a set nobody is curating says so' do
+    @set.messages.create!(user: @alice, author_role: :member, body: 'Anyone?')
+
+    visit admin_my_queue_path
+
+    within '[data-test-section="sets"]' do
+      assert_text '1 unassigned'
+      assert_no_text 'yours'
+    end
+  end
+
   # An attachment control a label does not name cannot be reached by a
   # screen reader or by a test.
   test 'the file control on the curator form is named' do

--- a/web/tests/acceptance/submission-messages-test.gts
+++ b/web/tests/acceptance/submission-messages-test.gts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit, fillIn, click, triggerEvent, waitUntil } from '@ember/test-helpers';
+import { visit, fillIn, click, triggerEvent, waitUntil, settled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'repository/tests/helpers';
 import { setupAuthentication } from 'repository/tests/helpers/setup-auth';
 
@@ -227,6 +227,14 @@ module('Acceptance | submission messages', function (hooks) {
     // until it has — `resetHandlers` runs the moment this test body
     // ends, and anything still in flight then lands on the real network.
     await waitUntil(() => posted);
+
+    // And then the rest of it. Posting refreshes the route and the
+    // attention banner, which are issued after the POST resolves: on a
+    // slower machine those land after the test body has finished, on
+    // handlers that no longer exist and an owner that has been torn
+    // down. `waitUntil` returns at the POST, so it is not enough on its
+    // own.
+    await settled();
 
     assert.strictEqual(authorization, 'Bearer test-token', 'the token went with the upload');
     assert.true(put, 'and the bytes went to storage');


### PR DESCRIPTION
セット宛の質問に誰が答えるべきかは、たいてい**中身の担当**で決まります。それはセットにもスレッドにも書かれていない唯一の事実でした。

queue の行と `/admin/sets` の Submissions 列に出します:

```
test   2 submissions, 1 member — 1 yours, 1 keycloak    [1 message]  waiting just now
```

- **自分の分が先頭** — 読む側は「これは自分のか」を判断しているので
- **未割当は最後** — まだ誰も取っていない部分
- **名前は2人まで、残りは `N others`** — 割れているときに割れていると分かることが要点で、行は一目で読むもの
- セット詳細の submission 一覧には行ごとに `submitter → curator`

担当そのもの（会話の claim）は次の PR です。claim を入れてもこの表示は要るので、先出しは無駄になりません。

- `bin/rails test:all` 1320 / rubocop clean
- ブラウザで確認済み（queue・一覧・詳細）

🤖 Generated with [Claude Code](https://claude.com/claude-code)