### PR TITLE
セットの会話に claim を入れ、queue を1本にする

### DIFF
--- a/app/controllers/admin/my_queue_controller.rb
+++ b/app/controllers/admin/my_queue_controller.rb
@@ -12,31 +12,22 @@ module Admin
     # rows helps nobody — the tail becomes a link into the ledger.
     PER_SECTION = 25
 
-    Listing = Data.define(:section, :rows, :count, :overflow)
+    Listing = Data.define(:section, :rows, :sets, :count, :overflow)
 
     def show
-      queue = MyQueue.new(current_user)
+      @sections = MyQueue.new(current_user).sections.map { present(it) }
+      @total    = @sections.sum(&:count)
 
-      @sections = queue.sections.map { present(it) }
-      @requests = @sections.sum(&:count)
+      # Everything the set rows on this page print, asked once for the
+      # page rather than once per row.
+      sets = @sections.flat_map(&:sets)
+      ids  = sets.map(&:id)
 
-      # The other axis. Not a section: the three above are one thing
-      # split by this curator's relationship to it, and a set has no
-      # assignee for that split to be about.
-      @sets       = queue.sets.limit(PER_SECTION).to_a
-      @set_count  = queue.set_count
-      @set_unread = SubmissionSet.curator_unread_counts(current_user, @sets.map(&:id))
-      @set_counts = SubmissionSet.counts_for(@sets.map(&:id))
-
-      # Since when, so the row and the order it is in are the same fact.
-      @waiting_since = SubmissionSet.waiting_since(@sets.map(&:id))
-
-      # And who is already curating what is in it, which is usually what
-      # decides whether this question is the reader's to answer.
-      @set_assignees = SubmissionSet.assignee_counts(@sets.map(&:id))
+      @set_unread    = SubmissionSet.curator_unread_counts(current_user, ids)
+      @set_counts    = SubmissionSet.counts_for(ids)
+      @waiting_since = SubmissionSet.waiting_since(ids)
+      @set_assignees = SubmissionSet.assignee_counts(ids)
       @assignee_uids = assignee_uids(@set_assignees)
-
-      @total = @requests + @set_count
     end
 
     private
@@ -48,11 +39,20 @@ module Admin
       User.where(id: ids).pluck(:id, :uid).to_h
     end
 
+    # Both axes, each capped, so one long side cannot crowd the other out
+    # of the page. The overflow line names what is left of the pair.
     def present(section)
       count    = section.count
       requests = section.requests.limit(PER_SECTION).to_a
+      sets     = section.set_conversations.limit(PER_SECTION).to_a
 
-      Listing.new(section:, rows: rows_for(requests), count:, overflow: [count - PER_SECTION, 0].max)
+      Listing.new(
+        section:,
+        rows:     rows_for(requests),
+        sets:,
+        count:,
+        overflow: [count - requests.size - sets.size, 0].max
+      )
     end
 
     # Both per-row facts for the whole section at once. Two grouped

--- a/app/controllers/admin/set_assignments_controller.rb
+++ b/app/controllers/admin/set_assignments_controller.rb
@@ -1,0 +1,37 @@
+module Admin
+  # Who is answering a set's conversation.
+  #
+  # The set-axis twin of Admin::AssignmentsController, plus the release a
+  # request gets from the assignee field in its curation rail — a set has
+  # no such rail, so both live here: `create` claims it (for yourself, or
+  # for a colleague you are handing it to) and `destroy` puts it back.
+  class SetAssignmentsController < ApplicationController
+    before_action :load_set
+
+    def create
+      @set.assign! assignee
+
+      redirect_to admin_set_path(@set), notice: "Answering: #{@set.assignee.uid}."
+    rescue ArgumentError => e
+      redirect_to admin_set_path(@set), alert: "Could not assign: #{e.message}"
+    end
+
+    def destroy
+      @set.assign! nil
+
+      redirect_to admin_set_path(@set), notice: 'Released. Nobody is answering this set.'
+    end
+
+    private
+
+    # Absent means "me", which is what the one-click claim on the queue
+    # sends. A named one is a hand-over, and it has to be a curator.
+    def assignee
+      id = params[:assignee_id].presence or return current_user
+
+      User.staff.find(id)
+    end
+
+    def load_set = @set = SubmissionSet.find(params.expect(:set_id))
+  end
+end

--- a/app/controllers/admin/sets_controller.rb
+++ b/app/controllers/admin/sets_controller.rb
@@ -34,7 +34,7 @@ module Admin
       # that both constrain `id` REPLACES the first condition rather than
       # narrowing it, so asking both questions used to silently answer
       # only the second.
-      scope = SubmissionSet.includes(:owner).order(updated_at: :desc)
+      scope = SubmissionSet.includes(:owner, :assignee).order(updated_at: :desc)
       scope = scope.where(id: SubmissionSet.needing_curator(current_user).select(:id)) if waiting?
       scope = scope.where(id: SubmissionSet.followed_by(current_user).select(:id))     if following?
 
@@ -60,7 +60,7 @@ module Admin
 
 
     def show
-      @set = SubmissionSet.includes(:owner).find(params.expect(:id))
+      @set = SubmissionSet.includes(:owner, :assignee).find(params.expect(:id))
 
       # The thread renders each message's attachments as well as its
       # author — `:user` alone leaves a pair of queries per message.

--- a/app/models/submission_request.rb
+++ b/app/models/submission_request.rb
@@ -65,13 +65,19 @@ class SubmissionRequest < ApplicationRecord
   # notice — if the section is never empty, that is a staffing signal
   # rather than an individual's backlog.
   #
