### PR TITLE
セットのスレッドを request 側と同じところまで持っていく

### DIFF
--- a/app/controllers/admin/set_messages_controller.rb
+++ b/app/controllers/admin/set_messages_controller.rb
@@ -15,7 +15,24 @@ module Admin
         return
       end
 
-      message = @set.messages.create!(user: current_user, author_role: :curator, body:, files:)
+      cc = cc_users
+
+      message = @set.messages.create!(
+        user:        current_user,
+        author_role: :curator,
+        body:,
+        cc_user_ids: cc.map(&:id),
+        files:
+      )
+
+      # Copied-in curators follow it from here on, which is the whole of
+      # what copying somebody in does. Told now as well as followed: a
+      # set with nothing unanswered says nothing in a queue, so without a
+      # mail they would learn of it whenever a member next happened to
+      # write, which may be never.
+      cc.each { @set.subscribe!(it) }
+
+      SubmissionSetMessageMailer.with(message:).copied_in.deliver_later if cc.any?
 
       # Everyone in the set hears about it — see
       # SubmissionSetMessageMailer for what that costs at size.
@@ -33,7 +50,10 @@ module Admin
       @set.subscribe!(current_user)
       @set.mark_read_by!(current_user, as: :curator, through: params[:through_id])
 
-      redirect_to admin_set_path(@set), notice: "Message sent to #{helpers.pluralize(@set.users.size, 'member')} of this set."
+      notice = "Message sent to #{helpers.pluralize(@set.users.size, 'member')} of this set."
+      notice += " #{cc.map(&:uid).to_sentence} copied in." if cc.any?
+
+      redirect_to admin_set_path(@set), notice:
     end
 
     # "I know about this." A member's message a curator has read and does
@@ -53,5 +73,15 @@ module Admin
     private
 
     def load_set = @set = SubmissionSet.find(params.expect(:set_id))
+
+    # Admins other than the sender, from what the form offered. Anything
+    # else in the params is dropped rather than refused: copying somebody
+    # in is a courtesy on top of the message, and it must not be able to
+    # stop the message being sent.
+    def cc_users
+      ids = Array(params[:cc_user_ids]).map(&:to_i)
+
+      User.staff.where(id: ids).where.not(id: current_user.id).order(:uid).to_a
+    end
   end
 end

--- a/app/controllers/admin/sets_controller.rb
+++ b/app/controllers/admin/sets_controller.rb
@@ -71,9 +71,12 @@ module Admin
       # three-year conversation is not a page to render by default.
       thread = @set.messages.includes(:user, files_attachments: :blob)
 
+      # `thread_page` sets `@thread_size`; the full render has to say what
+      # it is showing all of.
       @messages    = params[:full].present? ? thread.to_a : thread_page(thread)
-      @thread_size = @set.messages.count
-      @members  = @set.members.ordered.includes(:user, :invited_by).to_a
+      @thread_size ||= @messages.size
+
+      @members = @set.members.ordered.includes(:user, :invited_by).to_a
 
       # Paginated: a set holds however much it holds, and a three-year
       # study is hundreds of submissions. The member's own view of the

--- a/app/controllers/admin/sets_controller.rb
+++ b/app/controllers/admin/sets_controller.rb
@@ -14,6 +14,7 @@ module Admin
   # this" is answered by who is following it — which is a thing curators
   # already read on the request axis.
   class SetsController < ApplicationController
+    include MessageThreadPaging
     include Pagy::Method
 
     helper_method :waiting?, :following?
@@ -64,7 +65,14 @@ module Admin
 
       # The thread renders each message's attachments as well as its
       # author — `:user` alone leaves a pair of queries per message.
-      @messages = @set.messages.includes(:user, files_attachments: :blob).to_a
+      #
+      # The newest page unless asked for the whole of it: a curator
+      # opening a set is looking at what was said recently, and a
+      # three-year conversation is not a page to render by default.
+      thread = @set.messages.includes(:user, files_attachments: :blob)
+
+      @messages    = params[:full].present? ? thread.to_a : thread_page(thread)
+      @thread_size = @set.messages.count
       @members  = @set.members.ordered.includes(:user, :invited_by).to_a
 
       # Paginated: a set holds however much it holds, and a three-year

--- a/app/controllers/admin/submission_requests_controller.rb
+++ b/app/controllers/admin/submission_requests_controller.rb
@@ -8,6 +8,7 @@ module Admin
     include RequestListing
     include SubmissionDetail
     include RequestSearch
+    include MessageThreadPaging
 
     before_action :load_workbench, only: %i[show samples entries messages record]
 
@@ -98,7 +99,14 @@ module Admin
       # The thread renders each message's attachments as well as its
       # author, and `:user` does not cover them — one pair of queries per
       # message otherwise.
-      @messages = @request.messages.includes(:user, files_attachments: :blob).to_a
+      #
+      # The newest page unless asked for the whole of it, as on the set
+      # axis: a curator opening a thread is looking at what was said
+      # recently.
+      thread = @request.messages.includes(:user, files_attachments: :blob)
+
+      @messages    = params[:full].present? ? thread.to_a : thread_page(thread)
+      @thread_size = @request.messages.count
     end
 
     def record

--- a/app/controllers/admin/submission_requests_controller.rb
+++ b/app/controllers/admin/submission_requests_controller.rb
@@ -105,8 +105,10 @@ module Admin
       # recently.
       thread = @request.messages.includes(:user, files_attachments: :blob)
 
+      # `thread_page` sets `@thread_size`; the full render has to say what
+      # it is showing all of.
       @messages    = params[:full].present? ? thread.to_a : thread_page(thread)
-      @thread_size = @request.messages.count
+      @thread_size ||= @messages.size
     end
 
     def record

--- a/app/controllers/concerns/message_thread_paging.rb
+++ b/app/controllers/concerns/message_thread_paging.rb
@@ -16,17 +16,29 @@ module MessageThreadPaging
 
   private
 
-  # `before_id` is the oldest message the caller already has. Ids are
-  # sequential and `chronological` breaks ties by id, so the cursor and
-  # the reading order are the same order.
+  # `before_id` is the oldest message the caller already has.
+  #
+  # Paged by id and cut by id — one column for both, so the boundary is
+  # exact. `created_at` is stamped in Ruby and the id at INSERT, so two
+  # messages written at the same moment can disagree about which is
+  # older; paging by one and cutting by the other would then hand the
+  # same message out twice, and the thread renders it twice because
+  # nothing keys the list.
+  #
+  # Sets `@thread_size` as well as the header: the screens that render
+  # the page need the same number, and it is one COUNT either way.
   def thread_page(scope)
     # `reorder`, not `order`: the association carries `chronological`, and
     # appending to it leaves the oldest end first — so the page would be
     # the *beginning* of the thread, rendered backwards.
-    page = scope.reorder(created_at: :desc, id: :desc)
-    page = page.where(id: ...params[:before_id].to_i) if params[:before_id].present?
+    page   = scope.reorder(id: :desc)
+    before = params[:before_id].to_s.to_i
 
