### PR TITLE
Regenerate の走行が貼り付けたリストを読み直さないようにする

### DIFF
--- a/app/controllers/admin/regenerate_flatfiles_controller.rb
+++ b/app/controllers/admin/regenerate_flatfiles_controller.rb
@@ -9,14 +9,14 @@ module Admin
     def show
       @scope     = RegenerationScope.new(params)
       @all_total = RegenerationScope.regeneratable.count
-      @blocking  = RegenerateFlatfilesRun.in_flight.recent.first
-      @run       = RegenerateFlatfilesRun.recent.first
+      @blocking  = RegenerateFlatfilesRun.without_numbers.in_flight.recent.first
+      @run       = RegenerateFlatfilesRun.without_numbers.recent.first
 
       # The newest run is the panel, so it is not also a row: the panel
       # keeps itself up to date and the table does not, and the two
       # disagreeing about whether the run has finished is the sort of
       # thing that makes a screen not worth reading.
-      @runs = RegenerateFlatfilesRun.recent.where.not(id: @run&.id).limit(10)
+      @runs = RegenerateFlatfilesRun.without_numbers.recent.where.not(id: @run&.id).limit(10)
     end
 
     # The count, live, as the form is filled in. Its own endpoint rather
@@ -30,7 +30,7 @@ module Admin
     def preview
       render partial: 'summary', locals: {
         scope:    RegenerationScope.new(params),
-        blocking: RegenerateFlatfilesRun.in_flight.recent.first
+        blocking: RegenerateFlatfilesRun.without_numbers.in_flight.recent.first
       }
     end
 
@@ -47,7 +47,7 @@ module Admin
       # button while a run is going; this is the same rule for the press
       # that arrives anyway — a second tab, a back button, a double
       # submit of the confirmation.
-      if (blocking = RegenerateFlatfilesRun.in_flight.recent.first)
+      if (blocking = RegenerateFlatfilesRun.without_numbers.in_flight.recent.first)
         return redirect_to admin_regenerate_flatfiles_path,
                            alert: "A regeneration run started at #{helpers.format_datetime(blocking.started_at)} " \
                                   'is still going. Wait for it to finish.'
@@ -94,6 +94,9 @@ module Admin
       # would have the retry date only those. Stored as the parsed list
       # rather than the paste, so the run and the form that made it count
       # the same numbers.