-  # Subscribed participations only: if everyone who touched it has since
-  # stopped following, nobody is watching it, and that is exactly what
-  # this section is for. Keying on the row's mere existence would leave
-  # such a request owned by nobody and visible to nobody.
-  scope :unclaimed, -> {
-    unassigned.where.not(id: SubmissionRequestParticipant.subscribed.select(:submission_request_id))
-  }
+  # Nobody has claimed it — and that is the whole of the rule.
+  #
+  # It used to exclude anything somebody was following, which made the
+  # pool depend on a fact nobody can see from the row: a curator who
+  # replied and later put the thread aside took it out of their own
+  # sections AND out of everybody's pool, leaving a submitter waiting on
+  # work that appeared in no queue at all. It also made "is this
+  # unclaimed?" a question with a two-part answer, which is not a
+  # question a screen can ask somebody to remember.
+  #
+  # Being unassigned is itself the anomaly. It is what the section is
+  # named after, and following is not a claim.
+  scope :unclaimed, -> { unassigned }
 
   # What is on the submitter rather than on us: a file that failed
   # validation, a validated file waiting for them to press Apply, or a

--- a/app/models/submission_set.rb
+++ b/app/models/submission_set.rb
@@ -72,13 +72,10 @@ class SubmissionSet < ApplicationRecord
   scope :assigned_to, ->(user) { where(assignee_id: user.id) }
   scope :unassigned,  -> { where(assignee_id: nil) }
 
-  # Nobody has claimed it and nobody is listening — the same two
-  # conditions the request axis uses, for the same reason: a set that
-  # somebody stopped following is nobody's again, which is exactly what
-  # this section is for.
-  scope :unclaimed, -> {
-    unassigned.where.not(id: SubmissionSetParticipant.subscribed.select(:submission_set_id))
-  }
+  # Nobody has claimed it — the same one-part rule as the request axis,
+  # and for the same reason: following is not a claim, and a pool that
+  # depends on who happens to be following is a pool nobody can predict.
+  scope :unclaimed, -> { unassigned }
 
   # Sets whose thread is waiting on the curator side: a member has
   # written and no curator has written since.

--- a/app/models/submission_set.rb
+++ b/app/models/submission_set.rb
@@ -44,6 +44,10 @@ class SubmissionSet < ApplicationRecord
   has_many :followers, -> { merge(SubmissionSetParticipant.subscribed) },
            through: :participations, source: :user
 
+  # Who is answering the conversation. Only that: a set has no state to
+  # move through, and nothing to hand over but the thread.
+  belongs_to :assignee, class_name: 'User', optional: true
+
   validates :name, presence: true, length: {maximum: 200}
 
   # The creator is on the roster from the start. A set nobody is in
@@ -63,6 +67,17 @@ class SubmissionSet < ApplicationRecord
   # SubmissionRequest.involving.
   scope :followed_by, ->(user) {
     where(id: SubmissionSetParticipant.subscribed.where(user_id: user.id).select(:submission_set_id))
+  }
+
+  scope :assigned_to, ->(user) { where(assignee_id: user.id) }
+  scope :unassigned,  -> { where(assignee_id: nil) }
+
+  # Nobody has claimed it and nobody is listening — the same two
+  # conditions the request axis uses, for the same reason: a set that
+  # somebody stopped following is nobody's again, which is exactly what
+  # this section is for.
+  scope :unclaimed, -> {
+    unassigned.where.not(id: SubmissionSetParticipant.subscribed.select(:submission_set_id))
   }
 
   # Sets whose thread is waiting on the curator side: a member has
@@ -244,6 +259,15 @@ class SubmissionSet < ApplicationRecord
     scope  = scope.where('submission_set_messages.created_at > ?', marker) if marker
 
     scope.count
+  end
+
+  # Claiming says who is answering; it is not a claim to have read
+  # anything, and it must not discharge the question that prompted it —
+  # so no marker and no subscription here, exactly as on a request.
+  def assign!(user)
+    raise ArgumentError, 'Assignee must be an admin user.' unless user.nil? || user.admin?
+
+    update!(assignee: user)
   end
 
   # "I have seen this thread, up to here." `through` is the newest

--- a/app/services/my_queue.rb
+++ b/app/services/my_queue.rb
@@ -98,23 +98,30 @@ class MyQueue
         scope:     needing_curator(user).assigned_to(user),
         sets:      SubmissionSet.needing_curator(user).assigned_to(user)
       ),
-      # IS DISTINCT FROM, not `!=`: SQL inequality is NULL for an
-      # unassigned row, so `where.not(assignee_id: id)` silently drops
-      # exactly the requests that are involved-but-unowned — and since
-      # `unclaimed` excludes anything with a participant, replying to a
-      # submitter made the request vanish from every curator's queue.
+      # Somebody else's, specifically. Anything nobody holds is Unclaimed
+      # whoever has touched it, which is what makes the three sections a
+      # partition of one fact — who holds this: me, somebody else, or
+      # nobody — rather than three overlapping questions.
+      #
+      # `where.not(assignee_id: nil)` first: SQL inequality is NULL for
+      # an unassigned row, so an `assignee_id != ?` on its own would
+      # silently drop every unassigned row from BOTH sections and lose
+      # them entirely. That has happened here before.
       Section.new(
         key:       :involved,
         title:     "I'm involved",
-        criterion: 'You replied or edited here — somebody else holds it, or nobody does.',
-        scope:     needing_curator(user).involving(user).where('submission_requests.assignee_id IS DISTINCT FROM ?', user.id),
+        criterion: 'You replied or edited here — someone else holds the assignment.',
+        scope:     needing_curator(user).involving(user)
+                                        .where.not(submission_requests: {assignee_id: nil})
+                                        .where.not(submission_requests: {assignee_id: user.id}),
         sets:      SubmissionSet.needing_curator(user).followed_by(user)
-                                .where('submission_sets.assignee_id IS DISTINCT FROM ?', user.id)
+                                .where.not(submission_sets: {assignee_id: nil})
+                                .where.not(submission_sets: {assignee_id: user.id})
       ),
       Section.new(
         key:       :unclaimed,
         title:     'Unclaimed',
-        criterion: 'No assignee, nobody has replied — every curator sees this section identically.',
+        criterion: 'Nobody has claimed these — every curator sees this section identically.',
         scope:     needing_curator.unclaimed,
         sets:      SubmissionSet.needing_curator.unclaimed
       )