-    response.headers['Total-Count'] = scope.reorder(nil).count.to_s
+    page = page.where(id: ...before) if before.positive?
+
+    @thread_size = scope.reorder(nil).count
+
+    response.headers['Total-Count'] = @thread_size.to_s
 
     page.limit(PER_PAGE).to_a.reverse
   end

--- a/app/controllers/concerns/message_thread_paging.rb
+++ b/app/controllers/concerns/message_thread_paging.rb
@@ -1,0 +1,33 @@
+# A thread is read from the end, so it is loaded from the end.
+#
+# Not `pagy`: page numbers count from the oldest message, so every new
+# message shifts what "page 2" means, and the page somebody is reading
+# changes under them. A cursor does not move.
+#
+# `Total-Count` says how many there are in all, which is what tells a
+# client whether there is anything earlier to ask for. It is already in
+# the CORS expose list, unlike a header invented here.
+module MessageThreadPaging
+  extend ActiveSupport::Concern
+
+  # Enough that most threads arrive whole, small enough that the one that
+  # does not cannot hold up the screen.
+  PER_PAGE = 50
+
+  private
+
+  # `before_id` is the oldest message the caller already has. Ids are
+  # sequential and `chronological` breaks ties by id, so the cursor and
+  # the reading order are the same order.
+  def thread_page(scope)
+    # `reorder`, not `order`: the association carries `chronological`, and
+    # appending to it leaves the oldest end first — so the page would be
+    # the *beginning* of the thread, rendered backwards.
+    page = scope.reorder(created_at: :desc, id: :desc)
+    page = page.where(id: ...params[:before_id].to_i) if params[:before_id].present?
+
+    response.headers['Total-Count'] = scope.reorder(nil).count.to_s
+
+    page.limit(PER_PAGE).to_a.reverse
+  end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,5 +1,6 @@
 class MessagesController < ApplicationController
   include AttachmentSignedIds
+  include MessageThreadPaging
 
   before_action :load_submission_request
 
@@ -10,7 +11,7 @@ class MessagesController < ApplicationController
   # curator waiting on that answer saw nothing either, because their queue
   # tracks unread SUBMITTER messages. The conversation just went quiet.
   def index
-    @messages = @request.messages.includes(:user, files_attachments: :blob).to_a
+    @messages = thread_page(@request.messages.includes(:user, files_attachments: :blob))
   end
 
   def create

--- a/app/controllers/set_messages_controller.rb
+++ b/app/controllers/set_messages_controller.rb
@@ -8,6 +8,7 @@
 class SetMessagesController < ApplicationController
   include SetContents
   include AttachmentSignedIds
+  include MessageThreadPaging
 
   # Both writes: `read` moves a marker on the member's own roster row,
   # which is that person's reminder and not a curator's to discharge
@@ -16,7 +17,7 @@ class SetMessagesController < ApplicationController
   before_action :load_set
 
   def index
-    @messages = @set.messages.includes(:user, files_attachments: :blob).to_a
+    @messages = thread_page(@set.messages.includes(:user, files_attachments: :blob))
   end
 
   def create

--- a/app/mailers/submission_set_message_mailer.rb
+++ b/app/mailers/submission_set_message_mailer.rb
@@ -63,6 +63,27 @@ class SubmissionSetMessageMailer < ApplicationMailer
     )
   end
 
+  # Copied in by a colleague. A separate mail from the members', because
+  # the audience and the ask are different: the set is being answered,
+  # these curators are being shown something.
+  #
+  # It has to be a mail rather than only a subscription: a curator who
+  # has just answered leaves nothing unanswered, so the queue would say
+  # nothing about the set until a member writes back — which may be
+  # never, and is not when they were asked to look.
+  def copied_in
+    @message = params[:message]
+    @set     = @message.set
+
+    recipients = @message.cc_users.filter_map { recipient_for(it) }
+    return if recipients.empty?
+
+    mail(
+      to:      recipients,
+      subject: "[DDBJ Repository] #{@message.user.uid} copied you in on the set “#{@set.name}”"
+    )
+  end
+
   private
 
   # A Bcc-only mail still needs somewhere to be addressed, and the

--- a/app/models/submission_set.rb
+++ b/app/models/submission_set.rb
@@ -298,10 +298,18 @@ class SubmissionSet < ApplicationRecord
     marked.positive?
   end
 
-  # Who hears about a message here, apart from whoever wrote it. Asked by
-  # the mailer and by the caller deciding whether there is anything to
-  # send, so the two cannot drift.
-  def followers_to_notify(message) = followers.reject { it.id == message.user_id }
+  # Who hears about a message here, apart from whoever wrote it and
+  # anyone being copied in on it — they get the more direct mail, and
+  # copying somebody in subscribes them, so without this they would be
+  # told twice about one message.
+  #
+  # Asked by the mailer and by the caller deciding whether there is
+  # anything to send, so the two cannot drift.
+  def followers_to_notify(message)
+    told = [message.user_id, *message.cc_user_ids]
+
+    followers.reject { told.include?(it.id) }
+  end
 
   def following?(user)
     return false unless user

--- a/app/models/submission_set_message.rb
+++ b/app/models/submission_set_message.rb
@@ -44,6 +44,10 @@ class SubmissionSetMessage < ApplicationRecord
   # misfire, and both sides refuse it before they get here.
   validates :body, presence: true, unless: -> { files.attached? }
 
+  # Curators copied in on this message. Subscribing them is what makes it
+  # do anything later; this is what makes the thread say it happened.
+  def cc_users = User.where(id: cc_user_ids).order(:uid)
+
   scope :chronological, -> { order(:created_at, :id) }
 
   # Both scopes below compare `(created_at, id)` rather than `created_at`

--- a/app/views/admin/messages/_also_notify.html.erb
+++ b/app/views/admin/messages/_also_notify.html.erb
@@ -1,0 +1,37 @@
+<%# locals: (colleagues:, followers:, following:) %>
+<%# What a curator does in mail without thinking about it. Without it the %>
+<%# only way to bring a colleague in is to tell them out of band, and the %>
+<%# thread stops being the record of who was asked. %>
+<%# %>
+<%# Not behind a disclosure. This is one field and no ceremony in mail, %>
+<%# and a control nobody finds is a control nobody uses. %>
+<% if colleagues.any? %>
+  <div class="mb-3">
+    <span class="form-label">Also notify</span>
+
+    <div>
+      <% colleagues.each do |colleague| %>
+        <% already = followers.include?(colleague) %>
+
+        <%# Copying somebody in adds them to the notifications from here %>
+        <%# on — that is all it does. This thread is not a way to put %>
+        <%# work to another curator, so there is nothing a tick could %>
+        <%# mean for somebody already following. Shown ticked and fixed %>
+        <%# rather than blank, which would read as a list you have to %>
+        <%# fill in on every message. %>
+        <div class="form-check form-check-inline">
+          <%= check_box_tag 'cc_user_ids[]', colleague.id, already,
+                            id: "cc_#{colleague.id}", class: 'form-check-input',
+                            disabled: already %>
+          <%= label_tag "cc_#{colleague.id}", colleague.uid,
+                        class: "form-check-label#{' text-body-secondary' if already}" %>
+        </div>
+      <% end %>
+    </div>
+
+    <p class="text-body-secondary small mb-0 mt-1">
+      Anyone already following is emailed a copy — greyed above, nothing to do.
+      Ticking somebody else starts notifying them of <%= following %> from here on.
+    </p>
+  </div>
+<% end %>