+      #
+      # `accession_count` comes off the list on save, through the same
+      # parse a retry will run, so the two cannot drift apart.
       run = RegenerateFlatfilesRun.create!(
         actor:      current_actor,
         target:     scope.target,

--- a/app/controllers/admin/regenerate_flatfiles_runs_controller.rb
+++ b/app/controllers/admin/regenerate_flatfiles_runs_controller.rb
@@ -20,8 +20,12 @@ module Admin
 
     private
 
+    # Without the accession list: `show` is the frame the tool screen
+    # polls every three seconds, and neither it nor the failure download
+    # reads the numbers back. A retry is the one thing that does, and it
+    # loads the run for itself.
     def set_run
-      @run = RegenerateFlatfilesRun.find(params[:id])
+      @run = RegenerateFlatfilesRun.without_numbers.find(params[:id])
     end
   end
 end

--- a/app/models/regenerate_flatfiles_run.rb
+++ b/app/models/regenerate_flatfiles_run.rb
@@ -31,8 +31,43 @@ class RegenerateFlatfilesRun < ApplicationRecord
 
   validates :actor, presence: true
 
+  # How the pasted list is read, wherever it is read. `RegenerationScope`
+  # runs these numbers and this row reports how many there were, and a
+  # run that says "2 accessions" beside a list a retry resolves to three
+  # is a run nobody can check.
+  SEPARATOR = /[\s,]+/
+
+  def self.parse_numbers(text) = text.to_s.split(SEPARATOR).reject(&:blank?).uniq
+
+  # The count every screen reads, kept from the list only a retry reads.
+  # Derived here rather than passed in, so a run written from anywhere —
+  # the controller, a console, a test — carries the count of its own list.
+  #
+  # The guard is what makes this compatible with `without_numbers`: on a
+  # row loaded without the column, reading `numbers` raises
+  # `ActiveModel::MissingAttributeError`, and the panel controller saves
+  # such rows. It is not about the counter writes during a run — those go
+  # through `update_counters` and `update_all`, which fire no callbacks
+  # at all.
+  #
+  # `has_attribute?` rather than `will_save_change_to_numbers?`, so the
+  # count is recomputed even when only the count was assigned. That costs
+  # one 40 ms split per save of a full row, and a run is saved twice.
+  before_save :count_accessions, if: -> { has_attribute?(:numbers) }
+
   scope :recent,   -> { order(started_at: :desc) }
   scope :finished, -> { where.not(finished_at: nil) }
+
+  # Without the accession list. A bulk paste is over a megabyte — 127,604
+  # numbers is 1.1 MB — and the only thing that reads it back is a retry.
+  # Every other reader wants the count, which `accession_count` carries.
+  #
+  # The progress panel is why this is a scope rather than a habit: it
+  # polls its own run every three seconds for the length of the run, so
+  # loading the column there meant detoasting a megabyte and splitting it
+  # into 127,604 strings six hundred times over a half-hour regeneration
+  # — inside the Puma process that is also running the jobs.
+  scope :without_numbers, -> { select(column_names - ['numbers']) }
 
   # What a second press has to wait for. Two runs over the same
   # submission put two workers on the same record: both rewrite the
@@ -49,7 +84,10 @@ class RegenerateFlatfilesRun < ApplicationRecord
   # would stay wrong silently. Nil until there is a finished run to
   # measure, and the screens then say nothing rather than guessing.
   def self.measured_rate
-    rows = finished.where('regenerated + skipped + failed > 0').recent.limit(5).to_a
+    # Five whole rows, of which this reads six integers and three
+    # timestamps — and it is called from the summary partial, which the
+    # preview endpoint re-renders while somebody is pasting the list.
+    rows = without_numbers.finished.where('regenerated + skipped + failed > 0').recent.limit(5).to_a
     return nil if rows.empty?
 
     # Weighted by what each run actually got through, not one vote per
@@ -123,11 +161,12 @@ class RegenerateFlatfilesRun < ApplicationRecord
     case target
     when 'all'   then 'All submissions'
     when 'retry' then "Retry of ##{retry_of_id}"
-    else              "#{number_list.size} #{'accession'.pluralize(number_list.size)}"
+    # Delimited here rather than by the view, because the label is one
+    # phrase and its three branches should not be assembled two different
+    # ways. Six figures is the ordinary size of one of these runs.
+    else              "#{ActiveSupport::NumberHelper.number_to_delimited(accession_count)} #{'accession'.pluralize(accession_count)}"
     end
   end
-
-  def number_list = numbers.to_s.split(/[\s,]+/).reject(&:blank?)
 
   # Records a failure and counts it in one go, so the row and the counter
   # cannot disagree — a screen that says "6 failed" and lists five is a
@@ -192,5 +231,11 @@ class RegenerateFlatfilesRun < ApplicationRecord
         .where(id:, finished_at: nil)
         .where('regenerated + skipped + failed >= total')
         .update_all(finished_at: Time.current, updated_at: Time.current)
+  end
+
+  private
+
+  def count_accessions
+    self.accession_count = self.class.parse_numbers(numbers).size
   end
 end

--- a/app/services/regeneration_scope.rb
+++ b/app/services/regeneration_scope.rb
@@ -49,7 +49,7 @@ class RegenerationScope
 
   def accessions_target? = target == 'accessions'
 
-  def numbers = @numbers ||= numbers_text.split(/[\s,]+/).reject(&:blank?).uniq
+  def numbers = @numbers ||= RegenerateFlatfilesRun.parse_numbers(numbers_text)
 
   def submissions
     @submissions ||=

--- a/db/migrate/20260827000001_add_accession_count_to_regenerate_flatfiles_runs.rb
+++ b/db/migrate/20260827000001_add_accession_count_to_regenerate_flatfiles_runs.rb
@@ -1,0 +1,39 @@
+class AddAccessionCountToRegenerateFlatfilesRuns < ActiveRecord::Migration[8.1]
+  # The same rule `RegenerateFlatfilesRun.parse_numbers` applies, written
+  # again in SQL because existing rows have to be counted where they are.
+  #
+  # Single-quoted heredoc, and the class spelled out rather than `\s`.
+  # Both are load-bearing: in an interpolating heredoc Ruby turns `\s`
+  # into a literal space and the pattern stops splitting on newlines,
+  # and Postgres' own `\s` is `[[:space:]]`, which matches the full-width
+  # space a Japanese paste is liable to contain and Ruby's `\s` does not.
+  #
+  # `btrim` is not a way to drop the leading empty token either: it
+  # strips spaces, not newlines. Filtering the tokens is, and
+  # `~ '[^[:space:]]'` is what `String#present?` means.
+  #
+  # DISTINCT because the form dedupes before it runs the numbers, so a
+  # count that did not would disagree with what a retry of the row does.
+  BACKFILL = <<~'SQL'.freeze
+    UPDATE regenerate_flatfiles_runs
+    SET    accession_count = (
+             SELECT count(DISTINCT token)
+             FROM   unnest(regexp_split_to_array(coalesce(numbers, ''), '[ \t\n\v\f\r,]+')) AS token
+             WHERE  token ~ '[^[:space:]]'
+           )
+  SQL
+
+  def up
+    add_column :regenerate_flatfiles_runs, :accession_count, :integer, null: false, default: 0
+
+    # Existing runs count themselves from the list they stored. The
+    # progress panel is why the column exists and it is polled every three
+    # seconds, so a run that predates this migration would otherwise
+    # report "0 accessions" for as long as anyone looked at it.
+    execute BACKFILL
+  end
+
+  def down
+    remove_column :regenerate_flatfiles_runs, :accession_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_21_000003) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_27_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -202,6 +202,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_21_000003) do
   end
 
   create_table "regenerate_flatfiles_runs", force: :cascade do |t|