--- a/app/services/my_queue.rb
+++ b/app/services/my_queue.rb
@@ -24,12 +24,21 @@ class MyQueue
   # one that blocks somebody else first.
   ISSUABLE_STATUS_IDS = -> { AccessionIssue::ISSUABLE_FROM.map { Lifecycleable::STATUSES.fetch(it) } }
 
-  Section = Data.define(:key, :title, :criterion, :scope) do
-    def count = scope.reorder(nil).count
+  # One relationship, two axes. A section holds the requests AND the set
+  # conversations that stand in that relationship to this curator: both
+  # are work waiting on them, and which of the two a given piece of work
+  # is says nothing about whether it is theirs — which is what the three
+  # sections are about.
+  Section = Data.define(:key, :title, :criterion, :scope, :sets) do
+    def count = scope.reorder(nil).count + sets.reorder(nil).count
 
     # Oldest first: a queue is a working order, not a newsfeed.
     def requests
       scope.reorder(updated_at: :asc).includes(:user, :assignee, submission: :project)
+    end
+
+    def set_conversations
+      sets.includes(:owner, :assignee).by_longest_waiting
     end
   end
 
@@ -86,7 +95,8 @@ class MyQueue
         key:       :assigned,
         title:     'Assigned to me',
         criterion: 'You took these on — assignment only changes when someone changes it.',
-        scope:     needing_curator(user).assigned_to(user)
+        scope:     needing_curator(user).assigned_to(user),
+        sets:      SubmissionSet.needing_curator(user).assigned_to(user)
       ),
       # IS DISTINCT FROM, not `!=`: SQL inequality is NULL for an
       # unassigned row, so `where.not(assignee_id: id)` silently drops
@@ -96,32 +106,30 @@ class MyQueue
       Section.new(
         key:       :involved,
         title:     "I'm involved",
-        criterion: 'You replied or edited here — someone else holds the assignment.',
-        scope:     needing_curator(user).involving(user).where('submission_requests.assignee_id IS DISTINCT FROM ?', user.id)
+        criterion: 'You replied or edited here — somebody else holds it, or nobody does.',
+        scope:     needing_curator(user).involving(user).where('submission_requests.assignee_id IS DISTINCT FROM ?', user.id),
+        sets:      SubmissionSet.needing_curator(user).followed_by(user)
+                                .where('submission_sets.assignee_id IS DISTINCT FROM ?', user.id)
       ),
       Section.new(
         key:       :unclaimed,
         title:     'Unclaimed',
         criterion: 'No assignee, nobody has replied — every curator sees this section identically.',
-        scope:     needing_curator.unclaimed
+        scope:     needing_curator.unclaimed,
+        sets:      SubmissionSet.needing_curator.unclaimed
       )
     ]
   end
 
-  # Requests and set conversations, which are two axes and one queue.
-  # A question about a bundle waits on a curator in exactly the way a
+  # Requests and set conversations, which are two axes and one queue. A
+  # question about a bundle waits on a curator in exactly the way a
   # question about one submission does, and a landing screen that
   # promises "everything waiting" cannot answer only for the axis it was
   # built on first.
-  def count = sections.sum(&:count) + set_count
+  def count = sections.sum(&:count)
 
-  # Oldest first, like the sections: a queue is a working order — and
-  # "oldest" means the question that has been sitting longest, not the
-  # set that was touched longest ago. `updated_at` moves for a rename as
-  # readily as for a message, which would send a five-day-old question to
-  # the back of the queue and relabel it as new.
-  def sets = SubmissionSet.needing_curator(user).includes(:owner).by_longest_waiting
-
+  # The set axis's own share, for the Sets tab's badge. Not a section:
+  # this one is "still unanswered by you", whoever is assigned.
   def set_count = SubmissionSet.needing_curator(user).count
 
   # Requests with something a curator can actually do. Kept as two plain

--- a/app/views/admin/my_queue/_set_row.html.erb
+++ b/app/views/admin/my_queue/_set_row.html.erb
@@ -1,0 +1,40 @@
+<%# locals: (set:, section:, unread:, counts:, assignees:, uids:, waiting_since:) %>
+<%# The set-axis row, alongside the request rows in the same section: %>
+<%# what makes a piece of work this curator's is the same question either %>
+<%# way, and which of the two it is does not change the answer. %>
+<div class="list-group-item d-flex align-items-center gap-3 flex-wrap" data-test-set="<%= set.id %>">
+  <%= link_to set.name, admin_set_path(set), class: 'fw-semibold text-nowrap' %>
+
+  <span class="badge text-bg-light border">Set</span>
+
+  <span class="small text-body-secondary">
+    <%= pluralize(counts.fetch(:submissions).fetch(set.id, 0), 'submission') %>,
+    <%= pluralize(counts.fetch(:members).fetch(set.id, 0), 'member') %>
+
+    <%# Who is already curating what is in it — usually the answer to %>
+    <%# "is this mine?", and where it is split, the split is the thing %>
+    <%# that has to be seen rather than assumed. %>
+    <% breakdown = assignee_breakdown(assignees[set.id], uids:) %>
+    <%= " — #{breakdown}" if breakdown %>
+
+    <% if section.key == :involved && set.assignee %>
+      · answering <%= set.assignee.uid %>
+    <% end %>
+  </span>
+
+  <span class="flex-fill small text-body-secondary">
+    <%= pluralize(unread, 'unread message') %>
+  </span>
+
+  <%# How long the question has been sitting — the value this section is %>
+  <%# ordered by, so the row and its place agree. %>
+  <span class="small text-nowrap <%= 'text-danger fw-semibold' if stale?(waiting_since) %>">
+    waiting <%= elapsed_time(waiting_since) %>
+  </span>
+
+  <%= link_to 'Answer', admin_set_path(set), class: 'btn btn-outline-secondary btn-sm' %>
+
+  <% if section.key == :unclaimed %>
+    <%= button_to 'Assign to me', admin_set_assignment_path(set), method: :post, class: 'btn btn-primary btn-sm' %>
+  <% end %>
+</div>