--- a/app/views/admin/messages/_thread.html.erb
+++ b/app/views/admin/messages/_thread.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (request:, messages:, unread: 0, colleagues: [], followers: []) %>
+<%# locals: (request:, messages:, unread: 0, colleagues: [], followers: [], thread_size: nil) %>
 <%# Per-request curator ↔ submitter thread. Submitter posts via the web %>
 <%# UI; curator posts via the form at the bottom. Speakers are told apart %>
 <%# by side and colour rather than by a label the eye has to read. %>
@@ -34,6 +34,16 @@
   </div>
 
   <% if messages.any? %>
+    <%# A thread is read from its newest end, so that is the end this %>
+    <%# renders. What is missing is the beginning of it. %>
+    <% if thread_size && thread_size > messages.size %>
+      <p class="small mb-3">
+        <%= link_to "Show all #{number_with_delimiter(thread_size)} messages",
+                    messages_admin_submission_request_path(request, full: 1), data: {test_show_full: true} %>
+        <span class="text-body-secondary">— the <%= messages.size %> most recent are below.</span>
+      </p>
+    <% end %>
+
     <ul class="list-unstyled mb-4 d-flex flex-column gap-3">
       <% messages.each do |m| %>
         <li class="d-flex gap-3 <%= 'ps-5' unless m.curator_role? %>">

--- a/app/views/admin/messages/_thread.html.erb
+++ b/app/views/admin/messages/_thread.html.erb
@@ -101,42 +101,7 @@
       <%= file_field_tag 'files[]', multiple: true, class: 'form-control', data: {direct_upload_url: admin_direct_uploads_path} %>
     </div>
 
-    <%# What a curator does in mail without thinking about it. Without %>
-    <%# it the only way to bring a colleague in is to tell them out of %>
-    <%# band, and the thread stops being the record of who was asked. %>
-    <%# Not behind a disclosure. This is one field and no ceremony in %>
-    <%# mail, and a control nobody finds is a control nobody uses. %>
-    <% if colleagues.any? %>
-      <div class="mb-3">
-        <span class="form-label">Also notify</span>
-
-        <div>
-          <% colleagues.each do |colleague| %>
-            <% already = followers.include?(colleague) %>
-
-            <%# Copying somebody in adds them to the notifications from %>
-            <%# here on — that is all it does. This thread is the %>
-            <%# curator's conversation with the submitter, not a way to %>
-            <%# put work to another curator, so there is nothing a tick %>
-            <%# could mean for somebody already following. Shown ticked %>
-            <%# and fixed rather than blank, which would read as a list %>
-            <%# you have to fill in on every message. %>
-            <div class="form-check form-check-inline">
-              <%= check_box_tag 'cc_user_ids[]', colleague.id, already,
-                                id: "cc_#{colleague.id}", class: 'form-check-input',
-                                disabled: already %>
-              <%= label_tag "cc_#{colleague.id}", colleague.uid,
-                            class: "form-check-label#{' text-body-secondary' if already}" %>
-            </div>
-          <% end %>
-        </div>
-
-        <p class="text-body-secondary small mb-0 mt-1">
-          Anyone already following is emailed a copy — greyed above, nothing to do.
-          Ticking somebody else starts notifying them of this thread from here on.
-        </p>
-      </div>
-    <% end %>
+    <%= render 'admin/messages/also_notify', colleagues:, followers:, following: 'this thread' %>
 
     <%= f.submit 'Send message', class: 'btn btn-primary' %>
   <% end %>

--- a/app/views/admin/sets/_thread.html.erb
+++ b/app/views/admin/sets/_thread.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (set:, messages:, unread: 0, colleagues: [], followers: []) %>
+<%# locals: (set:, messages:, unread: 0, colleagues: [], followers: [], thread_size: nil) %>
 <%# The set's own thread. Everyone on the roster is party to it, which is %>
 <%# the difference from the per-request thread and the reason the author %>
 <%# of each message is named. %>
@@ -29,6 +29,16 @@
   <% end %>
 
   <% if messages.any? %>
+    <%# A thread is read from its newest end, so that is the end this %>
+    <%# renders. What is missing is the beginning of it. %>
+    <% if thread_size && thread_size > messages.size %>
+      <p class="small mb-3">
+        <%= link_to "Show all #{number_with_delimiter(thread_size)} messages",
+                    admin_set_path(set, full: 1), data: {test_show_full: true} %>
+        <span class="text-body-secondary">— the <%= messages.size %> most recent are below.</span>
+      </p>
+    <% end %>
+
     <ul class="list-unstyled mb-4 d-flex flex-column gap-3">
       <% messages.each do |m| %>
         <li class="d-flex gap-3 <%= 'ps-5' unless m.curator_role? %>">

--- a/app/views/admin/sets/_thread.html.erb
+++ b/app/views/admin/sets/_thread.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (set:, messages:, unread: 0) %>
+<%# locals: (set:, messages:, unread: 0, colleagues: [], followers: []) %>
 <%# The set's own thread. Everyone on the roster is party to it, which is %>
 <%# the difference from the per-request thread and the reason the author %>
 <%# of each message is named. %>
@@ -45,6 +45,16 @@
 
             <div style="white-space: pre-wrap;"><%= m.body %></div>
 
+            <%# Who started following here, on the message that brought %>
+            <%# them in. The subscription is invisible from the thread, so %>
+            <%# without this there is no sign of when somebody joined the %>
+            <%# conversation. %>
+            <% if m.cc_user_ids.any? %>
+              <p class="small text-body-secondary mb-0 mt-2">
+                copied in <%= m.cc_users.map(&:uid).to_sentence %>
+              </p>
+            <% end %>
+
             <% if m.files.attached? %>
               <ul class="list-unstyled mb-0 mt-2 small">
                 <% m.files.each do |file| %>
@@ -79,6 +89,8 @@
       <%= label_tag 'files_', 'Attach files', class: 'form-label' %>
       <%= file_field_tag 'files[]', multiple: true, class: 'form-control', data: {direct_upload_url: admin_direct_uploads_path} %>
     </div>
+
+    <%= render 'admin/messages/also_notify', colleagues:, followers:, following: 'this set' %>
 
     <%= f.submit 'Send message', class: 'btn btn-primary' %>
   <% end %>

--- a/app/views/admin/sets/show.html.erb
+++ b/app/views/admin/sets/show.html.erb
@@ -50,7 +50,9 @@
 <div class="row g-4">
   <div class="col-lg-7">
     <%= render 'thread', set: @set, messages: @messages,
-               unread: @set.unread_message_count_for(current_user) %>
+               unread:     @set.unread_message_count_for(current_user),
+               colleagues: User.staff.where.not(id: current_user.id).order(:uid),
+               followers:  @set.followers.to_a %>
   </div>
 
   <div class="col-lg-5">