+    t.integer "accession_count", default: 0, null: false
     t.string "actor", null: false
     t.datetime "created_at", null: false
     t.integer "failed", default: 0, null: false

--- a/test/integration/admin/regenerate_flatfiles_test.rb
+++ b/test/integration/admin/regenerate_flatfiles_test.rb
@@ -38,6 +38,7 @@ class AdminRegenerateFlatfilesTest < ActionDispatch::IntegrationTest
     # there is no list to carry.
     assert_nil enqueued_argument('accessions')
     assert_nil RegenerateFlatfilesRun.sole.numbers
+    assert_equal 0, RegenerateFlatfilesRun.sole.accession_count
   end
 
   # The list is the job's, not just the scope's: it decides whose LOCUS
@@ -52,6 +53,7 @@ class AdminRegenerateFlatfilesTest < ActionDispatch::IntegrationTest
     assert_redirected_to admin_regenerate_flatfiles_path
     assert_equal [accession], enqueued_argument('accessions')
     assert_equal accession,   RegenerateFlatfilesRun.sole.numbers
+    assert_equal 1,           RegenerateFlatfilesRun.sole.accession_count
   end
 
   # The dialog disables a button; a disabled button is a courtesy. The

--- a/test/models/regenerate_flatfiles_run_test.rb
+++ b/test/models/regenerate_flatfiles_run_test.rb
@@ -102,6 +102,111 @@ class RegenerateFlatfilesRunTest < ActiveSupport::TestCase
     assert_predicate dead, :stale?
   end
 