--- a/app/views/admin/my_queue/show.html.erb
+++ b/app/views/admin/my_queue/show.html.erb
@@ -12,8 +12,7 @@
     <%= pluralize(@total, 'thing') %>
     <%= @total == 1 ? 'needs' : 'need' %> a curator:
     <%= mine %> <%= mine == 1 ? 'is' : 'are' %> yours or involve you,
-    <%= unclaimed %> unclaimed<%= ", #{pluralize(@set_count, 'set conversation')}" if @set_count.positive? %>.
-    Oldest first.
+    <%= unclaimed %> unclaimed. Oldest first.
   <% end %>
 </p>
 
@@ -33,7 +32,7 @@
       <span class="small text-body-tertiary"><%= listing.section.criterion %></span>
     </div>
 
-    <% if listing.rows.empty? %>
+    <% if listing.count.zero? %>
       <%# Empty is the point of a queue, so it reads as an outcome and %>
       <%# carries nothing to press — a button here would send somebody %>
       <%# looking for work the screen has just said there is none of. %>
@@ -43,6 +42,21 @@
         <% listing.rows.each do |row| %>
           <%= render 'row', row: row, section: listing.section %>
         <% end %>
+
+        <%# The other axis, in the same section. Kept together rather than %>
+        <%# interleaved: the two carry different facts in the same places, %>
+        <%# and a column of alternating shapes is harder to read than two %>
+        <%# short runs. %>
+        <% listing.sets.each do |set| %>
+          <%= render 'set_row',
+                     set:           set,
+                     section:       listing.section,
+                     unread:        @set_unread.fetch(set.id, 0),
+                     counts:        @set_counts,
+                     assignees:     @set_assignees,
+                     uids:          @assignee_uids,
+                     waiting_since: @waiting_since[set.id] %>
+        <% end %>
       </div>
 
       <% if listing.overflow.positive? %>
@@ -51,65 +65,6 @@
           <%= link_to 'open in All requests', admin_submission_requests_path %>.
         </p>
       <% end %>
-    <% end %>
-  </section>
-<% end %>
-
-<%# The other axis. Kept apart from the three above rather than made a %>
-<%# fourth of them: those three are one thing split by this curator's %>
-<%# relationship to it, and a set has no assignee for that split to be %>
-<%# about — only whether anybody has answered. %>
-<% if @set_count.positive? %>
-  <section class="mb-4" data-test-section="sets">
-    <div class="d-flex align-items-baseline gap-2 flex-wrap mb-2">
-      <h2 class="h6 mb-0">Set conversations</h2>
-      <span class="badge text-bg-danger"><%= number_with_delimiter(@set_count) %></span>
-      <span class="small text-body-tertiary">
-        A question about a bundle of submissions — asked once, answered once. Longest waiting first.
-      </span>
-    </div>
-
-    <div class="list-group">
-      <% @sets.each do |set| %>
-        <% unread = @set_unread.fetch(set.id, 0) %>
-
-        <%= link_to admin_set_path(set), class: 'list-group-item list-group-item-action', data: {test_set: set.id} do %>
-          <div class="d-flex justify-content-between align-items-baseline gap-2 flex-wrap">
-            <span>
-              <strong><%= set.name %></strong>
-              <%# Who is already curating what is in it. Usually the answer %>
-              <%# to "is this mine?" — and where it is split, the split is %>
-              <%# the thing that has to be seen rather than assumed. %>
-              <% breakdown = assignee_breakdown(@set_assignees[set.id], uids: @assignee_uids) %>
-
-              <span class="text-body-secondary small">
-                <%= pluralize(@set_counts.fetch(:submissions).fetch(set.id, 0), 'submission') %>,
-                <%= pluralize(@set_counts.fetch(:members).fetch(set.id, 0), 'member') %><%= " — #{breakdown}" if breakdown %>
-              </span>
-            </span>
-
-            <span class="d-flex align-items-baseline gap-2">
-              <% if unread.positive? %>
-                <span class="badge text-bg-danger"><%= pluralize(unread, 'message') %></span>
-              <% end %>
-
-              <%# How long the question has been sitting — the same value %>
-              <%# the section is ordered by. `updated_at` would say "just %>
-              <%# now" for a set somebody renamed this morning. %>
-              <span class="small text-body-secondary">
-                waiting <%= elapsed_time(@waiting_since[set.id]) %>
-              </span>
-            </span>
-          </div>
-        <% end %>
-      <% end %>
-    </div>
-
-    <% if @set_count > @sets.size %>
-      <p class="small text-body-secondary mt-2 mb-0">
-        <%= number_with_delimiter(@set_count - @sets.size) %> more —
-        <%= link_to 'open in Sets', admin_sets_path(filter: 'waiting') %>.
-      </p>
     <% end %>
   </section>
 <% end %>

--- a/app/views/admin/sets/index.html.erb
+++ b/app/views/admin/sets/index.html.erb
@@ -56,6 +56,7 @@
           <th>Owner</th>
           <th class="text-end">Members</th>
           <th class="text-end">Submissions</th>