--- a/app/views/admin/sets/show.html.erb
+++ b/app/views/admin/sets/show.html.erb
@@ -51,8 +51,9 @@
   <div class="col-lg-7">
     <%= render 'thread', set: @set, messages: @messages,
                unread:     @set.unread_message_count_for(current_user),
-               colleagues: User.staff.where.not(id: current_user.id).order(:uid),
-               followers:  @set.followers.to_a %>
+               colleagues:  User.staff.where.not(id: current_user.id).order(:uid),
+               followers:   @set.followers.to_a,
+               thread_size: @thread_size %>
   </div>
 
   <div class="col-lg-5">

--- a/app/views/admin/submission_requests/messages.html.erb
+++ b/app/views/admin/submission_requests/messages.html.erb
@@ -2,7 +2,8 @@
 
 <%= render layout: 'workbench', locals: {tab: :messages} do %>
   <%= render 'admin/messages/thread', request: @request, messages: @messages,
-             unread:     @request.unread_message_count_for(current_user),
-             colleagues: User.staff.where.not(id: current_user.id).order(:uid),
-             followers:  @request.followers.to_a %>
+             unread:      @request.unread_message_count_for(current_user),
+             colleagues:  User.staff.where.not(id: current_user.id).order(:uid),
+             followers:   @request.followers.to_a,
+             thread_size: @thread_size %>
 <% end %>

--- a/app/views/submission_set_message_mailer/copied_in.html.erb
+++ b/app/views/submission_set_message_mailer/copied_in.html.erb
@@ -1,0 +1,24 @@
+<% thread_url = File.join(Rails.application.config_for(:app).app_url!, 'admin', 'sets', @set.id.to_s) %>
+
+<p>
+  <%= @message.user.uid %> copied you in on the set “<%= @set.name %>”
+  (<%= @set.submission_requests.size %> submissions, <%= @set.users.size %> members),
+  where they wrote to its members:
+</p>
+
+<% if @message.body.present? %>
+  <blockquote style="border-left: 3px solid #ccc; padding-left: 1em; color: #555;">
+    <%= simple_format @message.body %>
+  </blockquote>
+<% end %>
+
+<%= render 'files', message: @message %>
+
+<p>
+  You are now following this set, so replies from its members will reach your queue.
+  Stop following from the set page if you would rather not.
+</p>
+
+<p><a href="<%= thread_url %>">Open the thread in the admin UI.</a></p>
+
+<p>— DDBJ Repository</p>

--- a/app/views/submission_set_message_mailer/copied_in.text.erb
+++ b/app/views/submission_set_message_mailer/copied_in.text.erb
@@ -1,0 +1,14 @@
+<% app_url = Rails.application.config_for(:app).app_url! -%>
+<%= @message.user.uid %> copied you in on the set “<%= @set.name %>” (<%= @set.submission_requests.size %> submissions, <%= @set.users.size %> members), where they wrote to its members:
+
+<% if @message.body.present? -%>
+<%= @message.body.lines.map { "  #{it}" }.join.chomp %>
+<% end -%>
+<%= render 'files', message: @message -%>
+
+You are now following this set, so replies from its members will reach your queue. Stop following from the set page if you would rather not.
+
+Open the thread in the admin UI:
+<%= File.join(app_url, 'admin', 'sets', @set.id.to_s) %>
+
+— DDBJ Repository

--- a/db/migrate/20260821000003_add_cc_user_ids_to_submission_set_messages.rb
+++ b/db/migrate/20260821000003_add_cc_user_ids_to_submission_set_messages.rb
@@ -1,0 +1,11 @@
+# Copying a colleague in on a set's conversation.
+#
+# The same field the per-request thread carries, for the same reason: it
+# is what a curator does in mail without thinking about it, and without
+# it the only way to bring somebody in is to tell them out of band —
+# which stops the thread being the record of who was asked.
+class AddCcUserIdsToSubmissionSetMessages < ActiveRecord::Migration[8.1]
+  def change
+    add_column :submission_set_messages, :cc_user_ids, :jsonb, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_21_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_21_000003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -381,6 +381,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_21_000002) do
   create_table "submission_set_messages", force: :cascade do |t|
     t.string "author_role", null: false
     t.text "body", null: false
+    t.jsonb "cc_user_ids", default: [], null: false
     t.datetime "created_at", null: false
     t.bigint "submission_set_id", null: false
     t.datetime "updated_at", null: false

--- a/schema/openapi.d.ts
+++ b/schema/openapi.d.ts
@@ -848,10 +848,19 @@ export interface paths {
             };
             cookie?: never;
         };