+  # The panel polls its own run every three seconds for the length of the
+  # run, and the history lists ten at a time. Splitting the paste to count
+  # its lines meant a megabyte read and 127,604 strings allocated on every
+  # one of those renders.
+  test 'the accession count is stored, not counted from the list on the way out' do
+    # Comma-separated and newline-separated, with a blank line and a
+    # repeat — so the count is what a retry of this row would run, not
+    # the lines it happens to be stored on.
+    run = new_run(target: 'accessions', numbers: "X00001, X00002, X00003\n\nX00001", total: 1)
+
+    assert_equal 3, run.accession_count
+    assert_equal 3, run.numbers.lines.size
+    assert_equal '3 accessions', run.scope_label
+
+    # From the column, so the label survives a load that leaves the list
+    # behind.
+    assert_equal '3 accessions', RegenerateFlatfilesRun.without_numbers.find(run.id).scope_label
+  end
+
+  # What the screens report and what a retry re-runs come off the same
+  # parse, so they cannot disagree about how many were named.
+  test 'the count is the list a retry of the run would resolve' do
+    run = new_run(target: 'accessions', numbers: "X00001, X00002\n\nX00001", total: 1)
+
+    assert_equal RegenerationScope.retrying(run).numbers.size, run.accession_count
+  end
+
+  test 'the stored count follows the list when it changes' do
+    run = new_run(target: 'accessions', numbers: 'X00001', total: 1)
+
+    run.update! numbers: "X00001\nX00002"
+
+    assert_equal 2, run.reload.accession_count
+  end
+
+  # The count is the list's, not the caller's. Guarding on "did the list
+  # change" would leave a count assigned on its own standing, and then
+  # the label the screens read is whatever somebody typed.
+  test 'a count assigned on its own is replaced by the list it claims to describe' do
+    run = new_run(target: 'accessions', numbers: "X00001\nX00002", accession_count: 99, total: 1)
+
+    assert_equal 2, run.accession_count
+
+    run.update! accession_count: 99
+
+    assert_equal 2, run.reload.accession_count
+  end
+
+  # The callback and `without_numbers` only work together because the
+  # callback checks first: the panel controller loads runs without the
+  # column, and reading it on one of those raises.
+  test 'a run loaded without its list can still be saved' do
+    run  = new_run(target: 'accessions', numbers: 'X00001', total: 1)
+    lean = RegenerateFlatfilesRun.without_numbers.find(run.id)
+
+    lean.update! total: 2
+
+    assert_equal 1, run.reload.accession_count
+    assert_equal 2, run.total
+  end
+
+  # Six figures is the ordinary size of one of these runs.
+  test 'the label delimits the count' do
+    assert_equal '127,604 accessions', RegenerateFlatfilesRun.new(target: 'accessions', accession_count: 127_604).scope_label
+  end
+
+  test 'a run that named no accessions counts none' do
+    run = new_run(target: 'all', total: 1)
+
+    assert_equal 0, run.accession_count
+    assert_equal 'All submissions', run.scope_label
+  end
+
+  # The one place the parse rule is written twice: rows that predate the
+  # column are counted in SQL, and the suite loads the schema rather than
+  # running migrations, so nothing else would exercise it.
+  test 'the backfill counts what the callback counts' do
+    require Rails.root.join('db/migrate/20260827000001_add_accession_count_to_regenerate_flatfiles_runs')
+
+    texts = [
+      nil,
+      '',
+      "   \n ",
+      'X00001',
+      "X00001\nX00002",
+      'X00001, X00002,,X00003',
+      "\nX00001\r\n\tX00002 \n",
+      "X00001\nX00001",
+      # Ruby's \s is ASCII-only and Postgres' is not: a full-width space
+      # is one token to the parse and would be two to a `\s` pattern.
+      "X00001\u3000X00002"
+    ]
+
+    runs = texts.map { new_run(target: 'accessions', numbers: it, total: 1) }
+
+    RegenerateFlatfilesRun.update_all accession_count: -1
+    ActiveRecord::Base.connection.execute AddAccessionCountToRegenerateFlatfilesRuns::BACKFILL
+
+    runs.each do |run|
+      expected = RegenerateFlatfilesRun.parse_numbers(run.numbers).size
+
+      assert_equal expected, run.reload.accession_count, run.numbers.inspect
+    end
+  end
+
   private
 
   def new_run(**attrs)