+          <th>Answering</th>
           <th>Last message</th>
           <th>Waiting</th>
         </tr>
@@ -77,6 +78,14 @@
 
               <% if breakdown %>
                 <div class="small text-body-secondary"><%= breakdown %></div>
+              <% end %>
+            </td>
+
+            <td>
+              <% if set.assignee %>
+                <code class="small"><%= set.assignee.uid %></code>
+              <% else %>
+                <span class="text-body-secondary">—</span>
               <% end %>
             </td>
 

--- a/app/views/admin/sets/show.html.erb
+++ b/app/views/admin/sets/show.html.erb
@@ -8,16 +8,39 @@
 <div class="d-flex justify-content-between align-items-start gap-3 flex-wrap mb-1">
   <h1 class="display-6 mb-0"><%= @set.name %></h1>
 
-  <%# Following, not assignment. A set has no state to move through and %>
-  <%# nothing to hand over but the conversation, so who is dealing with %>
-  <%# it is who is listening to it. %>
-  <% if @set.following?(current_user) %>
-    <%= button_to 'Unfollow', admin_set_subscription_path(@set), method: :delete,
-                  class: 'btn btn-outline-secondary btn-sm' %>
-  <% else %>
-    <%= button_to 'Follow', admin_set_subscription_path(@set), method: :post,
-                  class: 'btn btn-outline-secondary btn-sm' %>
-  <% end %>
+  <div class="d-flex gap-2 align-items-center flex-wrap">
+    <%# Claiming the conversation, not the set: a set has no state to %>
+    <%# move through, and the only thing there is to hand over is who %>
+    <%# answers. Named as that, so nobody reads it as the start of a %>
+    <%# status column. %>
+    <% if @set.assignee %>
+      <span class="small text-body-secondary" data-test-answering>
+        Answering: <code><%= @set.assignee.uid %></code>
+      </span>
+
+      <% if @set.assignee_id == current_user.id %>
+        <%= button_to 'Release', admin_set_assignment_path(@set), method: :delete,
+                      class: 'btn btn-outline-secondary btn-sm' %>
+      <% else %>
+        <%= button_to 'Take over', admin_set_assignment_path(@set), method: :post,
+                      class: 'btn btn-outline-secondary btn-sm' %>
+      <% end %>
+    <% else %>
+      <%= button_to 'Answer this', admin_set_assignment_path(@set), method: :post,
+                    class: 'btn btn-primary btn-sm' %>
+    <% end %>
+
+    <%# Following is separate: replying subscribes you whether or not you %>
+    <%# hold it, and a colleague who wants to keep an eye on a set they %>
+    <%# are not answering needs a way to say so. %>
+    <% if @set.following?(current_user) %>
+      <%= button_to 'Unfollow', admin_set_subscription_path(@set), method: :delete,
+                    class: 'btn btn-outline-secondary btn-sm' %>
+    <% else %>
+      <%= button_to 'Follow', admin_set_subscription_path(@set), method: :post,
+                    class: 'btn btn-outline-secondary btn-sm' %>
+    <% end %>
+  </div>
 </div>
 
 <p class="text-body-secondary mb-4">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -235,6 +235,10 @@ Rails.application.routes.draw do
       end
 
       resource :subscription, only: %i[create destroy], controller: 'set_subscriptions'
+
+      # Claiming the conversation. Singular, like the request's: what is
+      # created is this set's assignment, which has no id of its own.
+      resource :assignment, only: %i[create destroy], controller: 'set_assignments'
     end
 
     resources :users,               only: %i[index show update], param: :uid do

--- a/db/migrate/20260821000002_add_assignee_to_submission_sets.rb
+++ b/db/migrate/20260821000002_add_assignee_to_submission_sets.rb
@@ -1,0 +1,15 @@
+# Who is answering a set's conversation.
+#
+# The set axis had no claim, so a waiting set sat in every curator's queue
+# until somebody answered it — which is the "visible to everyone, owned by
+# nobody" that the three-way split of the queue exists to fix. Following
+# does not fill the gap: it is written by replying, so it records what
+# already happened rather than saying "I am taking this".
+#
+# Deliberately only about the conversation. A set has no state to move
+# through, and this column must not become the seed of one.
+class AddAssigneeToSubmissionSets < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :submission_sets, :assignee, foreign_key: {to_table: :users}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_21_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_21_000002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -403,10 +403,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_21_000001) do
   end
 
   create_table "submission_sets", force: :cascade do |t|
+    t.bigint "assignee_id"
     t.datetime "created_at", null: false
     t.string "name", null: false
     t.bigint "owner_id", null: false
     t.datetime "updated_at", null: false
+    t.index ["assignee_id"], name: "index_submission_sets_on_assignee_id"
     t.index ["owner_id"], name: "index_submission_sets_on_owner_id"
   end
 
@@ -524,6 +526,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_21_000001) do
   add_foreign_key "submission_set_messages", "users"
   add_foreign_key "submission_set_participants", "submission_sets"
   add_foreign_key "submission_set_participants", "users"
+  add_foreign_key "submission_sets", "users", column: "assignee_id"
   add_foreign_key "submission_sets", "users", column: "owner_id"
   add_foreign_key "submission_updates", "submissions"
   add_foreign_key "submissions", "submission_updates", column: "cached_at_update_id", on_delete: :nullify

--- a/test/models/submission_request_test.rb
+++ b/test/models/submission_request_test.rb
@@ -155,24 +155,26 @@ class SubmissionRequestTest < ActiveSupport::TestCase
     assert_equal 0, req.unread_message_count_for(users(:bob)), 'a stale press must not resurrect'
   end
 