-        /** @description Get the curator ↔ submitter message thread for a request. Marks any unread curator-authored messages as read. */
+        /**
+         * @description The curator ↔ submitter thread, newest end first: the most recent
+         *     messages in chronological order, with `Total-Count` saying how many
+         *     there are in all. `before_id` asks for the ones older than that —
+         *     a cursor rather than a page number, because a page counted from the
+         *     oldest message moves under the reader every time somebody writes.
+         */
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    /** @description The oldest message the caller already has. */
+                    before_id?: number;
+                };
                 header?: never;
                 path: {
                     submission_request_id: number;
@@ -863,6 +872,8 @@ export interface paths {
                 /** @description Returns the chronological list of messages. */
                 200: {
                     headers: {
+                        /** @description How many messages the thread holds in all. */
+                        "Total-Count"?: string;
                         [name: string]: unknown;
                     };
                     content: {
@@ -1579,10 +1590,17 @@ export interface paths {
          *     submitter and DDBJ, and being able to read somebody's submission
          *     through a shared set is not being party to what they were asked about
          *     it.
+         *
+         *     Newest end first, like the per-request thread: the most recent
+         *     messages in chronological order, `Total-Count` saying how many there
+         *     are in all, and `before_id` asking for the ones older than that.
          */
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    /** @description The oldest message the caller already has. */
+                    before_id?: number;
+                };
                 header?: never;
                 path: {
                     set_id: number;
@@ -1594,6 +1612,8 @@ export interface paths {
                 /** @description The chronological list of messages. */
                 200: {
                     headers: {
+                        /** @description How many messages the thread holds in all. */
+                        "Total-Count"?: string;
                         [name: string]: unknown;
                     };
                     content: {

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -825,14 +825,34 @@ paths:
           type: number
 
     get:
-      description: Get the curator ↔ submitter message thread for a request. Marks any unread curator-authored messages as read.
+      description: |
+        The curator ↔ submitter thread, newest end first: the most recent
+        messages in chronological order, with `Total-Count` saying how many
+        there are in all. `before_id` asks for the ones older than that —
+        a cursor rather than a page number, because a page counted from the
+        oldest message moves under the reader every time somebody writes.
 
       tags:
         - Submission Requests
 
+      parameters:
+        - name: before_id
+          in: query
+          description: The oldest message the caller already has.
+
+          schema:
+            type: number
+
       responses:
         '200':
           description: Returns the chronological list of messages.
+
+          headers:
+            Total-Count:
+              description: How many messages the thread holds in all.
+
+              schema:
+                type: string
 
           content:
             application/json:
@@ -1550,12 +1570,31 @@ paths:
         through a shared set is not being party to what they were asked about
         it.
 
+        Newest end first, like the per-request thread: the most recent
+        messages in chronological order, `Total-Count` saying how many there
+        are in all, and `before_id` asking for the ones older than that.
+
       tags:
         - Sets
+
+      parameters:
+        - name: before_id
+          in: query
+          description: The oldest message the caller already has.
+
+          schema:
+            type: number
 
       responses:
         '200':
           description: The chronological list of messages.
+
+          headers:
+            Total-Count:
+              description: How many messages the thread holds in all.
+
+              schema:
+                type: string
 
           content:
             application/json:

--- a/test/integration/set_messages_test.rb
+++ b/test/integration/set_messages_test.rb
@@ -201,6 +201,30 @@ class SetMessagesTest < ActionDispatch::IntegrationTest
     assert_equal 1, waiting.fetch('unread_message_count'), 'nothing was marked, so nothing was cleared'
   end
 
+  # A thread is read from its newest end, so that is the end it arrives
+  # from — and `Total-Count` is how a client knows there is a beginning
+  # it has not seen.
+  test 'a long thread arrives newest-end first, and says how long it is' do
+    messages = Array.new(MessageThreadPaging::PER_PAGE + 5) {
+      @set.messages.create!(user: @alice, author_role: :member, body: "message #{it}")
+    }
+
+    get set_messages_path(@set)
+
+    assert_conform_schema 200
+    assert_equal MessageThreadPaging::PER_PAGE, response.parsed_body.size
+    assert_equal messages.size.to_s, response.headers['Total-Count']
+    assert_equal messages.last.id,   response.parsed_body.last.fetch('id'), 'the newest is on the page'
+    assert_equal messages.last(MessageThreadPaging::PER_PAGE).map(&:id), response.parsed_body.pluck('id')
+
+    # And the beginning, by cursor: a page number counted from the oldest
+    # message would move every time somebody writes.
+    get set_messages_path(@set, before_id: response.parsed_body.first.fetch('id'))
+
+    assert_conform_schema 200
+    assert_equal messages.first(5).map(&:id), response.parsed_body.pluck('id')
+  end
+
   test 'a message with neither body nor file is refused' do
     with_exceptions_app do
       post set_messages_path(@set), params: {submission_set_message: {body: '   '}}.to_json, headers: JSON_HEADERS

--- a/test/system/admin_sets_test.rb
+++ b/test/system/admin_sets_test.rb
@@ -237,6 +237,44 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
     assert_text 'Answering: bob'
   end
 
+  # Bringing a colleague in. Without it the only way is to tell them out
+  # of band, and then the thread stops being the record of who was asked.
+  test 'a curator copies a colleague in, and it says so on the message' do
+    @set.messages.create!(user: @alice, author_role: :member, body: 'Anyone?')
+
+    visit admin_set_path(@set)
+
+    check 'dave'
+    fill_in 'New message to the set', with: 'Looping dave in.'
+
+    perform_enqueued_jobs do
+      click_button 'Send message'
+    end
+
+    assert_text 'dave copied in'
+    assert_text 'copied in dave'
+
+    # Following from here on is the whole of what copying somebody in
+    # does — plus being told now, because a set with nothing unanswered
+    # says nothing in their queue.
+    assert @set.following?(users(:dave))
+
+    copied = ActionMailer::Base.deliveries.find { it.subject.to_s.include?('copied you in') }
+
+    assert_not_nil copied
+    assert_equal [users(:dave).email], copied.to
+  end
+
+  # Somebody already following is greyed rather than offered: there is
+  # nothing a tick could mean for them.
+  test 'a colleague who already follows the set is not offered again' do
+    @set.subscribe! users(:dave)
+
+    visit admin_set_path(@set)
+
+    assert_selector "input#cc_#{users(:dave).id}[disabled]"
+  end
+
   # Who is already curating what is in the set. This is what decides
   # whether a set-wide question is the reader's to answer, and it is the
   # one fact neither the set nor the thread carries.

--- a/test/system/admin_sets_test.rb
+++ b/test/system/admin_sets_test.rb
@@ -275,6 +275,24 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
     assert_selector "input#cc_#{users(:dave).id}[disabled]"
   end
 
+  # A curator opening a set is looking at what was said recently. The
+  # whole of a three-year conversation is a link away, not the default.
+  test 'a long thread renders its newest end, and offers the rest' do
+    messages = Array.new(MessageThreadPaging::PER_PAGE + 2) {
+      @set.messages.create!(user: @alice, author_role: :member, body: "message #{it}")
+    }
+
+    visit admin_set_path(@set)
+
+    assert_text messages.last.body
+    assert_no_text messages.first.body
+
+    click_link "Show all #{messages.size} messages"
+
+    assert_text messages.first.body
+    assert_text messages.last.body
+  end
+
   # Who is already curating what is in the set. This is what decides
   # whether a set-wide question is the reader's to answer, and it is the
   # one fact neither the set nor the thread carries.

--- a/test/system/admin_sets_test.rb
+++ b/test/system/admin_sets_test.rb
@@ -263,6 +263,13 @@ class AdminSetsSystemTest < ApplicationSystemTestCase
 
     assert_not_nil copied
     assert_equal [users(:dave).email], copied.to
+
+    # Once, not twice. Copying somebody in subscribes them, so a
+    # follower list built after that would also mail them the "somebody
+    # replied on a set you follow" notice about the same message.
+    to_dave = ActionMailer::Base.deliveries.count { it.to.to_a.include?(users(:dave).email) }
+
+    assert_equal 1, to_dave, ActionMailer::Base.deliveries.map(&:subject).inspect
   end
 
   # Somebody already following is greyed rather than offered: there is

--- a/web/app/components/message-thread.ts
+++ b/web/app/components/message-thread.ts
@@ -84,7 +84,13 @@ export default class MessageThread<S, M extends { id: number }> extends Componen
   // The page before the oldest one on screen, prepended. `before_id`
   // rather than a page number: a page counted from the oldest message
   // moves under the reader every time somebody writes.
-  async loadEarlier(url: string) {
+  //
+  // `stillHere` is asked again on the way back. A component instance is
+  // reused when the model changes under the same route, so an answer for
+  // the thread we have left would otherwise be prepended to the one we
+  // are looking at — somebody else's conversation, under this one's
+  // name.
+  async loadEarlier(url: string, stillHere: () => boolean = () => true) {
     const oldest = this.messages[0]?.id;
     if (!oldest || this.loadingEarlier) return;
 
@@ -96,12 +102,31 @@ export default class MessageThread<S, M extends { id: number }> extends Componen
         options: { params: { before_id: oldest }, reportErrors: false },
       });
 
-      this.messages = [...content, ...this.messages];
+      if (stillHere()) this.messages = [...content, ...this.messages];
     } catch {
-      this.error = 'Could not load the earlier messages. Try again.';
+      if (stillHere()) this.error = 'Could not load the earlier messages. Try again.';
     } finally {
       this.loadingEarlier = false;
     }
+  }
+
+  // Appending, and saying so. `total` is what decides whether there is a
+  // beginning left to fetch, so a message added here has to count: with
+  // 51 messages and 50 on screen, one reply would otherwise make the
+  // lengths match and take "Show earlier messages" away with the first
+  // message still unread.
+  appendMessage(message: M) {
+    this.messages = [...this.messages, message];
+    this.total = Math.max(this.total + 1, this.messages.length);
+  }
+
+  // Starting again on a different thread: everything about the old one
+  // goes, including whether it was still loading.
+  resetThread() {
+    this.messages = [];
+    this.total = 0;
+    this.loadingEarlier = false;
+    this.error = null;
   }
 
   uploadDraftFiles() {

--- a/web/app/components/message-thread.ts
+++ b/web/app/components/message-thread.ts
@@ -20,11 +20,19 @@ import type RouterService from '@ember/routing/router-service';
 // everyone in it, and they name their speakers, count their unread and
 // address their endpoints differently. What is shared is the plumbing
 // under that, which was copied once and would have drifted.
-export default class MessageThread<S> extends Component<S> {
+export default class MessageThread<S, M extends { id: number }> extends Component<S> {
   @service declare attention: AttentionService;
   @service declare currentUser: CurrentUserService;
   @service declare requestManager: RequestManager;
   @service declare router: RouterService;
+
+  @tracked messages: M[] = [];
+
+  // How many the thread holds in all, from `Total-Count`. A thread is
+  // read from its newest end, so what arrives is the last page of it —
+  // and this is how the screen knows whether to offer the rest.
+  @tracked total = 0;
+  @tracked loadingEarlier = false;
 
   @tracked draft = '';
   @tracked files: File[] = [];
@@ -58,6 +66,42 @@ export default class MessageThread<S> extends Component<S> {
     return new Promise<string>((resolve, reject) => {
       upload.create((error, blob) => (error ? reject(error) : resolve(blob!.signed_id)));
     });
+  }
+
+  get hasEarlier() {
+    return this.total > this.messages.length;
+  }
+
+  // The newest page, replacing whatever was on screen.
+  async loadThread(url: string) {
+    const { content, response } = await this.requestManager.request<M[]>({ url });
+
+    this.total = Number(response?.headers?.get('Total-Count')) || content.length;
+
+    return content;
+  }
+
+  // The page before the oldest one on screen, prepended. `before_id`
+  // rather than a page number: a page counted from the oldest message
+  // moves under the reader every time somebody writes.
+  async loadEarlier(url: string) {
+    const oldest = this.messages[0]?.id;
+    if (!oldest || this.loadingEarlier) return;
+
+    this.loadingEarlier = true;
+
+    try {
+      const { content } = await this.requestManager.request<M[]>({
+        url,
+        options: { params: { before_id: oldest }, reportErrors: false },
+      });
+
+      this.messages = [...content, ...this.messages];
+    } catch {
+      this.error = 'Could not load the earlier messages. Try again.';
+    } finally {
+      this.loadingEarlier = false;
+    }
   }
 
   uploadDraftFiles() {

--- a/web/app/components/set-messages.gts
+++ b/web/app/components/set-messages.gts
@@ -1,5 +1,4 @@
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
 import { modifier } from 'ember-modifier';
 import { uniqueId } from '@ember/helper';
@@ -38,9 +37,7 @@ interface Signature {
 // and are on each submission's own page; being able to read somebody's
 // submission through a shared set is not being party to what they were
 // asked about it.
-export default class SetMessages extends MessageThread<Signature> {
-  @tracked messages: Message[] = [];
-
+export default class SetMessages extends MessageThread<Signature, Message> {
   // Which set the messages on screen belong to. Ember reuses a component
   // instance when the model changes under the same route, so loading
   // once at construction would leave one set's thread rendered under
@@ -57,16 +54,22 @@ export default class SetMessages extends MessageThread<Signature> {
     void this.load();
   });
 
+  get url() {
+    return `/sets/${this.args.setId}/messages`;
+  }
+
   async load() {
     const setId = this.args.setId;
-
-    const { content } = await this.requestManager.request<MessagesResponse>({
-      url: `/sets/${setId}/messages`,
-    });
+    const messages = await this.loadThread(this.url);
 
     // A slower answer for the set we have left must not land on the one
     // we are looking at.
-    if (setId === this.args.setId) this.messages = content;
+    if (setId === this.args.setId) this.messages = messages;
+  }
+
+  @action
+  showEarlier() {
+    void this.loadEarlier(this.url);
   }
 
   // Acknowledges what is on screen, not whatever has arrived since.
@@ -89,7 +92,7 @@ export default class SetMessages extends MessageThread<Signature> {
 
     try {
       await this.requestManager.request({
-        url: `/sets/${this.args.setId}/messages/read`,
+        url: `${this.url}/read`,
         method: 'POST',
         data: { through_id: this.newestMessageId },
         options: { reportErrors: false },
@@ -122,7 +125,7 @@ export default class SetMessages extends MessageThread<Signature> {
       const files = await this.uploadDraftFiles();
 
       const { content } = await this.requestManager.request<CreateMessageResponse>({
-        url: `/sets/${this.args.setId}/messages`,
+        url: this.url,
         method: 'POST',
         data: { submission_set_message: { body, files } },
         options: { reportErrors: false },
@@ -169,6 +172,20 @@ export default class SetMessages extends MessageThread<Signature> {
       member wrote it is named — unlike a submission's thread, where every
       non-curator message is by definition the owner's. }}
       {{#if this.messages.length}}
+        {{! A thread arrives from its newest end, so what is missing is
+        the beginning of it. }}
+        {{#if this.hasEarlier}}
+          <button
+            type="button"
+            class="btn btn-outline-secondary btn-sm mb-3"
+            disabled={{this.loadingEarlier}}
+            data-test-show-earlier
+            {{on "click" this.showEarlier}}
+          >
+            {{if this.loadingEarlier "Loading…" "Show earlier messages"}}
+          </button>
+        {{/if}}
+
         <ul class="list-unstyled mb-3 d-flex flex-column gap-3">
           {{#each this.messages as |m|}}
             <li class="d-flex gap-3 {{unless (isCurator m) 'ps-5'}}">

--- a/web/app/components/set-messages.gts
+++ b/web/app/components/set-messages.gts
@@ -49,27 +49,38 @@ export default class SetMessages extends MessageThread<Signature, Message> {
     if (this.#loaded === setId) return;
 
     this.#loaded = setId;
-    this.messages = [];
+
+    this.resetThread();
 
     void this.load();
   });
+
+  // Whether the answer to a request we sent is still about the thread on
+  // screen.
+  //
+  // The initial load's use of this is covered ("moving to another set
+  // fetches that set's thread"); `showEarlier`'s is not, because holding
+  // a request open across a navigation deadlocks Ember's settledness —
+  // `visit` waits for the very request the test needs to be in flight.
+  // It is the same guard for the same reason.
+  stillHere = (setId: number) => () => setId === this.args.setId;
 
   get url() {
     return `/sets/${this.args.setId}/messages`;
   }
 
   async load() {
-    const setId = this.args.setId;
+    const here = this.stillHere(this.args.setId);
     const messages = await this.loadThread(this.url);
 
     // A slower answer for the set we have left must not land on the one
     // we are looking at.
-    if (setId === this.args.setId) this.messages = messages;
+    if (here()) this.messages = messages;
   }
 
   @action
   showEarlier() {
-    void this.loadEarlier(this.url);
+    void this.loadEarlier(this.url, this.stillHere(this.args.setId));
   }
 
   // Acknowledges what is on screen, not whatever has arrived since.
@@ -98,9 +109,10 @@ export default class SetMessages extends MessageThread<Signature, Message> {
         options: { reportErrors: false },
       });
 
-      // Both: the count above comes from the route, and anything posted
-      // while this page was open is still missing from the thread.
-      await this.load();
+      // The count above comes from the route, so that is what is fetched
+      // again. NOT the thread: reloading it would replace what is on
+      // screen with the newest page and throw away anything the reader
+      // had pulled in with "Show earlier messages".
       await this.settle();
     } catch {
       this.error = 'Could not mark it read. Try again.';
@@ -131,8 +143,7 @@ export default class SetMessages extends MessageThread<Signature, Message> {
         options: { reportErrors: false },
       });
 
-      this.messages = [...this.messages, content];
-
+      this.appendMessage(content);
       this.clearForm();
 
       await this.settle();

--- a/web/app/components/submission-messages.gts
+++ b/web/app/components/submission-messages.gts
@@ -22,6 +22,14 @@ type Message = MessagesResponse[number];
 interface Signature {
   Args: {
     requestId: number;
+
+    // How many curator messages are waiting on the submitter, as the
+    // server counts them. Asked for rather than derived from the loaded
+    // messages: the thread arrives from its newest end, and a question
+    // older than that page would otherwise leave the reader with no way
+    // to discharge it — the lost reminder this whole design exists to
+    // prevent.
+    unreadCount: number;
   };
 }
 
@@ -46,10 +54,14 @@ export default class SubmissionMessages extends MessageThread<Signature, Message
   }
 
   // Reading is no longer what discharges the thread — see MessagesController.
-  // These two are, so both refresh the banner: it is rendered from a count
-  // the server keeps, and nothing else would go back for it.
+  // Replying and this do, so both refresh the banner: it is rendered from
+  // a count the server keeps, and nothing else would go back for it.
+  //
+  // There is nothing to acknowledge until the thread has arrived: with no
+  // id the server falls back to "now" and would discharge messages this
+  // reader has not seen.
   get unanswered() {
-    return this.messages.some((m) => m.author_role === 'curator' && !m.read_at);
+    return Boolean(this.args.unreadCount) && Boolean(this.newestMessageId);
   }
 
   // Acknowledges what is on screen, not whatever has arrived since: a
@@ -67,7 +79,10 @@ export default class SubmissionMessages extends MessageThread<Signature, Message
       data: { through_id: this.newestMessageId },
     });
 
-    await this.load();
+    // The count comes from the route, so that is what is fetched again.
+    // NOT the thread: reloading it would replace what is on screen with
+    // the newest page and throw away anything the reader had pulled in
+    // with "Show earlier messages".
     await this.settle();
   }
 
@@ -95,16 +110,10 @@ export default class SubmissionMessages extends MessageThread<Signature, Message
       });
 
       // Appended rather than re-fetched — saves a round trip and keeps
-      // the form snappy — but the curator's messages were just marked
-      // read server-side, so the copies held here have to learn that too
-      // or the button stays offering to do what replying already did.
-      this.messages = [
-        ...this.messages.map((m) =>
-          m.author_role === 'curator' && !m.read_at ? { ...m, read_at: new Date().toISOString() } : m,
-        ),
-        content,
-      ];
-
+      // the form snappy. The unread count is the route's now, and
+      // `settle` sends it back for below, so nothing here has to fix up
+      // what the server just marked read.
+      this.appendMessage(content);
       this.clearForm();
 
       await this.settle();

--- a/web/app/components/submission-messages.gts
+++ b/web/app/components/submission-messages.gts
@@ -1,5 +1,4 @@
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
 import { Textarea } from '@ember/component';
 
@@ -26,21 +25,24 @@ interface Signature {
   };
 }
 
-export default class SubmissionMessages extends MessageThread<Signature> {
-  @tracked messages: Message[] = [];
-
+export default class SubmissionMessages extends MessageThread<Signature, Message> {
   constructor(owner: unknown, args: Signature['Args']) {
     // @ts-expect-error -- Glimmer Component owner typing
     super(owner, args);
     void this.load();
   }
 
-  async load() {
-    const { content } = await this.requestManager.request<MessagesResponse>({
-      url: `/submission_requests/${this.args.requestId}/messages`,
-    });
+  get url() {
+    return `/submission_requests/${this.args.requestId}/messages`;
+  }
 
-    this.messages = content;
+  async load() {
+    this.messages = await this.loadThread(this.url);
+  }
+
+  @action
+  showEarlier() {
+    void this.loadEarlier(this.url);
   }
 
   // Reading is no longer what discharges the thread — see MessagesController.
@@ -60,7 +62,7 @@ export default class SubmissionMessages extends MessageThread<Signature> {
   @action
   async markRead() {
     await this.requestManager.request({
-      url: `/submission_requests/${this.args.requestId}/messages/read`,
+      url: `${this.url}/read`,
       method: 'POST',
       data: { through_id: this.newestMessageId },
     });
@@ -86,7 +88,7 @@ export default class SubmissionMessages extends MessageThread<Signature> {
       const files = await this.uploadDraftFiles();
 
       const { content } = await this.requestManager.request<CreateMessageResponse>({
-        url: `/submission_requests/${this.args.requestId}/messages`,
+        url: this.url,
         method: 'POST',
         data: { submission_message: { body, files } },
         options: { reportErrors: false },
@@ -139,6 +141,20 @@ export default class SubmissionMessages extends MessageThread<Signature> {
       eye has to read: the curator sits left with an avatar, you sit
       indented and tinted. }}
       {{#if this.messages.length}}
+        {{! A thread arrives from its newest end, so what is missing is
+        the beginning of it. }}
+        {{#if this.hasEarlier}}
+          <button
+            type="button"
+            class="btn btn-outline-secondary btn-sm mb-3"
+            disabled={{this.loadingEarlier}}
+            data-test-show-earlier
+            {{on "click" this.showEarlier}}
+          >
+            {{if this.loadingEarlier "Loading…" "Show earlier messages"}}
+          </button>
+        {{/if}}
+
         <ul class="list-unstyled mb-3 d-flex flex-column gap-3">
           {{#each this.messages as |m|}}
             <li class="d-flex gap-3 {{unless (isCurator m) 'ps-5'}}">

--- a/web/app/templates/request/index.gts
+++ b/web/app/templates/request/index.gts
@@ -246,7 +246,7 @@ export default class extends Component<Signature> {
       it — the server withholds the messages, and offering the box would
       only produce a 404. }}
       {{#if @model.owned}}
-        <SubmissionMessages @requestId={{@model.id}} />
+        <SubmissionMessages @requestId={{@model.id}} @unreadCount={{@model.unread_curator_message_count}} />
       {{/if}}
 
       {{! Reference material. Present, but not in the way of the answer. }}

--- a/web/tests/acceptance/set-conversation-test.gts
+++ b/web/tests/acceptance/set-conversation-test.gts
@@ -217,6 +217,30 @@ module('Acceptance | the conversation about a set', function (hooks) {
     assert.dom('[data-test-show-earlier]').doesNotExist('and there is no more of it');
   });
 
+  // Posting counts. With 51 messages and 50 on screen, one reply would
+  // otherwise make the lengths match and take "Show earlier messages"
+  // away with the first message still unread.
+  test('replying does not take the beginning of the thread away', async function (assert) {
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => response(200).json(set())),
+
+      http.get('/sets/{set_id}/messages', ({ response }) =>
+        response(200).json([message({ id: 9 })], { headers: { 'Total-Count': '2' } }),
+      ),
+
+      http.post('/sets/{set_id}/messages', ({ response }) => response(201).json(message({ id: 10 }))),
+    );
+
+    await visit('/sets/7');
+
+    assert.dom('[data-test-show-earlier]').exists();
+
+    await fillIn('[data-test-set-messages] textarea', 'One more thing.');
+    await click('[data-test-set-messages] button[type="submit"]');
+
+    assert.dom('[data-test-show-earlier]').exists('the beginning is still there to fetch');
+  });
+
   // A thread that arrived whole must not offer to fetch what is not
   // there.
   test('a short thread offers nothing to load', async function (assert) {

--- a/web/tests/acceptance/set-conversation-test.gts
+++ b/web/tests/acceptance/set-conversation-test.gts
@@ -185,6 +185,54 @@ module('Acceptance | the conversation about a set', function (hooks) {
     assert.strictEqual(sent, 42, 'it names the newest message it had in front of it');
   });
 
+  // A long conversation arrives from its newest end. What is missing is
+  // the beginning, and asking for it must not depend on a page number
+  // that moves every time somebody writes.
+  test('the beginning of a long thread is asked for by cursor', async function (assert) {
+    let asked: string | null = null;
+
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => response(200).json(set())),
+
+      http.get('/sets/{set_id}/messages', ({ request, response }) => {
+        asked = new URL(request.url).searchParams.get('before_id');
+
+        return asked
+          ? response(200).json([message({ id: 1, body: 'the first thing anybody said' })])
+          : response(200).json([message({ id: 9, body: 'the latest thing' })], {
+              headers: { 'Total-Count': '2' },
+            });
+      }),
+    );
+
+    await visit('/sets/7');
+
+    assert.dom('[data-test-set-messages]').includesText('the latest thing');
+    assert.dom('[data-test-show-earlier]').exists('the thread says it has a beginning');
+
+    await click('[data-test-show-earlier]');
+
+    assert.strictEqual(asked, '9', 'asked for what is older than the oldest on screen');
+    assert.dom('[data-test-set-messages]').includesText('the first thing anybody said');
+    assert.dom('[data-test-show-earlier]').doesNotExist('and there is no more of it');
+  });
+
+  // A thread that arrived whole must not offer to fetch what is not
+  // there.
+  test('a short thread offers nothing to load', async function (assert) {
+    worker.use(
+      http.get('/sets/{id}', ({ response }) => response(200).json(set())),
+
+      http.get('/sets/{set_id}/messages', ({ response }) =>
+        response(200).json([message()], { headers: { 'Total-Count': '1' } }),
+      ),
+    );
+
+    await visit('/sets/7');
+
+    assert.dom('[data-test-show-earlier]').doesNotExist();
+  });
+
   // A badge on a row is only visible if that row is on the page in front
   // of you. The nav carries it from wherever the member happens to be.
   test('a set waiting on you is visible from any screen', async function (assert) {

--- a/web/tests/acceptance/submission-messages-test.gts
+++ b/web/tests/acceptance/submission-messages-test.gts
@@ -79,11 +79,14 @@ module('Acceptance | submission messages', function (hooks) {
     ];
 
     worker.use(
-      http.get('/submission_requests/{id}', ({ response }) => response(200).json(request)),
-
-      http.get('/submission_requests/{submission_request_id}/messages', ({ response }) =>
-        response(200).json(read ? question.map((m) => ({ ...m, read_at: now })) : question),
+      // The count is the server's, not something derived from the loaded
+      // page: a question older than the newest page would otherwise
+      // leave the reader with no way to deal with it.
+      http.get('/submission_requests/{id}', ({ response }) =>
+        response(200).json({ ...request, unread_curator_message_count: read ? 0 : 1 }),
       ),
+
+      http.get('/submission_requests/{submission_request_id}/messages', ({ response }) => response(200).json(question)),
 
       http.post('/submission_requests/{submission_request_id}/messages/read', ({ response }) => {
         read = true;


### PR DESCRIPTION
#2018 で既知として残していた2つです。

## 1. 同僚を copy in できるようにする

request 側にあってセット側に無かった機能です。無いと、同僚を呼ぶ手段が場外で伝えることだけになり、スレッドが「誰に訊いたか」の記録でなくなります。

チェックした curator は以後このセットを追いかけ（それが copy in の全部）、同時にメールも飛びます — セットに未回答が無ければ queue は何も言わないので、購読だけでは「次にメンバーが書いたとき」まで知る機会がなく、それは見てほしいと頼まれた時点ではないので。

Also notify のブロックは request 側から切り出して両方で共有しています。

## 2. スレッドは新しい方の端から読み込む

会話は末尾から読むものなので、末尾から読み込みます。直近 50 件 + `Total-Count`。

**pagy を使いません。** ページ番号は古い方から数えるので、誰かが書き込むたびに「2ページ目」の意味がずれ、読んでいる場所が足元で動きます。カーソル（`before_id` = 手元にある最も古いメッセージ）なら動きません。

- web: 「Show earlier messages」で前を継ぎ足す
- admin: 直近 50 件 +「Show all N messages」— セットを開いた curator が見たいのは最近の話で、3年分の会話は既定で描くページではない
- ヘッダは `Total-Count`（CORS の expose リストに既にあるもの。ここで新しいヘッダを発明するとブラウザから読めない）
- request 側のスレッドも同じ形に。土台は `MessageThread` / `MessageThreadPaging` で共有

途中で踏んだ罠: `has_many :messages, -> { chronological }` に `order` を足すと**追加**になるので、`reorder` でないと「先頭 50 件を逆順に描く」ことになります。テストが掴みました。

- `bin/rails test:all` 1333 / `pnpm test` 94 / rubocop clean
- ブラウザで確認済み（dev のセットに 59 件入れて、admin の「Show all 59 messages」と web の「Show earlier messages」の両方）

🤖 Generated with [Claude Code](https://claude.com/claude-code)