--- a/test/system/tools_test.rb
+++ b/test/system/tools_test.rb
@@ -429,6 +429,29 @@ class RegenerateFlatfilesSystemTest < ApplicationSystemTestCase
       assert_text 'All submissions'
     end
   end
+
+  # A bulk paste is 127,604 numbers — 1.1 MB in the row — and the only
+  # thing that reads it back is a retry. The panel is polled every three
+  # seconds for the length of a run and the history lists ten rows at a
+  # time, so counting the list on the way out meant detoasting a megabyte
+  # and allocating 127,604 strings on every one of those renders, in the
+  # process that is also running the jobs.
+  test 'the run screens report the count without reading the list back' do
+    run = RegenerateFlatfilesRun.create!(actor: 'admin:sato', target: 'accessions', numbers: 'X00001 X00002',
+                                         total: 2, regenerated: 2, started_at: 2.days.ago, finished_at: 2.days.ago + 18)
+
+    [admin_regenerate_flatfiles_path, admin_regenerate_flatfiles_run_path(run)].each do |path|
+      # Naming the columns rather than SELECT *, and `numbers` not among
+      # them — asserting only the absence would pass for a SELECT * too.
+      assert_queries_match(/"regenerate_flatfiles_runs"\."actor"/) do
+        assert_no_queries_match(/"regenerate_flatfiles_runs"\.\*/) do
+          visit path
+        end
+      end
+
+      assert_text '2 accessions'
+    end
+  end
 end
 
 # The parts of the screen that only exist once JavaScript is running: the
@@ -459,6 +482,33 @@ class RegenerateFlatfilesJavaScriptTest < JavaScriptSystemTestCase
 
       assert_text 'every ST.26 submission with a stored record'
       assert_link 'Regenerate 1 submission…'
+    end
+  end
+
+  # The summary is re-rendered 300 ms after every keystroke, including
+  # while a 1.1 MB list is being pasted and while a run holding one is in
+  # flight. Both the blocking run it names and the finished runs its
+  # estimate is measured from are read on that path.
+  test 'the summary is refreshed without reading any accession list back' do
+    RegenerateFlatfilesRun.create!(actor: 'admin:sato', target: 'accessions', numbers: 'X00001 X00002',
+                                   total: 2, regenerated: 2, started_at: 2.days.ago, finished_at: 2.days.ago + 18)
+
+    RegenerateFlatfilesRun.create!(actor: 'admin:sato', target: 'accessions', numbers: 'X00003',
+                                   total: 1, started_at: 1.minute.ago)
+
+    visit admin_regenerate_flatfiles_path
+
+    assert_text 'still going'
+    assert_button 'Regenerate 0 submissions', disabled: true
+
+    # Asserting on the count is what makes this wait for the round trip.
+    # The blocking warning is already on the page from the first render,
+    # so a test that only looked for it would pass without the preview
+    # ever being asked.
+    assert_no_queries_match(/"regenerate_flatfiles_runs"\.\*/) do
+      fill_in 'Accession numbers', with: submissions(:st26).entries.first.accession
+
+      assert_button 'Regenerate 1 submission', disabled: true
     end
   end
 


### PR DESCRIPTION
## なにが起きていたか

`RegenerateFlatfilesRun#scope_label` が `numbers`（貼り付けたアクセッション番号）を毎回 `split` して件数を数えていた。しかも 1 回の文字列補間で 2 度呼んでいたので、1 レンダリングにつき 1.1MB を **2 回**割っていた。

問題は読まれる回数のほう:

- **走行中の進捗パネルは 3 秒ごとに自分の行を読み直す**（`auto_refresh_controller.js`、`INTERVAL_MS = 3000`）。実測で 1 リクエスト **102.7ms / 25万オブジェクト / +15.4MB**。30 分の走行なら 600 回、Puma の CPU 57 秒ぶんと約 9GB のアロケーション。
- しかも `SOLID_QUEUE_IN_PUMA=true` なので、これは**再生成ジョブそのものを走らせているプロセスの中**で起きる。
- 履歴の表でも 1 ページあたり最大 10 行ぶん同じことをしていた。大きい run が 6 本並ぶと tool 画面 1 回で **544ms / 155万オブジェクト / +101MB**。