-  # If everyone who touched it has stopped following, nobody is watching
-  # it — which is what Unclaimed is for. Keying on the row's existence
-  # would leave such a request owned by nobody and visible to nobody.
-  test 'a request nobody follows any more is unclaimed again' do
+  # Unclaimed asks one question — has anybody claimed this — because a
+  # two-part answer is not one a screen can ask somebody to remember.
+  # Following is not claiming: it says who is listening, and a pool that
+  # depended on that left work visible to nobody when the listener put
+  # it aside.
+  test 'following a request does not take it out of the pool' do
     req = submission_requests(:bioproject)
     req.subscribe!(users(:bob))
 
-    assert_not_includes SubmissionRequest.unclaimed, req
-
-    req.unsubscribe!(users(:bob))
-
     assert_includes SubmissionRequest.unclaimed, req
+
+    req.assign!(users(:bob))
+
+    assert_not_includes SubmissionRequest.unclaimed, req, 'claiming does'
   end
 
-  test 'unclaimed excludes anything assigned or participated in' do
-    assigned    = submission_requests(:bioproject)
-    involved    = submission_requests(:biosample)
-    untouched   = submission_requests(:st26)
+  test 'unclaimed excludes anything assigned, and nothing else' do
+    assigned  = submission_requests(:bioproject)
+    involved  = submission_requests(:biosample)
+    untouched = submission_requests(:st26)
 
     assigned.assign!(users(:bob))
     involved.participate!(users(:bob))
@@ -180,8 +182,8 @@ class SubmissionRequestTest < ActiveSupport::TestCase
     unclaimed = SubmissionRequest.unclaimed
 
     assert_includes     unclaimed, untouched
+    assert_includes     unclaimed, involved, 'somebody worked on it, but nobody has taken it'
     assert_not_includes unclaimed, assigned
-    assert_not_includes unclaimed, involved
   end
 
   # --- needs_submitter_action --------------------------------------------

--- a/test/services/my_queue_test.rb
+++ b/test/services/my_queue_test.rb
@@ -54,21 +54,33 @@ class MyQueueTest < ActiveSupport::TestCase
     assert_includes section(:involved).scope, @req
   end
 
-  # SQL inequality is NULL for an unassigned row, so the obvious
-  # `where.not(assignee_id:)` dropped exactly this case — and since
-  # Unclaimed excludes anything with a participant, replying to a
-  # submitter made the request vanish from every curator's queue.
-  test 'a request I worked on that nobody owns is still in I am involved' do
-    unread_request.participate!(users(:bob))
+  # Unclaimed is one question — has anybody claimed this — and having
+  # replied is not a claim. The row stays in the pool until somebody
+  # takes it, wherever else it also appears.
+  test 'a request I worked on that nobody owns is in Unclaimed, not in I am involved' do
+    unread_request.subscribe!(users(:bob))
 
     assert_nil @req.assignee_id
-    assert_includes section(:involved).scope, @req
+    assert_includes     section(:unclaimed).scope, @req
+    assert_not_includes section(:involved).scope,  @req
   end
 
   test 'an untouched, unowned request is in Unclaimed' do
     unread_request
 
     assert_includes section(:unclaimed).scope, @req
+  end
+
+  # The hole the old rule left: a curator who followed something and
+  # then put it aside took it out of their own sections AND out of
+  # everybody's pool, leaving a submitter waiting on work that appeared
+  # in no queue at all.
+  test 'putting an unclaimed request aside does not take it out of the pool' do
+    unread_request.subscribe!(users(:bob))
+    @req.mark_read_by!(users(:bob), through: @req.messages.last.id)
+
+    assert_includes section(:unclaimed).scope,               @req
+    assert_includes section(:unclaimed, users(:dave)).scope, @req
   end
 
   # Somebody else's work is not this curator's queue.
@@ -170,6 +182,21 @@ class MyQueueTest < ActiveSupport::TestCase
 
     assert_equal :involved, section_of(set)
     assert_equal :assigned, section_of(set, users(:dave))
+  end
+
+  # Following is not claiming, on this axis either — and a follower who
+  # puts it aside must not take it out of the pool with them.
+  test 'a set nobody holds stays in the pool however many people follow it' do
+    set = waiting_set
+
+    set.subscribe! users(:bob)
+
+    assert_equal :unclaimed, section_of(set)
+
+    set.mark_read_by!(users(:bob), as: :curator, through: set.messages.last.id)
+
+    assert_equal :unclaimed, section_of(set)
+    assert_equal :unclaimed, section_of(set, users(:dave))
   end
 
   # Releasing puts it back where anybody can take it.

--- a/test/services/my_queue_test.rb
+++ b/test/services/my_queue_test.rb
@@ -128,11 +128,64 @@ class MyQueueTest < ActiveSupport::TestCase
     }
   end
 
+  # Sets live in the same three sections as requests: what makes a piece
+  # of work this curator's is the same question either way.
+  def queued_sets(user = users(:bob))
+    MyQueue.new(user).sections.flat_map { it.set_conversations.to_a }
+  end
+
+  def section_of(set, user = users(:bob))
+    MyQueue.new(user).sections.find { it.set_conversations.exists?(id: set.id) }&.key
+  end
+
   test 'a set with an unanswered question is in the queue, and its count is the badge' do
     set = waiting_set
 
-    assert_equal [set], MyQueue.new(users(:bob)).sets.to_a
+    assert_equal [set], queued_sets
     assert_equal 1,     MyQueue.new(users(:bob)).set_count
+  end
+
+  # The three sections, on the set axis. Claiming is what takes a
+  # conversation out of everybody else's queue — which is the whole
+  # reason the column exists.
+  test 'an unclaimed set is unclaimed for everyone, and claiming moves it' do
+    set = waiting_set
+
+    assert_equal :unclaimed, section_of(set)
+    assert_equal :unclaimed, section_of(set, users(:dave))
+
+    set.assign! users(:bob)
+
+    assert_equal :assigned, section_of(set)
+    assert_nil section_of(set, users(:dave)), 'somebody else holds it and dave has never touched it'
+  end
+
+  # Answering follows it, so a colleague who replied to a set somebody
+  # else holds keeps seeing it — without owning it.
+  test 'a set you follow but do not hold is involved, not assigned' do
+    set = waiting_set
+
+    set.assign!    users(:dave)
+    set.subscribe! users(:bob)
+
+    assert_equal :involved, section_of(set)
+    assert_equal :assigned, section_of(set, users(:dave))
+  end
+
+  # Releasing puts it back where anybody can take it.
+  test 'releasing a set makes it unclaimed again' do
+    set = waiting_set
+
+    set.assign! users(:bob)
+    set.assign! nil
+
+    assert_equal :unclaimed, section_of(set)
+  end
+
+  test 'only a curator can be assigned a set' do
+    set = waiting_set
+
+    assert_raises(ArgumentError) { set.assign!(users(:alice)) }
   end
 
   test 'the total counts both axes' do
@@ -148,19 +201,37 @@ class MyQueueTest < ActiveSupport::TestCase
 
     set.messages.create!(user: users(:dave), author_role: :curator, body: 'Two.')
 
-    assert_empty MyQueue.new(users(:bob)).sets.to_a
-    assert_empty MyQueue.new(users(:dave)).sets.to_a
+    assert_empty queued_sets
+    assert_empty queued_sets(users(:dave))
   end
 
-  # Reading is not answering, and it speaks for nobody else.
+  # Reading is not answering, and it speaks for nobody else. Read
+  # through `set_count` — the number behind the Sets tab — because that
+  # is the per-curator one: the Unclaimed section is deliberately the
+  # same for everybody (a colleague putting something aside must not hide
+  # it from the pool), which is the request axis's rule too.
   test 'marking read clears one curator and leaves the others' do
     set     = waiting_set
     message = set.messages.last
 
     set.mark_read_by!(users(:bob), as: :curator, through: message.id)
 
-    assert_empty MyQueue.new(users(:bob)).sets.to_a
-    assert_equal [set], MyQueue.new(users(:dave)).sets.to_a
+    assert_equal 0, MyQueue.new(users(:bob)).set_count
+    assert_equal 1, MyQueue.new(users(:dave)).set_count
+  end
+
+  # Claimed, it is one curator's — and marking it read takes it out of
+  # their sections rather than only out of their badge.
+  test 'marking an assigned set read takes it out of the queue' do
+    set = waiting_set
+
+    set.assign! users(:bob)
+
+    assert_equal [set], queued_sets
+
+    set.mark_read_by!(users(:bob), as: :curator, through: set.messages.last.id)
+
+    assert_empty queued_sets
   end
 
   # The marker never moves backwards: a stale tab rendered when more was
@@ -174,7 +245,7 @@ class MyQueueTest < ActiveSupport::TestCase
     set.mark_read_by!(users(:bob), as: :curator, through: second.id)
     set.mark_read_by!(users(:bob), as: :curator, through: first.id)
 
-    assert_empty MyQueue.new(users(:bob)).sets.to_a, 'the older press must not undo the newer one'
+    assert_equal 0, MyQueue.new(users(:bob)).set_count, 'the older press must not undo the newer one'
   end
 
   # `through` bounds what a press can discharge to what was on screen.
@@ -185,7 +256,7 @@ class MyQueueTest < ActiveSupport::TestCase
     set.messages.create!(user: users(:alice), author_role: :member, body: 'One more')
     set.mark_read_by!(users(:bob), as: :curator, through: seen.id)
 
-    assert_equal [set], MyQueue.new(users(:bob)).sets.to_a
+    assert_equal 1, MyQueue.new(users(:bob)).set_count
   end
 
   # Which side somebody acts from is the screen they pressed, not what
@@ -197,12 +268,12 @@ class MyQueueTest < ActiveSupport::TestCase
     set.mark_read_by!(users(:bob), as: :member, through: set.messages.last.id)
 
     assert_not_nil membership.reload.last_read_at, 'the member side is what a press on the member screen marks'
-    assert_equal [set], MyQueue.new(users(:bob)).sets.to_a,
+    assert_equal 1, MyQueue.new(users(:bob)).set_count,
                  'and it must not discharge a curator queue entry they never saw as a curator'
 
     set.mark_read_by!(users(:bob), as: :curator, through: set.messages.last.id)
 
-    assert_empty MyQueue.new(users(:bob)).sets.to_a
+    assert_equal 0, MyQueue.new(users(:bob)).set_count
   end
 
   test 'the oldest question comes first' do
@@ -212,6 +283,6 @@ class MyQueueTest < ActiveSupport::TestCase
     older.messages.create!(user: users(:alice), author_role: :member, body: 'Still waiting', created_at: 7.days.ago)
     older.touch
 
-    assert_equal [older, recent], MyQueue.new(users(:bob)).sets.to_a
+    assert_equal [older, recent], queued_sets
   end
 end

--- a/test/system/admin_sets_test.rb
+++ b/test/system/admin_sets_test.rb
@@ -31,7 +31,7 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
 
     visit admin_my_queue_path
 
-    within '[data-test-section="sets"]' do
+    within '[data-test-section="unclaimed"]' do
       assert_text 'Deep sea study'
       assert_text '1 submission, 2 members'
 
@@ -63,7 +63,7 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
 
     visit admin_my_queue_path
 
-    assert_no_selector '[data-test-section="sets"]'
+    assert_no_selector "[data-test-set='#{@set.id}']"
   end
 
   # Reading is not answering. A curator who has looked and decided there
@@ -79,7 +79,11 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
     assert_text 'Marked as read.'
 
     visit admin_my_queue_path