Postgres 側の detoast は 1 回 2.5ms 程度で、コストのほぼ全部は Ruby の split。

ST.26 の LOCUS 日付変更で 12万件規模の run を作る運用が続くので、走行を重ねるほど効いてくる。

## 直し方

- **`accession_count` 列**を足し、`numbers` が読み込まれているときだけ `before_save` で数え直す。コントローラから渡すのではなくモデルで導出するので、コンソールでもテストでも「2 accessions と言いながらリストは 3 件」にならない。件数だけ直接代入しても、リストのほうで上書きされる。
- 読む側は **`without_numbers` スコープで列ごと引かない**。tool 画面・履歴 10 行・進捗パネル・`preview`・in-flight チェック・`measured_rate` の全部。リストを読み直すのは retry だけで、そこは自分で全件ロードする。
- **パース規則を `RegenerateFlatfilesRun.parse_numbers` に 1 本化**（区切り・空要素の除去・重複の除去）。`RegenerationScope` とコールバックの両方がこれを使うので、retry が実際に走らせる件数と画面が言う件数が同じ規則から出る。
- 既存行はマイグレーションで数え直す。SQL 側は次の 3 点が効いている: `<<~'SQL'`（補間ありだと Ruby が `\s` を空白 1 文字にしてしまい、改行で切れなくなる）、`\s` ではなく `[ \t\n\v\f\r,]+`（Postgres の `\s` は `[[:space:]]` で、和文ペーストにありがちな全角空白まで区切りにしてしまう）、`btrim` ではなくトークン側の `~ '[^[:space:]]'`（`btrim` は空白しか落とさず改行を落とさない）。

## 効果（実測）

| | 修正前 | 修正後 |
|---|---|---|
| 進捗パネル 1 リクエスト | 102.7ms | **20.3ms** |
| tool 画面（大きい run 1 + 小 5） | 118.4ms | **30.2ms** |
| tool 画面（大きい run 6） | 544ms / 155万obj | **36ms / 1.8万obj** |

書き込み側のコストは run 1 本あたり 2 回の save で計 80ms 程度。カウンタ更新（`update_counters` / `update_all`）はコールバックを起こさないので影響しない。

ついでに `scope_label` の件数を桁区切りにした（`127604 accessions` → `127,604 accessions`）。常用サイズが 6 桁なので。

## 検証

- `bin/rails test:all` 1,343 runs / 4,196 assertions / 0 failures、rubocop クリーン
- 画面を経由するテストは CLAUDE.md の方針どおり `test/system` に置いた（tool 画面・進捗パネル・preview の 3 経路で `numbers` を引いていないことを `assert_no_queries_match` で固定）
- マイグレーションのバックフィル SQL は `BACKFILL` 定数に切り出し、9 パターン（nil・空・空白のみ・改行・カンマ・CRLF・重複・全角空白）でコールバックと一致することをテストで固定
- ミューテーション: `without_numbers` を 4 つの読み手それぞれから外す / `before_save` を削除 / ガードを `will_save_change_to_numbers?` に戻す / `parse_numbers` の `uniq` を外す — すべてテストで検知される

## 残っている、この PR で直していないもの

- **`RegenerateSubmissionFlatfilesJob` が run を GlobalID で 1 ジョブごとにフルロードする**（`SELECT *`）。12万件の run は約 5,000 ジョブなので、1 走行あたり約 25 秒の DB+CPU と 6GB の一時ゴミ。ジョブは `run.numbers` を一切読まない。直すには引数を id に変えることになるが、デプロイ時にキューへ積まれている in-flight ジョブの引数の型が変わるため、別 PR で移行方法込みで扱うほうが安全と判断した。
- **admin レイアウトのナビバッジの集計**が、修正後のパネル 20.3ms のうち約 13ms を占める（3 秒ごとに `COUNT(*)` が 7 本）。この画面に限らない別件。