-    assert_no_selector '[data-test-section="sets"]'
+
+    # Unclaimed is the shared pool and is the same for everybody — the
+    # request axis's rule — so what a press puts aside is this curator's
+    # own count, on the Sets tab.
+    assert_selector '.navbar', text: 'Sets 0'
 
     # A colleague still has it.
     assert_equal 1, SubmissionSet.needing_curator(users(:dave)).count
@@ -169,12 +173,64 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
 
     visit admin_my_queue_path
 
-    within '[data-test-section="sets"]' do
-      names = all('.list-group-item strong').map(&:text)
+    within '[data-test-section="unclaimed"]' do
+      names = all('[data-test-set] a.fw-semibold').map(&:text)
 
       assert_equal ['Asked last week, renamed just now', 'Deep sea study'], names
       assert_text 'waiting 7d ago'
     end
+  end
+
+  # Claiming the conversation. Without it a waiting set sits in every
+  # curator's queue until somebody answers, which is the "visible to
+  # everyone, owned by nobody" the three sections exist to fix.
+  test 'a curator takes a set conversation on, and gives it back' do
+    @set.messages.create!(user: @alice, author_role: :member, body: 'Anyone?')
+
+    visit admin_my_queue_path
+
+    within '[data-test-section="unclaimed"]' do
+      click_button 'Assign to me'
+    end
+
+    assert_text 'Answering: bob'
+
+    visit admin_my_queue_path
+
+    within '[data-test-section="assigned"]' do
+      assert_text 'Deep sea study'
+    end
+
+    # And a colleague no longer sees it as theirs to pick up.
+    assert_empty MyQueue.new(users(:dave)).sections.flat_map { it.set_conversations.to_a }
+
+    visit admin_set_path(@set)
+    click_button 'Release'
+
+    assert_text 'Nobody is answering this set'
+
+    visit admin_my_queue_path
+
+    within '[data-test-section="unclaimed"]' do
+      assert_text 'Deep sea study'
+    end
+  end
+
+  # Somebody else holding it is not a wall — the roster is small and the
+  # coordination is human — but it has to be visible that it was theirs.
+  test 'a set somebody else holds says so, and can be taken over' do
+    @set.messages.create!(user: @alice, author_role: :member, body: 'Anyone?')
+    @set.assign! users(:dave)
+
+    visit admin_set_path(@set)
+
+    within '[data-test-answering]' do
+      assert_text 'dave'
+    end
+
+    click_button 'Take over'
+
+    assert_text 'Answering: bob'
   end
 
   # Who is already curating what is in the set. This is what decides
@@ -195,7 +251,7 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
 
     visit admin_my_queue_path
 
-    within '[data-test-section="sets"]' do
+    within '[data-test-section="unclaimed"]' do
       assert_text '3 submissions, 2 members — 1 yours, 1 dave, 1 unassigned'
     end
   end
@@ -207,7 +263,7 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
 
     visit admin_my_queue_path
 
-    within '[data-test-section="sets"]' do
+    within '[data-test-section="unclaimed"]' do
       assert_text '1 unassigned'
       assert_no_text 'yours'
     end

--- a/test/system/admin_sets_test.rb
+++ b/test/system/admin_sets_test.rb
@@ -80,10 +80,14 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
 
     visit admin_my_queue_path
 
-    # Unclaimed is the shared pool and is the same for everybody — the
-    # request axis's rule — so what a press puts aside is this curator's
-    # own count, on the Sets tab.
+    # Unclaimed is the shared pool: nobody has claimed this, so putting
+    # it aside is about this curator's own count on the Sets tab and not
+    # about whether anybody else can still find it.
     assert_selector '.navbar', text: 'Sets 0'
+
+    within '[data-test-section="unclaimed"]' do
+      assert_text 'Deep sea study'
+    end
 
     # A colleague still has it.
     assert_equal 1, SubmissionSet.needing_curator(users(:dave)).count


### PR DESCRIPTION
セット軸には claim が無かったので、**待っているセットは誰かが答えるまで全員の queue に居座って**いました。3分割はまさに「全員に見えていて誰のものでもない」を潰すためのもので、フォローは投稿すると自動で付く事後の記録なので「私が見ます」を先に言う手段になりません。

`submission_sets.assignee_id` を足し、request と同じ3セクションが **request の行とセットの行を混ぜて持つ**形にしました。別ブロックだった「Set conversations」は消え、「自分に関係する順に並んだ、待っているもの全部」に戻ります。

```
Assigned to me   1
  test  [Set]  2 submissions, 1 member — 1 yours, 1 keycloak   1 unread message   waiting 15m ago  [Answer]

Unclaimed        1
  #19547  BioSample  SSUB000001 · ursm   3 of 3 samples to issue   20d  [Issue] [Assign to me]
```

## 会話の claim であって、セットの状態ではない

画面の語も「Assignee」ではなく **`Answering: bob`**。セットには進むべき状態が無く、この列がステータス列の種になってはいけないので。

- 未割当なら `Answer this` / 自分が持っていれば `Release` / 他人が持っていれば `Take over`（名簿は小さく調整は人間がするので壁にはしない）
- queue の Unclaimed からは request と同じ `Assign to me`
- 一覧に Answering 列

## Unclaimed が curator ごとでないのは request 軸と同じ

既読で外れるのは「自分の」セクションと Sets タブの数字であって、共有プールではありません（同僚が脇に置いたものがプールから消えると困る）。

ついでに「I'm involved」の説明文を直しました。未割当でフォロー中のものもここに入るので、`someone else holds the assignment` は嘘でした。

- `bin/rails test:all` 1327 / rubocop・brakeman clean
- ブラウザで確認済み（claim → Assigned to me へ移動 → Release → Unclaimed へ戻る）
- ベースは #2019

🤖 Generated with [Claude Code](https://claude.com/claude-code)